### PR TITLE
Changing syntax of let

### DIFF
--- a/src/main/scala/apps/harrisCornerDetection.scala
+++ b/src/main/scala/apps/harrisCornerDetection.scala
@@ -93,11 +93,11 @@ object harrisCornerDetection {
         toPrivateFun(mapSeqUnroll(fun(hWsNbh =>
           C2D.weightsSeqVecUnroll(hWsNbh._1)(hWsNbh._2)
         ))) >>
-        let(fun(ixiy => {
+        letf(ixiy => {
           val ix = ixiy `@` lidx(0, 2)
           val iy = ixiy `@` lidx(1, 2)
           makeArray(3)(sq(ix))(ix * iy)(sq(iy)) |> mapSeqUnroll(id)
-        }))
+        })
       ) >> transpose >> map(asScalar)
     ) >> transpose
     /* TODO? output tuples
@@ -132,12 +132,12 @@ object harrisCornerDetection {
         toPrivateFun(mapSeqUnroll(
           C2D.weightsSeqVecUnroll(C2D.binomialWeightsH)
         )) >>
-        let(fun(s => {
+        letf(s => {
           val sxx = s `@` lidx(0, 3)
           val sxy = s `@` lidx(1, 3)
           val syy = s `@` lidx(2, 3)
           coarsityVector(sxx)(sxy)(syy)(kappa)
-        }))
+        })
       ) >> asScalar
     )
   })))
@@ -190,12 +190,12 @@ object harrisCornerDetection {
         toPrivateFun(mapSeqUnroll(
           C2D.weightsSeqVecUnroll(C2D.binomialWeightsH)
         )) >>
-        let(fun(s => {
+        letf(s => {
           val sxx = s `@` lidx(0, 3)
           val sxy = s `@` lidx(1, 3)
           val syy = s `@` lidx(2, 3)
           coarsityVector(sxx)(sxy)(syy)(kappa)
-        }))
+        })
       ) >> asScalar
     )
   )))

--- a/src/main/scala/apps/mm.scala
+++ b/src/main/scala/apps/mm.scala
@@ -39,15 +39,14 @@ object mm {
         mapGlobal(0)(fun(v3`.`o`.`f32)(p4 =>
           zip(transpose(p3))(transpose(p4)) |> // o.(Mi.f x Ni.f)
           oclReduceSeq(AddressSpace.Private)(fun((p6, p7) =>
-            toPrivate(pair(mapSeq(id)(p7._1),
-              asScalar o mapSeq(id) o asVectorAligned(vw) $ p7._2)) |>
-              let(fun(x =>
-                mapSeq(fun(p8 =>
-                  mapSeq(fun(p9 =>
-                    p9._1 + (p8._2 * p9._2)
-                  ))(zip(p8._1)(x._2))
-                ))(zip(p6)(x._1))
-              ))
+            let (toPrivate(pair(mapSeq(id)(p7._1),
+              asScalar o mapSeq(id) o asVectorAligned(vw) $ p7._2)))
+            be (x =>
+              mapSeq(fun(p8 =>
+                mapSeq(fun(p9 =>
+                  p9._1 + (p8._2 * p9._2)
+                ))(zip(p8._1)(x._2))
+              ))(zip(p6)(x._1)))
           ))(mapSeq(mapSeq(id))(generate(fun(_ => generate(fun(_ => l(0.0f)))))) :: (v4`.`v3`.`f32)) |> //
           mapSeq(asScalar o mapSeq(id) o asVector(vw)) |>
           transpose // v3.v4.f
@@ -78,14 +77,14 @@ object mm {
           zip(p2, p3) |> // O'.(v8.v5.f x v8.v7.f)
           oclReduceSeq(AddressSpace.Local)(fun((p13, p14) =>
             // (v5/^v4).(v7/^v3).v4.v3.f x (v8.v5.f x v8.v7.f)
-            toLocal(pair(
-              p14._1 |> join |> split(v6) |> // ((v8 x v5) /^ v6).v6.f
-              mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4)) |>
-              join |> split(v5), // v8.v5.f
-              p14._2 |> // v8.v7.f
-              mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4))
-            )) |>
-            let(fun(p15 =>
+            let (toLocal(pair(
+                p14._1 |> join |> split(v6) |> // ((v8 x v5) /^ v6).v6.f
+                mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4)) |>
+                join |> split(v5), // v8.v5.f
+                p14._2 |> // v8.v7.f
+                mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4))
+              )))
+            be(p15 =>
               zip(p13, split(v4)(transpose(p15._1))) |> // (v5/^v4).((v7/^v3).v4.v3.f x v4.v8.f)
               mapLocal(1)(fun(p16 =>
                 zip(p16._1, split(v3)(transpose(p15._2))) |> // (v7/^v3).(v4.v3.f x v3.v8.f)
@@ -93,8 +92,8 @@ object mm {
                   zip(transpose(p16._2), transpose(p17._2)) |> // v8.(v4.f x v3.f)
                   oclReduceSeq(AddressSpace.Private)(fun((p19, p20) =>
                     // v4.v3.f x (v4.f x v3.f)
-                    toPrivate(pair(mapSeq(id)(p20._1), mapSeq(id)(p20._2))) |>
-                    let(fun(p21 =>
+                    let (toPrivate(pair(mapSeq(id)(p20._1), mapSeq(id)(p20._2))))
+                    be (p21 =>
                       zip(p19, p21._1) |> // v4.(v3.f x f)
                       mapSeq(fun(p22 =>
                         zip(p22._1, p21._2) |> // v3.(f x f)
@@ -102,13 +101,13 @@ object mm {
                           p23._1 + (p22._2 * p23._2)
                         ))
                       ))
-                    ))
+                    )
                   ))(p17._1 // v4.v3.f
                     |> mapSeq(mapSeq(id)) // TODO: think about that
                   ) |> mapSeq(mapSeq(id)) // TODO: think about that
                 ))
               ))
-            ))
+            )
           ))(
             generate(fun(_ =>
               generate(fun( _ =>

--- a/src/main/scala/apps/molecularDynamics.scala
+++ b/src/main/scala/apps/molecularDynamics.scala
@@ -39,12 +39,13 @@ object molecularDynamics {
       split(128) |>
       mapWorkGroup(
         mapLocal(fun(p =>
-          toPrivate(p._1) |> let(fun(particle =>
+          let (toPrivate(p._1))
+          be (particle =>
             gather(p._2)(particles) |>
             oclReduceSeq(AddressSpace.Private)(fun(force => fun(n =>
               mdCompute(force)(particle)(n)(cutsq)(lj1)(lj2)
             )))(vectorFromScalar(l(0.0f)))
-          ))
+          )
         ))
       ) |> join
   )))

--- a/src/main/scala/apps/mriQ.scala
+++ b/src/main/scala/apps/mriQ.scala
@@ -39,15 +39,18 @@ object mriQ {
   )((x, y, z, Qr, Qi, kvalues) =>
     zip(x)(zip(y)(zip(z)(zip(Qr)(Qi)))) |>
     mapGlobal(fun(t =>
-      toPrivate(t._1) |> let(fun(sX =>
-        toPrivate(t._2._1) |> let(fun(sY =>
-          toPrivate(t._2._2._1) |> let(fun(sZ =>
+      let (toPrivate(t._1))
+      be (sX =>
+        let (toPrivate(t._2._1))
+        be (sY =>
+          let (toPrivate(t._2._2._1))
+          be (sZ =>
             kvalues |> oclReduceSeq(AddressSpace.Private)(fun((acc, p) =>
               qFun(sX)(sY)(sZ)(p._1._1._1)(p._1._1._2)(p._1._2)(p._2)(acc)
             ))(pair(t._2._2._2._1, t._2._2._2._2))
-          ))
-        ))
-      ))
+          )
+        )
+      )
     ))
   )))
 

--- a/src/main/scala/apps/nbody.scala
+++ b/src/main/scala/apps/nbody.scala
@@ -67,7 +67,8 @@ object nbody {
             // TODO: is this the correct address space?
             oclReduceSeq(AddressSpace.Local)(
               fun(tileY`.`tileX`.`vec(4, f32))(acc => fun(tileY`.`tileX`.`vec(4, f32))(p2 =>
-                let(fun((tileY`.`tileX`.`vec(4, f32)) ->: (tileY`.`tileX`.`vec(4, f32)))(p2Local =>
+                let (toLocal(mapLocal(1)(mapLocal(0)(id))(p2)))
+                be (p2Local =>
                   mapLocal(1)(fun(((tileX`.`vec(4, f32)) x (tileX`.`vec(4, f32))) ->: (tileX`.`vec(4, f32)))(accDim2 =>
                     mapLocal(0)(fun(((vec(4, f32) x vec(4, f32)) x vec(4, f32)) ->: vec(4, f32))(p1 =>
                       oclReduceSeq(AddressSpace.Private)(fun(vec(4, f32) ->: vec(4, f32) ->: vec(4, f32))((acc, p2) =>
@@ -75,7 +76,7 @@ object nbody {
                       ))(p1._2)(accDim2._1)
                     )) $ zip(newP1Chunk)(accDim2._2)
                   )) $ zip(p2Local)(acc)
-                )) $ toLocal(mapLocal(1)(mapLocal(0)(id))(p2))
+                )
               )))(mapLocal(1)(mapLocal(0)(id))(generate(fun(_ => generate(fun(_ => vectorFromScalar(l(0.0f))))))))
             o split(tileY) o split(tileX) $ pos
           // TODO: toPrivate when it works..

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -625,12 +625,12 @@ object fromRise {
         fun[ExpType](ExpType(a, read), x =>
           Cast(a, b, x))
 
-      case (core.Let(), lt.FunType(lt.FunType(la: lt.DataType, lb: lt.DataType), _))
+      case (core.Let(), lt.FunType(la: lt.DataType, lt.FunType(_, lb: lt.DataType)))
       =>
         val a = dataType(la)
         val b = dataType(lb)
-        fun[ExpType ->: ExpType](expT(a, read) ->: expT(b, read), f =>
-          fun[ExpType](ExpType(a, read), x =>
+        fun[ExpType](ExpType(a, read), x =>
+          fun[ExpType ->: ExpType](expT(a, read) ->: expT(b, read), f =>
             Let(a, b, x, f)))
 
       case (f @ l.ForeignFunction(decl), _)

--- a/src/test/scala/shine/DPIA/Primitives/Let.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Let.scala
@@ -17,10 +17,10 @@ class Let extends shine.test_util.Tests {
       toPrivate(x + l(2)) |> fun(y => y * y)
     )).code)
     plusNum(2, gen.OpenCLKernel(fun(int)(x =>
-      (x + l(2)) |> let(fun(y => y * y))
+      let (x + l(2)) be (y => y * y)
     )).code)
     plusNum(1, gen.OpenCLKernel(fun(int)(x =>
-      toPrivate(x + l(2)) |> let(fun(y => y * y))
+      let (toPrivate(x + l(2))) be (y => y * y)
     )).code)
   }
 }


### PR DESCRIPTION
This pull request changes the order of the arguments of `let` from:
```scala
e |> let(fun(x => body))
```
to
```scala
let (e) be (x => body)
```

The old-style syntax is still available as:
```scala
e |> letf(x => body)
```

This PR is related to [this PR](https://github.com/rise-lang/rise/pull/38) in the `rise` repo.