### PR TITLE
Enforce unique names during substitution

### DIFF
--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -72,7 +72,7 @@
    <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
   </parameters>
  </check>
- <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"/>
+ <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="false"/>
  <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
    <parameter name="maxLength"><![CDATA[60]]></parameter>

--- a/src/main/scala/shine/DPIA/Phrases/Phrase.scala
+++ b/src/main/scala/shine/DPIA/Phrases/Phrase.scala
@@ -150,18 +150,14 @@ object Phrase {
           }
 
           override def nat[N <: Nat](n: N): N = n.visitAndRebuild({
-            case i: NatIdentifier => idMap.get(i.name) match {
-              case Some(newName) => NatIdentifier(newName)
-              case None => i
-            }
+            case i: NatIdentifier =>
+              NatIdentifier(idMap.getOrElse(i.name, i.name))
             case ae => ae
           }).asInstanceOf[N]
 
           override def data[T <: DataType](dt: T): T = (dt match {
-            case i: DataTypeIdentifier => idMap.get(i.name) match {
-              case Some(newName) => DataTypeIdentifier(newName)
-              case None => i
-            }
+            case i: DataTypeIdentifier =>
+              DataTypeIdentifier(idMap.getOrElse(i.name, i.name))
             case dt => dt
           }).asInstanceOf[T]
         }

--- a/src/main/scala/shine/DPIA/Phrases/Phrase.scala
+++ b/src/main/scala/shine/DPIA/Phrases/Phrase.scala
@@ -141,10 +141,10 @@ object Phrase {
               Identifier(idMap.getOrElse(name, name),
                 VisitAndRebuild.visitPhraseTypeAndRebuild(t, this)).asInstanceOf[Phrase[T]])
             case l @ Lambda(x, _) =>
-              val newMap = idMap + (x.name -> freshName("s"))
+              val newMap = idMap + (x.name -> freshName(x.name.takeWhile(_.isLetter)))
               Continue(l, Renaming(newMap))
             case dl @ DepLambda(x, _) =>
-              val newMap = idMap + (x.name -> freshName("s"))
+              val newMap = idMap + (x.name -> freshName(x.name.takeWhile(_.isLetter)))
               Continue(dl, Renaming(newMap))
             case _ => Continue(p, this)
           }

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -52,7 +52,7 @@ object VisitAndRebuild {
           case DepLambda(a, p) => a match {
             case n: NatIdentifier =>
               DepLambda[NatKind, PhraseType](
-                v.nat(n).asInstanceOf[NatIdentifier], apply(p, v))
+                NatIdentifier(v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name), apply(p, v))
             case dt: DataTypeIdentifier =>
               DepLambda[DataKind, PhraseType](
                 v.data(dt).asInstanceOf[DataTypeIdentifier], apply(p, v))
@@ -121,7 +121,7 @@ object VisitAndRebuild {
     case DepFunType(x, t)           => x match {
       case n: NatIdentifier =>
         DepFunType[NatKind, PhraseType](
-          v.nat(n).asInstanceOf[NatIdentifier], visitPhraseTypeAndRebuild(t, v))
+          NatIdentifier(v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name), visitPhraseTypeAndRebuild(t, v))
       case dt: DataTypeIdentifier =>
         DepFunType[DataKind, PhraseType](
           v.data(dt).asInstanceOf[DataTypeIdentifier], visitPhraseTypeAndRebuild(t, v))

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -27,8 +27,11 @@ object VisitAndRebuild {
     def addressSpace(a: AddressSpace): AddressSpace = a
 
     abstract class Result[+T]
+
     case class Stop[T <: PhraseType](p: Phrase[T]) extends Result[Phrase[T]]
+
     case class Continue[T <: PhraseType](p: Phrase[T], v: Visitor) extends Result[Phrase[T]]
+
   }
 
   def apply[T <: PhraseType](phrase: Phrase[T], v: Visitor): Phrase[T] = {
@@ -173,9 +176,8 @@ object VisitAndRebuild {
       }
     }
 
-  private def visitDataTypeAndRebuild(dt: DataType, v: Visitor): DataType = {
-    val newData = v.data(dt)
-    newData match {
+  private def visitDataTypeAndRebuild(dt: DataType, v: Visitor): DataType =
+    v.data(dt) match {
       case i: IndexType => IndexType(v.nat(i.size))
       case a: ArrayType =>
         ArrayType(v.nat(a.size), visitDataTypeAndRebuild(a.elemType, v))
@@ -184,7 +186,6 @@ object VisitAndRebuild {
       case r: PairType =>
         PairType(visitDataTypeAndRebuild(r.fst, v),
           visitDataTypeAndRebuild(r.snd, v))
-      case _ => newData
+      case d => d
     }
-  }
 }

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -52,42 +52,62 @@ object VisitAndRebuild {
           case DepLambda(a, p) => a match {
             case n: NatIdentifier =>
               DepLambda[NatKind, PhraseType](
-                NatIdentifier(v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name), apply(p, v))
+                NatIdentifier(
+                  v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name),
+                apply(p, v))
             case dt: DataTypeIdentifier =>
               DepLambda[DataKind, PhraseType](
-                v.data(dt).asInstanceOf[DataTypeIdentifier], apply(p, v))
+                v.data(dt).asInstanceOf[DataTypeIdentifier],
+                apply(p, v))
             case ad: AddressSpaceIdentifier =>
               DepLambda[AddressSpaceKind, PhraseType](
-                v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier], apply(p, v))
+                v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier],
+                apply(p, v))
             case ac: AccessTypeIdentifier =>
               DepLambda[AccessKind, PhraseType](
-                v.access(ac).asInstanceOf[AccessTypeIdentifier], apply(p, v))
+                v.access(ac).asInstanceOf[AccessTypeIdentifier],
+                apply(p, v))
             case n2n: NatToNatIdentifier =>
               DepLambda[NatToNatKind, PhraseType](
-                v.natToNat(n2n).asInstanceOf[NatToNatIdentifier], apply(p, v))
+                v.natToNat(n2n).asInstanceOf[NatToNatIdentifier],
+                apply(p, v))
             case n2d: NatToDataIdentifier =>
               DepLambda[NatToDataKind, PhraseType](
-                v.natToData(n2d).asInstanceOf[NatToDataIdentifier], apply(p, v))
+                v.natToData(n2d).asInstanceOf[NatToDataIdentifier],
+                apply(p, v))
             case _ => ???
           }
 
           case DepApply(p, a) => a match {
             case n: Nat =>
-              DepApply[NatKind, T](apply(p, v).asInstanceOf[Phrase[NatKind `()->:` T]], v.nat(n))
+              DepApply[NatKind, T](
+                apply(p, v).asInstanceOf[Phrase[NatKind `()->:` T]],
+                v.nat(n))
             case dt: DataType =>
-              DepApply[DataKind, T](apply(p, v).asInstanceOf[Phrase[DataKind `()->:` T]], v.data(dt))
+              DepApply[DataKind, T](
+                apply(p, v).asInstanceOf[Phrase[DataKind `()->:` T]],
+                visitDataTypeAndRebuild(dt, v))
             case ad: AddressSpace =>
-              DepApply[AddressSpaceKind, T](apply(p, v).asInstanceOf[Phrase[AddressSpaceKind `()->:` T]], v.addressSpace(ad))
+              DepApply[AddressSpaceKind, T](
+                apply(p, v).asInstanceOf[Phrase[AddressSpaceKind `()->:` T]],
+                v.addressSpace(ad))
             case ac: AccessType =>
-              DepApply[AccessKind, T](apply(p, v).asInstanceOf[Phrase[AccessKind `()->:` T]], v.access(ac))
+              DepApply[AccessKind, T](
+                apply(p, v).asInstanceOf[Phrase[AccessKind `()->:` T]],
+                v.access(ac))
             case n2n: NatToNat =>
-              DepApply[NatToNatKind, T](apply(p, v).asInstanceOf[Phrase[NatToNatKind `()->:` T]], v.natToNat(n2n))
+              DepApply[NatToNatKind, T](
+                apply(p, v).asInstanceOf[Phrase[NatToNatKind `()->:` T]],
+                v.natToNat(n2n))
             case n2d: NatToData =>
-              DepApply[NatToDataKind, T](apply(p, v).asInstanceOf[Phrase[NatToDataKind `()->:` T]], v.natToData(n2d))
+              DepApply[NatToDataKind, T](
+                apply(p, v).asInstanceOf[Phrase[NatToDataKind `()->:` T]],
+                v.natToData(n2d))
             case ph: PhraseType => ???
           }
 
-          case LetNat(binder, defn, body) => LetNat(binder, apply(defn, v), apply(body, v))
+          case LetNat(binder, defn, body) =>
+            LetNat(binder, apply(defn, v), apply(body, v))
 
           case PhrasePair(p, q) => PhrasePair(apply(p, v), apply(q, v))
 
@@ -111,45 +131,58 @@ object VisitAndRebuild {
     }
   }
 
-  def visitPhraseTypeAndRebuild(phraseType: PhraseType, v: Visitor): PhraseType = phraseType match {
-    case ExpType(dt, w)                 => ExpType(visitDataTypeAndRebuild(dt, v), v.access(w))
-    case AccType(dt)                => AccType(visitDataTypeAndRebuild(dt, v))
-    case CommType()                 => CommType()
-    case PhrasePairType(t1, t2)           => PhrasePairType(visitPhraseTypeAndRebuild(t1, v), visitPhraseTypeAndRebuild(t2, v))
-    case FunType(inT, outT)         => FunType(visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
-    case PassiveFunType(inT, outT)  => PassiveFunType(visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
-    case DepFunType(x, t)           => x match {
-      case n: NatIdentifier =>
-        DepFunType[NatKind, PhraseType](
-          NatIdentifier(v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name), visitPhraseTypeAndRebuild(t, v))
-      case dt: DataTypeIdentifier =>
-        DepFunType[DataKind, PhraseType](
-          v.data(dt).asInstanceOf[DataTypeIdentifier], visitPhraseTypeAndRebuild(t, v))
-      case ad: AddressSpaceIdentifier =>
-        DepFunType[AddressSpaceKind, PhraseType](
-          v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier], visitPhraseTypeAndRebuild(t, v))
-      case ac: AccessTypeIdentifier =>
-        DepFunType[AccessKind, PhraseType](
-          v.access(ac).asInstanceOf[AccessTypeIdentifier], visitPhraseTypeAndRebuild(t, v))
-      case n2n: NatToNatIdentifier =>
-        DepFunType[NatToNatKind, PhraseType](
-          v.natToNat(n2n).asInstanceOf[NatToNatIdentifier], visitPhraseTypeAndRebuild(t, v))
-      case n2d: NatToDataIdentifier =>
-        DepFunType[NatToDataKind, PhraseType](
-          v.natToData(n2d).asInstanceOf[NatToDataIdentifier], visitPhraseTypeAndRebuild(t, v))
+  def visitPhraseTypeAndRebuild(pt: PhraseType, v: Visitor): PhraseType =
+    pt match {
+      case ExpType(dt, w) => ExpType(
+        visitDataTypeAndRebuild(dt, v),
+        v.access(w))
+      case AccType(dt) => AccType(visitDataTypeAndRebuild(dt, v))
+      case CommType() => CommType()
+      case PhrasePairType(t1, t2) => PhrasePairType(
+        visitPhraseTypeAndRebuild(t1, v), visitPhraseTypeAndRebuild(t2, v))
+      case FunType(inT, outT) => FunType(
+        visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
+      case PassiveFunType(inT, outT) => PassiveFunType(
+        visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
+      case DepFunType(x, t) => x match {
+        case n: NatIdentifier =>
+          DepFunType[NatKind, PhraseType](
+            NatIdentifier(
+              v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name),
+            visitPhraseTypeAndRebuild(t, v))
+        case dt: DataTypeIdentifier =>
+          DepFunType[DataKind, PhraseType](
+            v.data(dt).asInstanceOf[DataTypeIdentifier],
+            visitPhraseTypeAndRebuild(t, v))
+        case ad: AddressSpaceIdentifier =>
+          DepFunType[AddressSpaceKind, PhraseType](
+            v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier],
+            visitPhraseTypeAndRebuild(t, v))
+        case ac: AccessTypeIdentifier =>
+          DepFunType[AccessKind, PhraseType](
+            v.access(ac).asInstanceOf[AccessTypeIdentifier],
+            visitPhraseTypeAndRebuild(t, v))
+        case n2n: NatToNatIdentifier =>
+          DepFunType[NatToNatKind, PhraseType](
+            v.natToNat(n2n).asInstanceOf[NatToNatIdentifier],
+            visitPhraseTypeAndRebuild(t, v))
+        case n2d: NatToDataIdentifier =>
+          DepFunType[NatToDataKind, PhraseType](
+            v.natToData(n2d).asInstanceOf[NatToDataIdentifier],
+            visitPhraseTypeAndRebuild(t, v))
+      }
     }
-  }
 
-  def visitDataTypeAndRebuild(dataType: DataType, v: Visitor): DataType = dataType match {
-    case i: IndexType => IndexType(v.nat(i.size))
-    case a: ArrayType =>
-      ArrayType(v.nat(a.size), visitDataTypeAndRebuild(a.elemType, v))
-    case vec: VectorType =>
-      VectorType(v.nat(vec.size), v.data(vec.elemType))
-    case r: PairType =>
-      PairType(visitDataTypeAndRebuild(r.fst, v),
-        visitDataTypeAndRebuild(r.snd, v))
-    case _ => v.data(dataType)
-  }
-
+  private def visitDataTypeAndRebuild(dt: DataType, v: Visitor): DataType =
+    v.data(dt) match {
+      case i: IndexType => IndexType(v.nat(i.size))
+      case a: ArrayType =>
+        ArrayType(v.nat(a.size), visitDataTypeAndRebuild(a.elemType, v))
+      case vec: VectorType =>
+        VectorType(v.nat(vec.size), v.data(vec.elemType))
+      case r: PairType =>
+        PairType(visitDataTypeAndRebuild(r.fst, v),
+          visitDataTypeAndRebuild(r.snd, v))
+      case d => d
+    }
 }

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -173,8 +173,9 @@ object VisitAndRebuild {
       }
     }
 
-  private def visitDataTypeAndRebuild(dt: DataType, v: Visitor): DataType =
-    v.data(dt) match {
+  private def visitDataTypeAndRebuild(dt: DataType, v: Visitor): DataType = {
+    val newData = v.data(dt)
+    newData match {
       case i: IndexType => IndexType(v.nat(i.size))
       case a: ArrayType =>
         ArrayType(v.nat(a.size), visitDataTypeAndRebuild(a.elemType, v))
@@ -183,6 +184,7 @@ object VisitAndRebuild {
       case r: PairType =>
         PairType(visitDataTypeAndRebuild(r.fst, v),
           visitDataTypeAndRebuild(r.snd, v))
-      case d => d
+      case _ => newData
     }
+  }
 }

--- a/src/main/scala/shine/DPIA/Types/PhraseType.scala
+++ b/src/main/scala/shine/DPIA/Types/PhraseType.scala
@@ -117,9 +117,11 @@ object PhraseType {
         }
       }
 
-      override def nat[N <: Nat](n: N): N = Nat.substitute(ae, `for`, in=n)
+      override def nat[N <: Nat](n: N): N =
+        Nat.substitute(ae, `for`, in=n)
 
-      override def data[DT <: DataType](dt: DT): DT = DataType.substitute(ae, `for`, in=dt)
+      override def data[DT <: DataType](dt: DT): DT =
+        DataType.substitute(ae, `for`, in=dt)
     }
 
     val p = Phrases.VisitAndRebuild(in, Visitor)


### PR DESCRIPTION
The unique name invariant enforced before type inference in Rise (see RIse [#19](https://github.com/rise-lang/rise/pull/19)) is preserved during substitution in DPIA.