### PR TITLE
Fixes the Continuation Translation of ReduceSeq

### DIFF
--- a/src/main/scala/shine/DPIA/FunctionalPrimitives/AbstractReduce.scala
+++ b/src/main/scala/shine/DPIA/FunctionalPrimitives/AbstractReduce.scala
@@ -80,7 +80,7 @@ abstract class AbstractReduce(n: Nat,
       makeReduceI(n, dt1, dt2,
         λ(expT(dt2, read))(x =>
           λ(expT(dt1, read))(y =>
-            λ(accT(dt2))(o => acc( f(x)(y) )( o )))),
+            λ(accT(dt2))(o => acc(f(x)(y))(o)))),
         init, X, C)(context)))
   }
 

--- a/src/main/scala/shine/DPIA/FunctionalPrimitives/AbstractReduce.scala
+++ b/src/main/scala/shine/DPIA/FunctionalPrimitives/AbstractReduce.scala
@@ -21,7 +21,8 @@ abstract class AbstractReduce(n: Nat,
   extends ExpPrimitive {
 
   def makeReduce: (Nat, DataType, DataType,
-    Phrase[ExpType ->: ExpType ->: ExpType], Phrase[ExpType], Phrase[ExpType]) => AbstractReduce
+    Phrase[ExpType ->: ExpType ->: ExpType], Phrase[ExpType], Phrase[ExpType]
+  ) => AbstractReduce
 
   def makeReduceI(n: Nat,
                   dt1: DataType,
@@ -37,9 +38,12 @@ abstract class AbstractReduce(n: Nat,
   array :: expT(n`.`dt1, read)
   override val t: ExpType = expT(dt2, read)
 
-  override def visitAndRebuild(fun: VisitAndRebuild.Visitor): Phrase[ExpType] = {
+  override def visitAndRebuild(
+    fun: VisitAndRebuild.Visitor
+  ): Phrase[ExpType] = {
     makeReduce(fun.nat(n), fun.data(dt1), fun.data(dt2),
-      VisitAndRebuild(f, fun), VisitAndRebuild(init, fun), VisitAndRebuild(array, fun))
+      VisitAndRebuild(f, fun), VisitAndRebuild(init, fun),
+      VisitAndRebuild(array, fun))
   }
 
   override def eval(s: Store): Data = {
@@ -59,28 +63,31 @@ abstract class AbstractReduce(n: Nat,
     s"${this.getClass.getSimpleName} (${PrettyPhrasePrinter(f)}) " +
       s"(${PrettyPhrasePrinter(init)}) (${PrettyPhrasePrinter(array)})"
 
-
-  override def acceptorTranslation(A: Phrase[AccType])
-                                  (implicit context: TranslationContext): Phrase[CommType] = {
+  override def acceptorTranslation(A: Phrase[AccType])(
+    implicit context: TranslationContext
+  ): Phrase[CommType] = {
     import TranslationToImperative._
 
     con(this)(λ(expT(dt2, write))(r => acc(r)(A)))
   }
 
-  override def continuationTranslation(C: Phrase[ExpType ->: CommType])
-                                      (implicit context: TranslationContext): Phrase[CommType] = {
+  override def continuationTranslation(C: Phrase[ExpType ->: CommType])(
+    implicit context: TranslationContext
+  ): Phrase[CommType] = {
     import TranslationToImperative._
 
     con(array)(λ(expT(n`.`dt1, read))(X =>
-      con(init)(λ(expT(dt2, read))(Y =>
-        makeReduceI(n, dt1, dt2,
-          λ(expT(dt2, read))(x => λ(expT(dt1, read))(y => λ(accT(dt2))(o => acc( f(x)(y) )( o ) ))),
-          Y, X, C)))))
+      makeReduceI(n, dt1, dt2,
+        λ(expT(dt2, read))(x =>
+          λ(expT(dt1, read))(y =>
+            λ(accT(dt2))(o => acc( f(x)(y) )( o )))),
+        init, X, C)(context)))
   }
 
   override def xmlPrinter: Elem =
     <reduce n={ToString(n)} dt1={ToString(dt1)} dt2={ToString(dt2)}>
-      <f type={ToString(ExpType(dt1, read) ->: ExpType(dt2, read) ->: ExpType(dt2, write))}>
+      <f type={ToString(
+        ExpType(dt1, read) ->: ExpType(dt2, read) ->: ExpType(dt2, write))}>
         {Phrases.xmlPrinter(f)}
       </f>
       <init type={ToString(ExpType(dt2, write))}>

--- a/src/main/scala/shine/DPIA/IntermediatePrimitives/ReduceSeqI.scala
+++ b/src/main/scala/shine/DPIA/IntermediatePrimitives/ReduceSeqI.scala
@@ -1,12 +1,11 @@
 package shine.DPIA.IntermediatePrimitives
 
 import shine.DPIA.Compilation.TranslationContext
+import shine.DPIA.Compilation.TranslationToImperative.acc
 import shine.DPIA.DSL._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types._
 import shine.DPIA._
-
-import scala.language.reflectiveCalls
 
 object ReduceSeqI {
   def apply(n: Nat, dt1: DataType, dt2: DataType,
@@ -17,12 +16,11 @@ object ReduceSeqI {
             unroll: Boolean = false)
            (implicit context: TranslationContext): Phrase[CommType] =
   {
-    `new`(dt2, acc =>
-      //TODO implicit decisions happening here!
-      (acc.wr :=|dt2| init) `;`
-        comment("reduceSeq")`;`
-        `for`(n, i => f(acc.rd)(in `@` i)(acc.wr), unroll) `;`
-        out(acc.rd)
+    comment("reduceSeq")`;`
+    `new`(dt2, accum =>
+      acc(init)(accum.wr) `;`
+        `for`(n, i => f(accum.rd)(in `@` i)(accum.wr), unroll) `;`
+        out(accum.rd)
     )
   }
 }


### PR DESCRIPTION
This implements the continuation translation for `ReduceSeq` in the same way that it is implemented for `OpenCLReduceSeq`.

Instead of continuing on the `init` expression, it is passed to the acceptor translation in order to write the init value into the accumulator.

Most importantly, this fixes a bug in one of the tests in `feature/pldi-benchmarks`.