### PR TITLE
Undeclared index identifier

### DIFF
--- a/src/main/scala/shine/C/CodeGeneration/CodeGenerator.scala
+++ b/src/main/scala/shine/C/CodeGeneration/CodeGenerator.scala
@@ -754,10 +754,10 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
         case C.AST.ArithmeticExpr(ae) => acc(a, env, CIntExpr(ae) :: ps, cont)
         case cExpr:C.AST.Expr =>
           val arithVar = NamedVar(freshName("idxAcc"))
-          acc(a, env, CIntExpr(arithVar) :: ps, generated => C.AST.Block(immutable.Seq(
+          C.AST.Block(immutable.Seq(
             C.AST.DeclStmt(C.AST.VarDecl(arithVar.name, C.AST.Type.int, Some(cExpr))),
-            cont(generated)
-          )))
+            acc(a, env, CIntExpr(arithVar) :: ps, cont)
+          ))
       })
     }
 
@@ -792,10 +792,10 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
         case C.AST.ArithmeticExpr(ae) => exp(e, env, CIntExpr(ae) :: ps, cont)
         case cExpr:C.AST.Expr =>
           val arithVar = NamedVar(freshName("idx"))
-          exp(e, env, CIntExpr(arithVar) :: ps, generated => C.AST.Block(immutable.Seq(
+          C.AST.Block(immutable.Seq(
             C.AST.DeclStmt(C.AST.VarDecl(arithVar.name, C.AST.Type.int, Some(cExpr))),
-            cont(generated)
-          )))
+            exp(e, env, CIntExpr(arithVar) :: ps, cont)
+          ))
       })
     }
 

--- a/src/test/scala/shine/DPIA/Primitives/Select.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Select.scala
@@ -1,0 +1,29 @@
+package shine.DPIA.Primitives
+
+import rise.core.DSL._
+import rise.core.TypeLevelDSL._
+import rise.core.types._
+import util._
+
+class Select extends test_util.Tests {
+  val id = fun(x => x)
+
+  test("select from generate") {
+    val e =
+      generate(fun(x => {
+        select(x < lidx(2, 6), l(0), select(x < lidx(4, 6), l(1), l(2)))
+      })) :: (6`.`int) |> mapSeq(id)
+
+    gen.CProgram(e)
+  }
+
+  test("select from generate from gather") {
+    val e = fun(12`.`IndexType(6))(input =>
+      gather(input, generate(fun(x => {
+        select(x < lidx(2, 6), l(0), select(x < lidx(4, 6), l(1), l(2)))
+      }))) |> mapSeq(id)
+    )
+
+    gen.CProgram(e)
+  }
+}

--- a/src/test/scala/shine/DPIA/Primitives/SlideSeq.scala
+++ b/src/test/scala/shine/DPIA/Primitives/SlideSeq.scala
@@ -2,7 +2,7 @@ package shine.DPIA.Primitives
 
 import rise.core.DSL._
 import rise.core.types._
-import rise.core.primitives._
+import rise.core.primitives.SlideSeq._
 import util.{Execute, gen}
 
 class SlideSeq extends test_util.Tests {
@@ -10,7 +10,7 @@ class SlideSeq extends test_util.Tests {
 
   test("Simple example should generate C code producing the expected result on a test") {
     val e = nFun(n => fun(ArrayType(n, int))(a =>
-      a |> slideSeq(SlideSeq.Values)(3)(1)(fun(x => x))(reduceSeq(add)(l(0)))
+      a |> slideSeq(Values)(3)(1)(fun(x => x))(reduceSeq(add)(l(0)))
     ))
     val p = gen.CProgram(e)
 


### PR DESCRIPTION
A small example where codegen fails with an undeclared index identifier.
https://github.com/rise-lang/shine/commit/f79a480fe868258b9ad36feaec11d124af4238c0#diff-7630c39c500613b10242256eebeca2bfR20

It seems to me that the imperative DPIA code is correct. However C code generation is bugged:
```c
void foo(int* output, int* e58){
  /* mapSeq */
  for (int i_124 = 0;(i_124 < 12);i_124 = (1 + i_124)) {
    if ((idx125 < 2)) {
      int idx125 = e58[i_124];
      output[i_124] = 0;
    }
     else if ((idx125 < 4)) {
      int idx125 = e58[i_124];
      output[i_124] = 1;
    }
     else {
      int idx125 = e58[i_124];
      output[i_124] = 2;
    } 
  }
}
```