### PR TITLE
Explicit dependence as a togglable flag

### DIFF
--- a/src/main/scala/rise/core/TypedDSL.scala
+++ b/src/main/scala/rise/core/TypedDSL.scala
@@ -414,10 +414,14 @@ object TypedDSL {
       }
     }
 
-    def infer(e: Expr): Expr = {
+    def inferDependent(e: TDSL[Expr]): Expr = this.infer(e.e, Flags.ExplicitDependence.On)
+
+    def infer(e: Expr,
+              explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off
+             ): Expr = {
       val constraints = mutable.ArrayBuffer[Constraint]()
       val (typed_e, ftvSubs) = constrainTypes(e, constraints, mutable.Map())
-      val solution = Constraint.solve(constraints, Seq()) match {
+      val solution = Constraint.solve(constraints, Seq())(explDep) match {
         case Solution(ts, ns, as, n2ds, n2ns, natColls) =>
           Solution(
             ts.mapValues(t => ftvSubs(t)),

--- a/src/main/scala/rise/core/types/Flags.scala
+++ b/src/main/scala/rise/core/types/Flags.scala
@@ -4,7 +4,7 @@ object Flags {
   /** This flag enables the type inference system to express explicit dependence
     * of type variables within dependent functions.
     *
-    * The pass is slow and interferes with advanced arithmetic simplification.
+    * The transformation is slow and interferes with advanced arithmetic simplification.
     * However, it is necessary to use Dependent Arrays properly.
     * */
   sealed abstract class ExplicitDependence

--- a/src/main/scala/rise/core/types/Flags.scala
+++ b/src/main/scala/rise/core/types/Flags.scala
@@ -1,0 +1,15 @@
+package rise.core.types
+
+object Flags {
+  /** This flag enables the type inference system to express explicit dependence
+    * of type variables within dependent functions.
+    *
+    * The pass is slow and interferes with advanced arithmetic simplification.
+    * However, it is necessary to use Dependent Arrays properly.
+    * */
+  sealed abstract class ExplicitDependence
+  object ExplicitDependence {
+    case object On extends ExplicitDependence
+    case object Off extends ExplicitDependence
+  }
+}

--- a/src/main/scala/rise/core/types/infer.scala
+++ b/src/main/scala/rise/core/types/infer.scala
@@ -24,7 +24,7 @@ object infer {
 
     // solve the constraints
     // val bound = boundIdentifiers(typed_e)
-    val solution = Constraint.solve(constraints, Seq())
+    val solution = Constraint.solve(constraints, Seq())(Flags.ExplicitDependence.Off)
 
     // apply the solution
     val r = solution(typed_e)

--- a/src/test/scala/rise/core/dependentTypes.scala
+++ b/src/test/scala/rise/core/dependentTypes.scala
@@ -5,7 +5,7 @@ import rise.core.TypeLevelDSL._
 import rise.core.types._
 
 class dependentTypes extends test_util.Tests {
-  ignore("Infer int addition type") {
+  test("Infer int addition type") {
     val e =
       nFun(n =>
         fun(
@@ -15,7 +15,7 @@ class dependentTypes extends test_util.Tests {
           )
         )(xs => xs |> depMapSeq(nFun(_ => mapSeq(fun(x => x)))))
       )
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     println(inferred.t)
   }
@@ -24,7 +24,7 @@ class dependentTypes extends test_util.Tests {
     val e = nFun(n =>
       fun(n `.` f32)(x => dpair(n)(x))
     )
-     val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }
@@ -33,7 +33,7 @@ class dependentTypes extends test_util.Tests {
     val e = fun(n2dPairT(n => n`.`f32))(pair =>
       dmatch(pair)(nFun(n => fun(x => dpair(n)(x))))
     )
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }
@@ -44,7 +44,7 @@ class dependentTypes extends test_util.Tests {
         reduceSeq(fun(x => fun(y => x + y)))(l(1.0f))(xs))
       ))
     )
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }
@@ -55,7 +55,7 @@ class dependentTypes extends test_util.Tests {
         depMapSeq(nFun(_ => mapSeq(fun(x => x))))(array)
       ))
 
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }
@@ -65,7 +65,7 @@ class dependentTypes extends test_util.Tests {
       depMapSeq(nFun(_ => reduceSeq(fun(x => fun(y => x + y)))(l(0.0f))))(array)
     ))
 
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }
@@ -89,7 +89,7 @@ class dependentTypes extends test_util.Tests {
       }
     ))))
 
-    val inferred: Expr = e
+    val inferred: Expr = TDSL.inferDependent(e)
     println(inferred)
     print(inferred.t)
   }


### PR DESCRIPTION
Explicit dependence is necessary for the dependent arrays to work, but makes everything super slow and it seems to critically break arithmetic expression simplification/pivoting in some tests. Therefore, it was removed in the big merge.

I tried to find a general way to have the type-checking only perform explicit dependence when necessary, or to go around the problem entirely. So far, I have been stuck and unable to do so.

Therefore for now, I propose to add a "ExplicitDependence.On/Off" flag, which is passed down to the inference system. It defauls to Off, and it is On only in my dependence tests.

Hopefully infuture we can find a better solution!