### PR TITLE
Improved @primitive macro

### DIFF
--- a/macros/src/main/scala/rise/macros/Primitive.scala
+++ b/macros/src/main/scala/rise/macros/Primitive.scala
@@ -66,8 +66,8 @@ object Primitive {
 
         object ${TermName{name}}  extends Builder {
           override def primitive: ${TypeName(className)} = $makeInstance()
-          override def apply: rise.core.TypedDSL.TDSL[${TypeName(className)}] =
-            rise.core.TypedDSL.toTDSL($makeInstance())
+          override def apply: rise.core.TypedDSL.ToBeTyped[${TypeName(className)}] =
+            rise.core.TypedDSL.toBeTyped($makeInstance())
           override def unapply(arg: rise.core.Expr): Boolean = arg match {
             case _: ${TypeName(className)} => true
             case _ => false
@@ -107,8 +107,8 @@ object Primitive {
 
         final case class ${TypeName(name)}(..$params) extends Builder {
           override def primitive: ${TypeName(className)} = $makeInstance()
-          override def apply: rise.core.TypedDSL.TDSL[${TypeName(className)}] =
-            rise.core.TypedDSL.toTDSL($makeInstance())
+          override def apply: rise.core.TypedDSL.ToBeTyped[${TypeName(className)}] =
+            rise.core.TypedDSL.toBeTyped($makeInstance())
         }
 
         object ${TermName(name)} {

--- a/src/main/scala/apps/cameraPipe.scala
+++ b/src/main/scala/apps/cameraPipe.scala
@@ -101,14 +101,14 @@ object cameraPipe {
     )
   }
 
-  def interleaveX: Expr = implDT(dt => implN(h => implN(w => fun(
+  def interleaveX: Expr = implDT(dt => implNat(h => implNat(w => fun(
     (h`.`w`.`dt) ->: (h`.`w`.`dt) ->: (h`.`(2*w)`.`dt)
   )((a, b) =>
     generate(fun(i => select(i =:= lidx(0, 2))(a)(b))) |>
     transpose >> map(transpose >> join)
   ))))
 
-  def interleaveY: Expr = implDT(dt => implN(h => implN(w => fun(
+  def interleaveY: Expr = implDT(dt => implNat(h => implNat(w => fun(
     (h`.`w`.`dt) ->: (h`.`w`.`dt) ->: ((2*h)`.`w`.`dt)
   )((a, b) =>
     generate(fun(i => select(i =:= lidx(0, 2))(a)(b))) |>
@@ -425,8 +425,8 @@ object cameraPipe {
       //  mapSeq(mapSeqUnroll(fun(x => x)))
       // )) >> join >> map(transpose) >> transpose >>
       // --
-      map(implN(w => map(drop(1) >> take(w))) >>
-        implN(h => drop(1) >> take(h))) >>
+      map(implNat(w => map(drop(1) >> take(w))) >>
+        implNat(h => drop(1) >> take(h))) >>
       fun(x => color_correct(2*h+2)(2*w+2)(hm)(wm)(x)
         (matrix_3200)(matrix_7000)(color_temp)) >>
       // TODO: reorder and store with elevate

--- a/src/main/scala/apps/cameraPipeRewrite.scala
+++ b/src/main/scala/apps/cameraPipeRewrite.scala
@@ -1,7 +1,7 @@
 package apps
 
 import util.printTime
-import rise.core._
+import rise.core.{primitives => p, _}
 import rise.core.TypedDSL._
 import elevate.core._
 import elevate.core.strategies.basic._
@@ -71,12 +71,12 @@ object cameraPipeRewrite {
     if (predicate(p)) { a(p) } else { b(p) }
   }
 
-  def isAppliedMap: Strategy[Rise] = function(function(isEqualTo(DSL.map)))
-  def isAppliedZip: Strategy[Rise] = function(function(isEqualTo(DSL.zip)))
-  def isAppliedDrop: Strategy[Rise] = function(depFunction(isEqualTo(DSL.drop)))
-  def isAppliedTake: Strategy[Rise] = function(depFunction(isEqualTo(DSL.take)))
+  def isAppliedMap: Strategy[Rise] = function(function(isEqualTo(p.map.primitive)))
+  def isAppliedZip: Strategy[Rise] = function(function(isEqualTo(p.zip.primitive)))
+  def isAppliedDrop: Strategy[Rise] = function(depFunction(isEqualTo(p.drop.primitive)))
+  def isAppliedTake: Strategy[Rise] = function(depFunction(isEqualTo(p.take.primitive)))
   def isAppliedSlide: Strategy[Rise] =
-    function(depFunction(depFunction(isEqualTo(DSL.slide))))
+    function(depFunction(depFunction(isEqualTo(p.slide.primitive))))
 
   def anyMapOutsideZip: Strategy[Rise] = {
     // function(function(isEqualTo(DSL.zip))) `;`
@@ -156,8 +156,8 @@ object cameraPipeRewrite {
 
   // idx i >> f -> map f >> idx i
   def idxAfterF: Strategy[Rise] = {
-    case expr @ App(f, App(App(primitives.Idx(), i), in)) =>
-      Success(idx(i, map(f, in)) :: expr.t)
+    case expr @ App(f, App(App(p.idx(), i), in)) =>
+      Success(p.idx(i)(p.map(f)(in)) :: expr.t)
     case _ => Failure(idxAfterF)
   }
 
@@ -211,7 +211,7 @@ object cameraPipeRewrite {
   ) <+ debugS("zipSameId failed")
 
   def singleInputId(ret: Int => Unit): Strategy[Rise] = p => {
-    import primitives.Idx
+    import rise.core.primitives.idx
     import semantics.IndexData
     import arithexpr.arithmetic.Cst
 
@@ -223,7 +223,7 @@ object cameraPipeRewrite {
         ) `;` argument(traverse)
       ) <+ {
         case p @ App(
-          App(Idx(), Literal(IndexData(Cst(i), _))),
+          App(idx(), Literal(IndexData(Cst(i), _))),
           _
         ) =>
           // FIXME: could go wrong
@@ -256,7 +256,7 @@ object cameraPipeRewrite {
           case current +: rightPs =>
             val withSnd = if (rightPs.nonEmpty) {
               argument(zipSndAfter(
-                rightPs.reduceRight[Rise] { case (a, b) => zip(a, b) }
+                rightPs.reduceRight[Rise] { case (a, b) => rise.core.primitives.zip(a)(b) }
               )) `;` mapFusion
             } else {
               idS
@@ -273,9 +273,9 @@ object cameraPipeRewrite {
   }
 
   def unifyMapOutsideGenerateSelect: Strategy[Rise] = {
-    function(isEqualTo(DSL.generate)) `;`
+    function(isEqualTo(p.generate.primitive)) `;`
     argument(body(
-      function(function(function(isEqualTo(DSL.select)))) `;`
+      function(function(function(isEqualTo(p.select.primitive)))) `;`
       unifyMapInputs(scala.collection.Seq(argument, s => function(argument(s))))
     )) `;` mapOutsideGenerateSelect() `;`
     argument(argument(normalizeInput) `;` repeat(mapFusion))
@@ -283,7 +283,7 @@ object cameraPipeRewrite {
 
   def unifyMapOutsideMakeArray: Strategy[Rise] = {
     // TODO: can work for arbitrary size arrays
-    function(function(function(isEqualTo(DSL.makeArray(3))))) `;`
+    function(function(function(isEqualTo(p.makeArray(3).primitive)))) `;`
     unifyMapInputs(scala.collection.Seq(
       argument,
       s => function(argument(s)),
@@ -315,7 +315,7 @@ object cameraPipeRewrite {
       body(body(body(
         function(body(function(body(
           // generate/select 3x2
-          repeatNTimes(6)(topDown(function(isEqualTo(DSL.generate)) `;`
+          repeatNTimes(6)(topDown(function(isEqualTo(p.generate.primitive)) `;`
             topDown(one(unifyMapOutsideGenerateSelect))
           )) `;`
           gentlyReducedForm `;`
@@ -334,6 +334,7 @@ object cameraPipeRewrite {
       // 4. lowering with slideSeq
       {
         import TypedDSL._
+        import rise.core.primitives._
         body(body(body(
           function(body(function(body(
             argument(argument(
@@ -361,7 +362,7 @@ object cameraPipeRewrite {
   }
 
   def letContinuation(s: Strategy[Rise]): Strategy[Rise] =
-    function(function(isEqualTo(primitives.Let()()))) `;`
+    function(function(isEqualTo(p.let.primitive))) `;`
     argument(s)
 
   def afterTopLevel(s: Strategy[Rise]): Strategy[Rise] = p => {
@@ -381,17 +382,17 @@ object cameraPipeRewrite {
   }
 
   def letHoist: Strategy[Rise] = {
-    case expr @ App(f, App(App(primitives.Let(), v), Lambda(x, b))) =>
-      Success(letf(lambda(untyped(x), typed(f)(b)), v) :: expr.t)
+    case expr @ App(f, App(App(p.let(), v), Lambda(x, b))) =>
+      Success(letf(lambda(untyped(x), typed(f)(b)))(v) :: expr.t)
     // TODO: normal form / non-map specific?
-    case expr @ App(App(primitives.Map(), Lambda(y,
-      App(App(primitives.Let(), v), Lambda(x, b))
+    case expr @ App(App(p.map(), Lambda(y,
+      App(App(p.let(), v), Lambda(x, b))
     )), in) if !contains[Rise](y).apply(v) =>
-      Success(letf(lambda(untyped(x), map(lambda(untyped(y), b), in)), v) :: expr.t)
-    case expr @ App(primitives.Map(), Lambda(y,
-      App(App(primitives.Let(), v), Lambda(x, b))
+      Success(letf(lambda(untyped(x), p.map(lambda(untyped(y), b))(in)))(v) :: expr.t)
+    case expr @ App(p.map(), Lambda(y,
+      App(App(p.let(), v), Lambda(x, b))
     )) if !contains[Rise](y).apply(v) =>
-      Success(fun(in => letf(lambda(untyped(x), map(lambda(untyped(y), b), in)), v)) :: expr.t)
+      Success(fun(in => letf(lambda(untyped(x), p.map(lambda(untyped(y), b))(in)))(v)) :: expr.t)
     case _ => Failure(letHoist)
   }
 
@@ -400,8 +401,8 @@ object cameraPipeRewrite {
     afterTopLevel(
       argument(argument({
         case expr @ App(Lambda(x, color_correct), matrix) =>
-          Success(letf(lambda(toTDSL(x), color_correct),
-            mapSeq(mapSeq(fun(x => x)), matrix)) :: expr.t)
+          Success(letf(lambda(toTDSL(x), color_correct))(
+            p.mapSeq(p.mapSeq(fun(x => x)))(matrix)) :: expr.t)
         case _ => Failure(precomputeColorCorrectionMatrix)
       })) `;`
       normalize.apply(gentleBetaReduction() <+ letHoist)
@@ -415,11 +416,11 @@ object cameraPipeRewrite {
     afterTopLevel(
       argument(function(argument(
         topDown(
-          function(function(isEqualTo(primitives.Idx()()))) `;`
-          argument(function(isEqualTo(primitives.Generate()()))) `;`
+          function(function(isEqualTo(p.idx.primitive))) `;`
+          argument(function(isEqualTo(p.generate.primitive))) `;`
           argument({ curve =>
-            Success(letf(fun(x => x),
-              mapSeq(fun(x => x), curve)) :: curve.t)
+            Success(letf(fun(x => x))(
+              p.mapSeq(fun(x => x))(curve)) :: curve.t)
           })
         )
       ))) `;`
@@ -440,7 +441,7 @@ object cameraPipeRewrite {
             function(body(
               function(body(
                 // generate/select 3x2
-                repeatNTimes(6)(topDown(function(isEqualTo(DSL.generate)) `;`
+                repeatNTimes(6)(topDown(function(isEqualTo(p.generate.primitive)) `;`
                   topDown(one(unifyMapOutsideGenerateSelect))
                 )) `;`
                 gentlyReducedForm `;`

--- a/src/main/scala/apps/cameraPipeRewrite.scala
+++ b/src/main/scala/apps/cameraPipeRewrite.scala
@@ -347,7 +347,7 @@ object cameraPipeRewrite {
                 // TODO: use proper rewriting to achieve this
                 function(argument(body({ expr =>
                   Success(
-                    isTyped(expr) |> transpose >> map(transpose) >>
+                    preserveType(expr) |> transpose >> map(transpose) >>
                       // 2 bands of y. all x. rgb channels.
                       mapSeqUnroll(mapSeq(mapSeqUnroll(fun(x => x)))) >>
                       map(transpose) >> transpose
@@ -383,7 +383,7 @@ object cameraPipeRewrite {
 
   def letHoist: Strategy[Rise] = {
     case expr @ App(f, App(App(p.let(), v), Lambda(x, b))) =>
-      Success(letf(lambda(eraseType(x), isTyped(f)(b)))(v) :: expr.t)
+      Success(letf(lambda(eraseType(x), preserveType(f)(b)))(v) :: expr.t)
     // TODO: normal form / non-map specific?
     case expr @ App(App(p.map(), Lambda(y,
       App(App(p.let(), v), Lambda(x, b))

--- a/src/main/scala/apps/convolution.scala
+++ b/src/main/scala/apps/convolution.scala
@@ -30,7 +30,7 @@ object convolution {
   ))
 
   def padEmpty(l: Nat, r: Nat): Expr = padClamp(l)(r)
-  def unpadEmpty(l: Nat, r: Nat): Expr = implN(n => implDT(t =>
+  def unpadEmpty(l: Nat, r: Nat): Expr = implNat(n => implDT(t =>
     drop(l) >> (take(n) :: ((n + r) `.` t) ->: (n `.` t))
   ))
 

--- a/src/main/scala/apps/harrisCornerDetectionHalideRewrite.scala
+++ b/src/main/scala/apps/harrisCornerDetectionHalideRewrite.scala
@@ -77,7 +77,7 @@ object harrisCornerDetectionHalideRewrite {
       case _ if typeHasTrivialCopy(t) => fun(p => p)
       case PairType(a, b) if typeHasTrivialCopy(a) && typeHasTrivialCopy(b) =>
         fun(p => p)
-      case ArrayType(_, elem) => fun(p => mapSeqUnroll(writeUnrolled(elem), p))
+      case ArrayType(_, elem) => fun(p => rise.core.primitives.mapSeqUnroll(writeUnrolled(elem))(p))
       case _ => throw new Exception(s"did not expect $t")
     }
   }

--- a/src/main/scala/apps/harrisCornerDetectionHalideRewrite.scala
+++ b/src/main/scala/apps/harrisCornerDetectionHalideRewrite.scala
@@ -73,7 +73,7 @@ object harrisCornerDetectionHalideRewrite {
         case _ => ???
       } `;` reducedFusedForm
 
-    def writeUnrolled(t: Type): TDSL[Rise] = t match {
+    def writeUnrolled(t: Type): ToBeTyped[Rise] = t match {
       case _ if typeHasTrivialCopy(t) => fun(p => p)
       case PairType(a, b) if typeHasTrivialCopy(a) && typeHasTrivialCopy(b) =>
         fun(p => p)

--- a/src/main/scala/apps/separableConvolution2D.scala
+++ b/src/main/scala/apps/separableConvolution2D.scala
@@ -130,7 +130,7 @@ object separableConvolution2D {
   val shuffle: Expr =
     asScalar >> drop(3) >> take(6) >> slideVectors(4)
   val scanlinePar: Expr = fun(3`.`f32)(weightsV => fun(3`.`f32)(weightsH =>
-    map(implN(w => fun(w`.`f32)(x =>
+    map(implNat(w => fun(w`.`f32)(x =>
       x |> asVectorAligned(4)
         |> padCst(1)(0)(vectorFromScalar(x `@` lidx(0, w)))
         |> padCst(0)(1)(vectorFromScalar(x `@` lidx(w - 1, w)))
@@ -156,7 +156,7 @@ object separableConvolution2D {
     val Dv = weightsSeqVecUnroll(weightsV)
     val Dh = weightsSeqVecUnroll(weightsH)
     // map(padClamp(4)(4) >> asVectorAligned(4)) >> padClamp(1)(1) >>
-    map(implN(w => fun(w`.`f32)(x =>
+    map(implNat(w => fun(w`.`f32)(x =>
       x |> asVectorAligned(4)
         |> padCst(1)(0)(vectorFromScalar(x `@` lidx(0, w)))
         |> padCst(0)(1)(vectorFromScalar(x `@` lidx(w - 1, w)))

--- a/src/main/scala/apps/sgemm.scala
+++ b/src/main/scala/apps/sgemm.scala
@@ -14,7 +14,7 @@ object sgemm {
   // we can use implicit type parameters and type annotations to specify the function type of mult
   val mult  = implDT(dt => fun(x => x._1 * x._2) :: ((dt x dt) ->: dt))
   val add   = fun(x => fun(y => x + y))
-  val scal  = implN(n => fun(xs => fun(a => mapSeq(fun(x => a * x), xs))) :: (ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32)))
+  val scal  = implNat(n => fun(xs => fun(a => mapSeq(fun(x => a * x), xs))) :: (ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32)))
   val dot = fun(x => foreignFun("dot", vec(4, f32) ->: vec(4, f32) ->: f32)(x._1, x._2))
   def id: Expr = fun(x => x)
 
@@ -56,7 +56,7 @@ object sgemm {
     val p3: Nat = 4
     val vw: Nat = 4
 
-    val write_zeros = implN(n => implN(m =>
+    val write_zeros = implNat(n => implNat(m =>
       generate(fun(IndexType(m))(_ => generate(fun(IndexType(n))(_ => l(0.0f)))))
       |> mapSeq(mapSeq(id))))
 
@@ -112,7 +112,7 @@ object sgemm {
           generate(fun(IndexType(n2))(_ =>
             generate(fun(IndexType(n1))(_ => l(0.0f)))))))))))))
 
-    def tile2: Expr = nFun(s1 => nFun(s2 => implN(n1 => implN(n2 => fun(ArrayType(n1, ArrayType(n2, f32)))(x =>
+    def tile2: Expr = nFun(s1 => nFun(s2 => implNat(n1 => implNat(n2 => fun(ArrayType(n1, ArrayType(n2, f32)))(x =>
       transpose (map (transpose) (split (s1) (map (split (s2)) (x))))  )))))
 
     def redOp: Expr = fun((8`.`32`.`8`.`4`.`f32) ->: ( (8`.`64`.`f32) x (8`.`128`.`f32) ) ->: (8`.`32`.`8`.`4`.`f32) )((p14, p15) =>

--- a/src/main/scala/rise/core/Builder.scala
+++ b/src/main/scala/rise/core/Builder.scala
@@ -1,0 +1,22 @@
+package rise.core
+
+import types._
+
+trait Builder {
+  def apply: TypedDSL.TDSL[Primitive] =
+    throw new Exception("apply method must be overridden")
+  def apply(e: TypedDSL.TDSL[Expr]): TypedDSL.TDSL[App] =
+    TypedDSL.app(TypedDSL.toTDSL(apply), e)
+  def apply(n: Nat): TypedDSL.TDSL[DepApp[NatKind]] =
+    TypedDSL.depApp[NatKind](TypedDSL.toTDSL(apply), n)
+  def apply(dt: DataType): TypedDSL.TDSL[DepApp[DataKind]] =
+    TypedDSL.depApp[DataKind](TypedDSL.toTDSL(apply), dt)
+  def apply(a: AddressSpace): TypedDSL.TDSL[DepApp[AddressSpaceKind]] =
+    TypedDSL.depApp[AddressSpaceKind](TypedDSL.toTDSL(apply), a)
+
+  def unapply(arg: Expr): Boolean =
+    throw new Exception("unapply method must be overridden")
+
+  def primitive: Primitive =
+    throw new Exception("primitive method must be overridden")
+}

--- a/src/main/scala/rise/core/Builder.scala
+++ b/src/main/scala/rise/core/Builder.scala
@@ -3,16 +3,16 @@ package rise.core
 import types._
 
 trait Builder {
-  def apply: TypedDSL.TDSL[Primitive] =
+  def apply: TypedDSL.ToBeTyped[Primitive] =
     throw new Exception("apply method must be overridden")
-  def apply(e: TypedDSL.TDSL[Expr]): TypedDSL.TDSL[App] =
-    TypedDSL.app(TypedDSL.toTDSL(apply), e)
-  def apply(n: Nat): TypedDSL.TDSL[DepApp[NatKind]] =
-    TypedDSL.depApp[NatKind](TypedDSL.toTDSL(apply), n)
-  def apply(dt: DataType): TypedDSL.TDSL[DepApp[DataKind]] =
-    TypedDSL.depApp[DataKind](TypedDSL.toTDSL(apply), dt)
-  def apply(a: AddressSpace): TypedDSL.TDSL[DepApp[AddressSpaceKind]] =
-    TypedDSL.depApp[AddressSpaceKind](TypedDSL.toTDSL(apply), a)
+  def apply(e: TypedDSL.ToBeTyped[Expr]): TypedDSL.ToBeTyped[App] =
+    TypedDSL.app(TypedDSL.toBeTyped(apply), e)
+  def apply(n: Nat): TypedDSL.ToBeTyped[DepApp[NatKind]] =
+    TypedDSL.depApp[NatKind](TypedDSL.toBeTyped(apply), n)
+  def apply(dt: DataType): TypedDSL.ToBeTyped[DepApp[DataKind]] =
+    TypedDSL.depApp[DataKind](TypedDSL.toBeTyped(apply), dt)
+  def apply(a: AddressSpace): TypedDSL.ToBeTyped[DepApp[AddressSpaceKind]] =
+    TypedDSL.depApp[AddressSpaceKind](TypedDSL.toBeTyped(apply), a)
 
   def unapply(arg: Expr): Boolean =
     throw new Exception("unapply method must be overridden")

--- a/src/main/scala/rise/core/DSL.scala
+++ b/src/main/scala/rise/core/DSL.scala
@@ -1,8 +1,7 @@
 package rise.core
 
-import rise.core.types._
 import rise.core.semantics._
-import rise.core.primitives._
+import rise.core.types._
 
 import scala.language.implicitConversions
 
@@ -18,69 +17,69 @@ object DSL {
   def depApp[K <: Kind](f: Expr, x: K#T): DepApp[K] = DepApp[K](f, x)()
   def literal(d: semantics.Data): Literal = Literal(d)
 
-  def toMem: ToMem = ToMem()()
+  def toMem: Primitive = primitives.toMem.primitive
   def toMemFun(f: Expr): Expr = fun(x => toMem(f(x)))
-  def makeArray(n: Int): MakeArray = primitives.MakeArray(n)()
-  def cast: Cast = primitives.Cast()()
-  def depJoin: DepJoin = primitives.DepJoin()()
-  def depMapSeq: DepMapSeq = primitives.DepMapSeq()()
-  def depZip: DepZip = primitives.DepZip()()
-  def drop: Drop = primitives.Drop()()
-  def fst: Fst = primitives.Fst()()
-  def gather: Gather = primitives.Gather()()
-  def generate: Generate = primitives.Generate()()
-  def idx: Idx = primitives.Idx()()
-  def id: Id = primitives.Id()()
-  def indexAsNat: IndexAsNat = primitives.IndexAsNat()()
-  def iterate: Iterate = primitives.Iterate()()
-  def join: Join = primitives.Join()()
-  def map: Map = primitives.Map()()
-  def mapFst: MapFst = primitives.MapFst()()
-  def mapSnd: MapSnd = primitives.MapSnd()()
-  def mapSeq: MapSeq = primitives.MapSeq()()
-  def mapStream: MapStream = primitives.MapStream()()
-  def iterateStream: IterateStream = primitives.IterateStream()()
-  def mapSeqUnroll: MapSeqUnroll = primitives.MapSeqUnroll()()
-  def natAsIndex: NatAsIndex = primitives.NatAsIndex()()
-  def padCst: PadCst = primitives.PadCst()()
-  def padEmpty: PadEmpty = primitives.PadEmpty()()
-  def padClamp: PadClamp = primitives.PadClamp()()
-  def partition: Partition = primitives.Partition()()
-  def pair: Pair = primitives.Pair()()
-  def reduce: Reduce = primitives.Reduce()()
-  def reduceSeq: ReduceSeq = primitives.ReduceSeq()()
-  def reduceSeqUnroll: ReduceSeqUnroll = primitives.ReduceSeqUnroll()()
-  def reorder: Reorder = primitives.Reorder()()
-  def scanSeq: ScanSeq = primitives.ScanSeq()()
-  def slide: Slide = primitives.Slide()()
-  def circularBuffer: CircularBuffer = primitives.CircularBuffer()()
-  def rotateValues: RotateValues = primitives.RotateValues()()
-  def snd: Snd = primitives.Snd()()
-  def split: Split = primitives.Split()()
-  def take: Take = primitives.Take()()
-  def transpose: Transpose = primitives.Transpose()()
-  def select: Select = primitives.Select()()
-  def unzip: Unzip = primitives.Unzip()()
-  def zip: Zip = primitives.Zip()()
+  def makeArray(n: Int): Primitive = primitives.makeArray(n).primitive
+  def cast: Primitive = primitives.cast.primitive
+  def depJoin: Primitive = primitives.depJoin.primitive
+  def depMapSeq: Primitive = primitives.depMapSeq.primitive
+  def depZip: Primitive = primitives.depZip.primitive
+  def drop: Primitive = primitives.drop.primitive
+  def fst: Primitive = primitives.fst.primitive
+  def gather: Primitive = primitives.gather.primitive
+  def generate: Primitive = primitives.generate.primitive
+  def idx: Primitive = primitives.idx.primitive
+  def id: Primitive = primitives.id.primitive
+  def indexAsNat: Primitive = primitives.indexAsNat.primitive
+  def iterate: Primitive = primitives.iterate.primitive
+  def join: Primitive = primitives.join.primitive
+  def map: Primitive = primitives.map.primitive
+  def mapFst: Primitive = primitives.mapFst.primitive
+  def mapSnd: Primitive = primitives.mapSnd.primitive
+  def mapSeq: Primitive = primitives.mapSeq.primitive
+  def mapStream: Primitive = primitives.mapStream.primitive
+  def iterateStream: Primitive = primitives.iterateStream.primitive
+  def mapSeqUnroll: Primitive = primitives.mapSeqUnroll.primitive
+  def natAsIndex: Primitive = primitives.natAsIndex.primitive
+  def padCst: Primitive = primitives.padCst.primitive
+  def padEmpty: Primitive = primitives.padEmpty.primitive
+  def padClamp: Primitive = primitives.padClamp.primitive
+  def partition: Primitive = primitives.partition.primitive
+  def pair: Primitive = primitives.pair.primitive
+  def reduce: Primitive = primitives.reduce.primitive
+  def reduceSeq: Primitive = primitives.reduceSeq.primitive
+  def reduceSeqUnroll: Primitive = primitives.reduceSeqUnroll.primitive
+  def reorder: Primitive = primitives.reorder.primitive
+  def scanSeq: Primitive = primitives.scanSeq.primitive
+  def slide: Primitive = primitives.slide.primitive
+  def circularBuffer: Primitive = primitives.circularBuffer.primitive
+  def rotateValues: Primitive = primitives.rotateValues.primitive
+  def snd: Primitive = primitives.snd.primitive
+  def split: Primitive = primitives.split.primitive
+  def take: Primitive = primitives.take.primitive
+  def transpose: Primitive = primitives.transpose.primitive
+  def select: Primitive = primitives.select.primitive
+  def unzip: Primitive = primitives.unzip.primitive
+  def zip: Primitive = primitives.zip.primitive
 
-  def neg: Neg = primitives.Neg()()
-  def not: Not = primitives.Not()()
-  def add: Add = primitives.Add()()
-  def sub: Sub = primitives.Sub()()
-  def mul: Mul = primitives.Mul()()
-  def div: Div = primitives.Div()()
-  def mod: Mod = primitives.Mod()()
-  def gt: Gt = primitives.Gt()()
-  def lt: Lt = primitives.Lt()()
-  def equal: Equal = primitives.Equal()()
+  def neg: Primitive = primitives.neg.primitive
+  def not: Primitive = primitives.not.primitive
+  def add: Primitive = primitives.add.primitive
+  def sub: Primitive = primitives.sub.primitive
+  def mul: Primitive = primitives.mul.primitive
+  def div: Primitive = primitives.div.primitive
+  def mod: Primitive = primitives.mod.primitive
+  def gt: Primitive = primitives.gt.primitive
+  def lt: Primitive = primitives.lt.primitive
+  def equal: Primitive = primitives.equal.primitive
 
-  def asVector: AsVector = primitives.AsVector()()
-  def asVectorAligned: AsVectorAligned = primitives.AsVectorAligned()()
-  def asScalar: AsScalar = primitives.AsScalar()()
-  def vectorFromScalar: VectorFromScalar = primitives.VectorFromScalar()()
+  def asVector: Primitive = primitives.asVector.primitive
+  def asVectorAligned: Primitive = primitives.asVectorAligned.primitive
+  def asScalar: Primitive = primitives.asScalar.primitive
+  def vectorFromScalar: Primitive = primitives.vectorFromScalar.primitive
 
-  def printType(msg: String): PrintType = PrintType(msg)()
-  def typeHole(msg: String): TypeHole = TypeHole(msg)()
+  def printType(msg: String): Primitive = primitives.printType(msg).primitive
+  def typeHole(msg: String): Primitive = primitives.typeHole(msg).primitive
 
   // scalastyle:off method.name
   implicit class Ops(lhs: Expr) {
@@ -122,8 +121,8 @@ object DSL {
   }
    */
 
-  implicit class TypeAnnotation(t: Type) {
-    def ::(e: Expr): Expr = Annotation(e, t)
+  implicit class TypeAnnotationHelper(t: Type) {
+    def ::(e: Expr): Expr = TypeAnnotation(e, t)
     def `:`(e: Expr): Expr = e :: t
   }
   // scalastyle:on method.name
@@ -179,17 +178,17 @@ object DSL {
       def be(in: Expr => Expr): Expr
     } = new {
       def be(in: Expr => Expr): Expr =
-        primitives.Let()().apply(e).apply(fun(in))
+        primitives.let.primitive.apply(e).apply(fun(in))
     }
   }
   // scalastyle:on structural.type
 
   object letf {
     def apply(in: Expr => Expr): Expr = {
-      fun(e => primitives.Let()().apply(e).apply(fun(in)))
+      fun(e => primitives.let.primitive.apply(e).apply(fun(in)))
     }
     def apply(in: Expr): Expr = {
-      fun(e => primitives.Let()().apply(e).apply(in))
+      fun(e => primitives.let.primitive.apply(e).apply(in))
     }
   }
 

--- a/src/main/scala/rise/core/Expr.scala
+++ b/src/main/scala/rise/core/Expr.scala
@@ -89,9 +89,11 @@ final case class Literal(d: semantics.Data) extends Expr {
 }
 
 abstract class Primitive extends Expr {
-  def typeScheme: Type
+  override val t: Type = TypePlaceholder
+  def typeScheme: Type =
+    throw TypeException("typeScheme method must be overridden")
   def name: String =
-    throw RenderException("the name of Primitive should be set")
+    throw RenderException("the name of Primitive must be set")
   override def setType(t: Type): Primitive =
-    throw TypeException("setType method should be overridden")
+    throw TypeException("setType method must be overridden")
 }

--- a/src/main/scala/rise/core/HighLevelConstructs.scala
+++ b/src/main/scala/rise/core/HighLevelConstructs.scala
@@ -18,7 +18,7 @@ object HighLevelConstructs {
   val reorderWithStride: Expr = {
     nFun(s => {
       val f =
-        implN(n =>
+        implNat(n =>
           fun(IndexType(n))(i =>
             natAsIndex(n)(
               (indexAsNat(i) / (n /^ s)) +
@@ -53,7 +53,7 @@ object HighLevelConstructs {
   }
 
   def dropLast: Expr = nFun(n =>
-    implN(m => implDT(dt => take(m) :: ((m + n) `.` dt) ->: (m `.` dt)))
+    implNat(m => implDT(dt => take(m) :: ((m + n) `.` dt) ->: (m `.` dt)))
   )
 
   // TODO: Investigate. this might be wrong

--- a/src/main/scala/rise/core/TypeAnnotation.scala
+++ b/src/main/scala/rise/core/TypeAnnotation.scala
@@ -1,0 +1,12 @@
+package rise.core
+
+import rise.core.types.{Type, TypeException, TypePlaceholder}
+
+case class TypeAnnotation(e: Expr, annotation: Type) extends Primitive {
+  override val t: Type = TypePlaceholder
+  override def typeScheme: Type =
+    throw TypeException("cannot get the type scheme of an annotated Expr")
+  override def setType(t: Type): TypeAnnotation =
+    throw TypeException("cannot set the type of an annotated Expr")
+  override def name: String = s"Annotated Expr: $annotation"
+}

--- a/src/main/scala/rise/core/TypeLevelDSL.scala
+++ b/src/main/scala/rise/core/TypeLevelDSL.scala
@@ -54,7 +54,7 @@ object TypeLevelDSL {
   }
 
   // dependent function types
-  object nFunT {
+  object forallNat {
     def apply(f: NatIdentifier => Type): Type = {
       val x = NatIdentifier(freshName("n"), isExplicit = true)
       DepFunType[NatKind, Type](x, f(x))
@@ -68,7 +68,7 @@ object TypeLevelDSL {
     }
   }
 
-  object dtFunT {
+  object forallDT {
     def apply(f: DataTypeIdentifier => Type): Type = {
       val x = DataTypeIdentifier(freshName("dt"), isExplicit = true)
       DepFunType[DataKind, Type](x, f(x))
@@ -82,7 +82,7 @@ object TypeLevelDSL {
     }
   }
 
-  object n2nFunT {
+  object forallN2N {
     def apply(f: NatToNat => Type): Type = {
       val x = NatToNatIdentifier(freshName("n2n"), isExplicit = true)
       DepFunType[NatToNatKind, Type](x, f(x))
@@ -96,7 +96,7 @@ object TypeLevelDSL {
     }
   }
 
-  object n2dtFunT {
+  object forallN2DT {
     def apply(f: NatToData => Type): Type = {
       val x = NatToDataIdentifier(freshName("n2dt"), isExplicit = true)
       DepFunType[NatToDataKind, Type](x, f(x))
@@ -110,7 +110,7 @@ object TypeLevelDSL {
     }
   }
 
-  object aFunT {
+  object forallAddr {
     def apply(f: AddressSpaceIdentifier => Type): Type = {
       val x = AddressSpaceIdentifier(freshName("a"), isExplicit = true)
       DepFunType[AddressSpaceKind, Type](x, f(x))
@@ -140,11 +140,11 @@ object TypeLevelDSL {
   }
 
   // types with implicit type parameters
-  def implN[A](f: NatIdentifier => A): A = {
+  def implNat[A](f: NatIdentifier => A): A = {
     f(NatIdentifier(freshName("n")))
   }
 
-  def implT[A](f: TypeIdentifier => A): A = {
+  def implType[A](f: TypeIdentifier => A): A = {
     f(TypeIdentifier(freshName("t")))
   }
   def implDT[A](f: DataTypeIdentifier => A): A = {
@@ -167,7 +167,7 @@ object TypeLevelDSL {
     f(NatToDataIdentifier(freshName("n2dt")))
   }
 
-  def implA[A](f: AddressSpaceIdentifier => A): A = {
+  def implAddr[A](f: AddressSpaceIdentifier => A): A = {
     f(AddressSpaceIdentifier(freshName("w")))
   }
 
@@ -175,7 +175,7 @@ object TypeLevelDSL {
     f(NatCollectionIdentifier(freshName("ns")))
   }
 
-  def freshTypeIdentifier: Type = implT(identity)
+  def freshTypeIdentifier: Type = implType(identity)
 
   implicit final class TypeConstructors(private val r: Type) extends AnyVal {
     @inline def ->:(t: Type): FunType[Type, Type] = FunType(t, r)
@@ -218,6 +218,7 @@ object TypeLevelDSL {
   implicit final class DepArrayTypeConstructors(private val n: Nat)
     extends AnyVal {
     @inline def `..`(f: Nat => DataType): DepArrayType = DepArrayType(n, f)
+    @inline def `..`(f: NatToData): DepArrayType = DepArrayType(n, f)
   }
 
   implicit final class NatCollectionConstructors(private val e: TDSL[Expr])

--- a/src/main/scala/rise/core/TypeLevelDSL.scala
+++ b/src/main/scala/rise/core/TypeLevelDSL.scala
@@ -1,7 +1,7 @@
 package rise.core
 
 import arithexpr.arithmetic.{Cst, RangeAdd}
-import rise.core.TypedDSL.TDSL
+import rise.core.TypedDSL.ToBeTyped
 import rise.core.types._
 
 // scalastyle:off multiple.string.literals
@@ -221,7 +221,7 @@ object TypeLevelDSL {
     @inline def `..`(f: NatToData): DepArrayType = DepArrayType(n, f)
   }
 
-  implicit final class NatCollectionConstructors(private val e: TDSL[Expr])
+  implicit final class NatCollectionConstructors(private val e: ToBeTyped[Expr])
     extends AnyVal {
     @inline def `#`(nats: Nat*): Nat = {
       NatCollectionFromArray(e)(nats: _*)

--- a/src/main/scala/rise/core/TypedDSL.scala
+++ b/src/main/scala/rise/core/TypedDSL.scala
@@ -284,7 +284,7 @@ object TypedDSL {
     def >>=[X <: Expr](f: T => ToBeTyped[X]): ToBeTyped[X] = f(e)
   }
 
-  implicit def isTyped[T <: Expr](e: T): ToBeTyped[Opaque] = ToBeTyped(Opaque(e)())
+  implicit def preserveType[T <: Expr](e: T): ToBeTyped[Opaque] = ToBeTyped(Opaque(e)())
 
   def toBeTyped[T <: Expr](e: T): ToBeTyped[T] = ToBeTyped(e)
 

--- a/src/main/scala/rise/core/TypedDSL.scala
+++ b/src/main/scala/rise/core/TypedDSL.scala
@@ -279,23 +279,23 @@ object TypedDSL {
     }
   }
 
-  final case class TDSL[+T <: Expr](private val e: T) {
+  final case class ToBeTyped[+T <: Expr](private val e: T) {
     def toExpr: Expr = TDSL.infer(e)
-    def >>=[X <: Expr](f: T => TDSL[X]): TDSL[X] = f(e)
+    def >>=[X <: Expr](f: T => ToBeTyped[X]): ToBeTyped[X] = f(e)
   }
 
-  implicit def typed[T <: Expr](e: T): TDSL[Opaque] = TDSL(Opaque(e)())
+  implicit def isTyped[T <: Expr](e: T): ToBeTyped[Opaque] = ToBeTyped(Opaque(e)())
 
-  def toTDSL[T <: Expr](e: T): TDSL[T] = TDSL(e)
+  def toBeTyped[T <: Expr](e: T): ToBeTyped[T] = ToBeTyped(e)
 
-  implicit def toExpr[T <: Expr](d: TDSL[T]): Expr = d.toExpr
+  implicit def toExpr[T <: Expr](d: ToBeTyped[T]): Expr = d.toExpr
 
   def topLevel(e: Expr): TopLevel = TopLevel(e)()
 
-  implicit def tdslTopLevel[T <: Expr](d: TDSL[T]): TDSL[TopLevel] =
-    toTDSL(topLevel(toExpr(d)))
+  implicit def untypedTopLevel[T <: Expr](d: ToBeTyped[T]): ToBeTyped[TopLevel] =
+    toBeTyped(topLevel(toExpr(d)))
 
-  def erase[T <: Expr](e: T): T =
+  def eraseTypeFromExpr[T <: Expr](e: T): T =
     traversal
       .DepthFirstLocalResult(
         e,
@@ -308,7 +308,7 @@ object TypedDSL {
       )
       .asInstanceOf[T]
 
-  def untyped[T <: Expr](e: T): TDSL[T] = toTDSL(erase(e))
+  def eraseType[T <: Expr](e: T): ToBeTyped[T] = toBeTyped(eraseTypeFromExpr(e))
 
   object TDSL {
     case class Visitor(sol: Solution) extends traversal.Visitor {
@@ -414,7 +414,9 @@ object TypedDSL {
       }
     }
 
-    def inferDependent(e: TDSL[Expr]): Expr = this.infer(e.e, Flags.ExplicitDependence.On)
+    def inferDependent(e: ToBeTyped[Expr]): Expr = this.infer(e match {
+      case ToBeTyped(e) => e
+    }, Flags.ExplicitDependence.On)
 
     def infer(e: Expr,
               explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off
@@ -436,53 +438,53 @@ object TypedDSL {
     }
   }
 
-  def identifier(name: String): TDSL[Identifier] = toTDSL(Identifier(name)())
-  def lambda(x: TDSL[Identifier], e: TDSL[Expr]): TDSL[Lambda] =
-    x >>= (x => e >>= (e => toTDSL(Lambda(x, e)())))
-  def app(f: TDSL[Expr], e: TDSL[Expr]): TDSL[App] =
-    f >>= (f => e >>= (e => toTDSL(App(f, e)())))
+  def identifier(name: String): ToBeTyped[Identifier] = toBeTyped(Identifier(name)())
+  def lambda(x: ToBeTyped[Identifier], e: ToBeTyped[Expr]): ToBeTyped[Lambda] =
+    x >>= (x => e >>= (e => toBeTyped(Lambda(x, e)())))
+  def app(f: ToBeTyped[Expr], e: ToBeTyped[Expr]): ToBeTyped[App] =
+    f >>= (f => e >>= (e => toBeTyped(App(f, e)())))
   def depLambda[K <: Kind: KindName](
       x: K#I with Kind.Explicitness,
-      e: TDSL[Expr]
-  ): TDSL[DepLambda[K]] =
-    e >>= (e => toTDSL(DepLambda[K](x, e)()))
-  def depApp[K <: Kind](f: TDSL[Expr], x: K#T): TDSL[DepApp[K]] =
-    f >>= (f => toTDSL(DepApp[K](f, x)()))
-  def literal(d: semantics.Data): TDSL[Literal] = toTDSL(Literal(d))
+      e: ToBeTyped[Expr]
+  ): ToBeTyped[DepLambda[K]] =
+    e >>= (e => toBeTyped(DepLambda[K](x, e)()))
+  def depApp[K <: Kind](f: ToBeTyped[Expr], x: K#T): ToBeTyped[DepApp[K]] =
+    f >>= (f => toBeTyped(DepApp[K](f, x)()))
+  def literal(d: semantics.Data): ToBeTyped[Literal] = toBeTyped(Literal(d))
 
-  def array(n: Int): TDSL[Primitive] = primitives.makeArray(n).apply
-  def store(cont: TDSL[Expr] => TDSL[Expr]): TDSL[Expr] =
+  def array(n: Int): ToBeTyped[Primitive] = primitives.makeArray(n).apply
+  def store(cont: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] =
     fun(e => let(toMem(e))(fun(cont)))
-  def store(how: TDSL[Expr])
-           (in: TDSL[Expr] => TDSL[Expr]): TDSL[Expr] =
+  def store(how: ToBeTyped[Expr])
+           (in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] =
     fun(e => let(toMem(how(e)))(fun(in)))
-  def store2(how: TDSL[Expr]): TDSL[Expr] =
+  def store2(how: ToBeTyped[Expr]): ToBeTyped[Expr] =
     fun(e => let(toMem(how(e)))(fun(x => x)))
 
-  implicit class Ops(lhs: TDSL[Expr]) {
+  implicit class Ops(lhs: ToBeTyped[Expr]) {
 
     // binary
-    def +(rhs: TDSL[Expr]): TDSL[App] = add(lhs)(rhs)
-    def -(rhs: TDSL[Expr]): TDSL[App] = sub(lhs)(rhs)
-    def *(rhs: TDSL[Expr]): TDSL[App] = mul(lhs)(rhs)
-    def /(rhs: TDSL[Expr]): TDSL[App] = div(lhs)(rhs)
-    def %(rhs: TDSL[Expr]): TDSL[App] = mod(lhs)(rhs)
-    def >(rhs: TDSL[Expr]): TDSL[App] = gt(lhs)(rhs)
-    def <(rhs: TDSL[Expr]): TDSL[App] = lt(lhs)(rhs)
-    def =:=(rhs: TDSL[Expr]): TDSL[App] = equal(lhs)(rhs)
+    def +(rhs: ToBeTyped[Expr]): ToBeTyped[App] = add(lhs)(rhs)
+    def -(rhs: ToBeTyped[Expr]): ToBeTyped[App] = sub(lhs)(rhs)
+    def *(rhs: ToBeTyped[Expr]): ToBeTyped[App] = mul(lhs)(rhs)
+    def /(rhs: ToBeTyped[Expr]): ToBeTyped[App] = div(lhs)(rhs)
+    def %(rhs: ToBeTyped[Expr]): ToBeTyped[App] = mod(lhs)(rhs)
+    def >(rhs: ToBeTyped[Expr]): ToBeTyped[App] = gt(lhs)(rhs)
+    def <(rhs: ToBeTyped[Expr]): ToBeTyped[App] = lt(lhs)(rhs)
+    def =:=(rhs: ToBeTyped[Expr]): ToBeTyped[App] = equal(lhs)(rhs)
 
     // scalastyle:off disallow.space.before.token
     // unary
-    def unary_- : TDSL[App] = neg(lhs)
+    def unary_- : ToBeTyped[App] = neg(lhs)
     // scalastyle:on disallow.space.before.token
 
     // pair accesses
-    def _1: TDSL[App] = fst(lhs)
-    def _2: TDSL[App] = snd(lhs)
+    def _1: ToBeTyped[App] = fst(lhs)
+    def _2: ToBeTyped[App] = snd(lhs)
   }
 
-  implicit class Indexing(e: TDSL[Expr]) {
-    def `@`(i: TDSL[Expr]): TDSL[App] = idx(i)(e)
+  implicit class Indexing(e: ToBeTyped[Expr]) {
+    def `@`(i: ToBeTyped[Expr]): ToBeTyped[App] = idx(i)(e)
   }
 
   /*
@@ -495,174 +497,174 @@ object TypedDSL {
   }
    */
   implicit class TypeAnnotationHelper(t: Type) {
-    def ::[T <: Expr](e: TDSL[T]): TDSL[Expr] =
-      e >>= (e => toTDSL(TypeAnnotation(e, t)))
-    def `:`[T <: Expr](e: TDSL[T]): TDSL[Expr] = e :: t
+    def ::[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] =
+      e >>= (e => toBeTyped(TypeAnnotation(e, t)))
+    def `:`[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = e :: t
   }
 
-  implicit class FunCall(f: TDSL[Expr]) {
+  implicit class FunCall(f: ToBeTyped[Expr]) {
 
-    def apply(e: TDSL[Expr]): TDSL[App] = app(f, e)
-    def apply(n: Nat): TDSL[DepApp[NatKind]] = depApp[NatKind](f, n)
-    def apply(dt: DataType): TDSL[DepApp[DataKind]] = depApp[DataKind](f, dt)
-    def apply(a: AddressSpace): TDSL[DepApp[AddressSpaceKind]] =
+    def apply(e: ToBeTyped[Expr]): ToBeTyped[App] = app(f, e)
+    def apply(n: Nat): ToBeTyped[DepApp[NatKind]] = depApp[NatKind](f, n)
+    def apply(dt: DataType): ToBeTyped[DepApp[DataKind]] = depApp[DataKind](f, dt)
+    def apply(a: AddressSpace): ToBeTyped[DepApp[AddressSpaceKind]] =
       depApp[AddressSpaceKind](f, a)
 
-    def apply(n2n: NatToNat): TDSL[DepApp[NatToNatKind]] =
+    def apply(n2n: NatToNat): ToBeTyped[DepApp[NatToNatKind]] =
       depApp[NatToNatKind](f, n2n)
 
-    def apply(e1: TDSL[Expr], e2: TDSL[Expr]): TDSL[App] = {
+    def apply(e1: ToBeTyped[Expr], e2: ToBeTyped[Expr]): ToBeTyped[App] = {
       f(e1)(e2)
     }
 
-    def apply(e1: TDSL[Expr], e2: TDSL[Expr], e3: TDSL[Expr]): TDSL[App] = {
+    def apply(e1: ToBeTyped[Expr], e2: ToBeTyped[Expr], e3: ToBeTyped[Expr]): ToBeTyped[App] = {
       f(e1)(e2)(e3)
     }
 
     def apply(
-        e1: TDSL[Expr],
-        e2: TDSL[Expr],
-        e3: TDSL[Expr],
-        e4: TDSL[Expr]
-    ): TDSL[App] = {
+               e1: ToBeTyped[Expr],
+               e2: ToBeTyped[Expr],
+               e3: ToBeTyped[Expr],
+               e4: ToBeTyped[Expr]
+    ): ToBeTyped[App] = {
       f(e1)(e2)(e3)(e4)
     }
 
     def apply(
-        e1: TDSL[Expr],
-        e2: TDSL[Expr],
-        e3: TDSL[Expr],
-        e4: TDSL[Expr],
-        e5: TDSL[Expr]
-    ): TDSL[App] = {
+               e1: ToBeTyped[Expr],
+               e2: ToBeTyped[Expr],
+               e3: ToBeTyped[Expr],
+               e4: ToBeTyped[Expr],
+               e5: ToBeTyped[Expr]
+    ): ToBeTyped[App] = {
       f(e1)(e2)(e3)(e4)(e5)
     }
   }
 
-  implicit class FunPipe(e: TDSL[Expr]) {
-    def |>(f: TDSL[Expr]): TDSL[App] = f.apply(e)
+  implicit class FunPipe(e: ToBeTyped[Expr]) {
+    def |>(f: ToBeTyped[Expr]): ToBeTyped[App] = f.apply(e)
   }
 
-  implicit class FunPipeReverse(f: TDSL[Expr]) {
-    def $(e: TDSL[Expr]): TDSL[App] = f.apply(e)
+  implicit class FunPipeReverse(f: ToBeTyped[Expr]) {
+    def $(e: ToBeTyped[Expr]): ToBeTyped[App] = f.apply(e)
   }
 
   implicit class FunPipeReversePrimitiveBuilde(f: Builder) {
-    def $(e: TDSL[Expr]): TDSL[App] = f.apply(e)
+    def $(e: ToBeTyped[Expr]): ToBeTyped[App] = f.apply(e)
   }
 
-  implicit class FunComp(f: TDSL[Expr]) {
-    def >>(g: TDSL[Expr]): TDSL[Lambda] = fun(x => g(f(x)))
+  implicit class FunComp(f: ToBeTyped[Expr]) {
+    def >>(g: ToBeTyped[Expr]): ToBeTyped[Lambda] = fun(x => g(f(x)))
   }
 
   implicit class FunCompPrimitiveBuilder(f: Builder) {
-    def >>(g: TDSL[Expr]): TDSL[Lambda] = fun(x => g(f.apply(x)))
+    def >>(g: ToBeTyped[Expr]): ToBeTyped[Lambda] = fun(x => g(f.apply(x)))
   }
 
-  implicit class FunCompReverse(f: TDSL[Expr]) {
-    def o(g: TDSL[Expr]): TDSL[Lambda] = fun(x => f(g(x)))
+  implicit class FunCompReverse(f: ToBeTyped[Expr]) {
+    def o(g: ToBeTyped[Expr]): ToBeTyped[Lambda] = fun(x => f(g(x)))
   }
 
   implicit class FunCompReversePrimitiveBuilder(f: Builder) {
-    def o(g: TDSL[Expr]): TDSL[Lambda] = fun(x => f.apply(g(x)))
+    def o(g: ToBeTyped[Expr]): ToBeTyped[Lambda] = fun(x => f.apply(g(x)))
   }
 
   // function values
   object fun {
-    def apply(t: Type)(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Lambda] = {
-      val x = identifier(freshName("e")) >>= (i => toTDSL(i.setType(t)))
+    def apply(t: Type)(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Lambda] = {
+      val x = identifier(freshName("e")) >>= (i => TypedDSL.toBeTyped(i.setType(t)))
       lambda(x, f(x))
     }
 
-    def apply(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Lambda] = untyped(f)
+    def apply(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Lambda] = untyped(f)
     def apply(
-        f: (TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-    ): TDSL[Lambda] = untyped(f)
+        f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = untyped(f)
     def apply(
-        f: (TDSL[Identifier], TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-    ): TDSL[Lambda] = untyped(f)
-    def apply(
-        f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = untyped(f)
+        f: (ToBeTyped[Identifier], ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = untyped(f)
     def apply(
         f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = untyped(f)
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = untyped(f)
     def apply(
         f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = untyped(f)
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = untyped(f)
+    def apply(
+        f: (
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = untyped(f)
 
-    private def untyped(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Lambda] = {
+    private def untyped(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, f(e))
     }
 
     private def untyped(
-        f: (TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-    ): TDSL[Lambda] = {
+        f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, untyped(e1 => f(e, e1)))
     }
 
     private def untyped(
-        f: (TDSL[Identifier], TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-    ): TDSL[Lambda] = {
+        f: (ToBeTyped[Identifier], ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, untyped((e1, e2) => f(e, e1, e2)))
     }
 
     private def untyped(
         f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = {
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, untyped((e1, e2, e3) => f(e, e1, e2, e3)))
     }
 
     private def untyped(
         f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = {
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, untyped((e1, e2, e3, e4) => f(e, e1, e2, e3, e4)))
     }
 
     private def untyped(
         f: (
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier],
-            TDSL[Identifier]
-        ) => TDSL[Expr]
-    ): TDSL[Lambda] = {
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier],
+            ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[Lambda] = {
       val e = identifier(freshName("e"))
       lambda(e, untyped((e1, e2, e3, e4, e5) => f(e, e1, e2, e3, e4, e5)))
     }
@@ -670,68 +672,68 @@ object TypedDSL {
     // noinspection TypeAnnotation
     // scalastyle:off structural.type
     def apply(ft: FunType[Type, Type]): Object {
-      def apply(f: (TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-               ): TDSL[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+               ): ToBeTyped[Expr]
 
-      def apply(f: (TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier]) => TDSL[Expr]
-               ): TDSL[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier]) => ToBeTyped[Expr]
+               ): ToBeTyped[Expr]
 
-      def apply(f: (TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-               ): TDSL[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+               ): ToBeTyped[Expr]
 
-      def apply(f: (TDSL[Identifier], TDSL[Identifier],
-                    TDSL[Identifier]) => TDSL[Expr]
-               ): TDSL[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
+                    ToBeTyped[Identifier]) => ToBeTyped[Expr]
+               ): ToBeTyped[Expr]
 
-      def apply(f: (TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-               ): TDSL[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+               ): ToBeTyped[Expr]
 
-      def apply(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Expr]
+      def apply(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Expr]
     } = new {
-      def apply(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Expr] =
+      def apply(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Expr] =
         untyped(f) :: ft
       def apply(
-          f: (TDSL[Identifier], TDSL[Identifier]) => TDSL[Expr]
-      ): TDSL[Expr] = untyped(f) :: ft
+          f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+      ): ToBeTyped[Expr] = untyped(f) :: ft
       def apply(
           f: (
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier]
-          ) => TDSL[Expr]
-      ): TDSL[Expr] = untyped(f) :: ft
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier]
+          ) => ToBeTyped[Expr]
+      ): ToBeTyped[Expr] = untyped(f) :: ft
       def apply(
           f: (
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier]
-          ) => TDSL[Expr]
-      ): TDSL[Expr] = untyped(f) :: ft
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier]
+          ) => ToBeTyped[Expr]
+      ): ToBeTyped[Expr] = untyped(f) :: ft
       def apply(
           f: (
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier]
-          ) => TDSL[Expr]
-      ): TDSL[Expr] = untyped(f) :: ft
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier]
+          ) => ToBeTyped[Expr]
+      ): ToBeTyped[Expr] = untyped(f) :: ft
       def apply(
           f: (
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier],
-              TDSL[Identifier]
-          ) => TDSL[Expr]
-      ): TDSL[Expr] = untyped(f) :: ft
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier],
+              ToBeTyped[Identifier]
+          ) => ToBeTyped[Expr]
+      ): ToBeTyped[Expr] = untyped(f) :: ft
     }
     // scalastyle:on structural.type
   }
@@ -740,27 +742,27 @@ object TypedDSL {
   object nFun {
     def apply(
         r: arithexpr.arithmetic.Range,
-        f: NatIdentifier => TDSL[Expr]
-    ): TDSL[DepLambda[NatKind]] = {
+        f: NatIdentifier => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[NatKind]] = {
       val x = NatIdentifier(freshName("n"), r, isExplicit = true)
       depLambda[NatKind](x, f(x))
     }
 
-    def apply(f: NatIdentifier => TDSL[Expr]): TDSL[DepLambda[NatKind]] = {
+    def apply(f: NatIdentifier => ToBeTyped[Expr]): ToBeTyped[DepLambda[NatKind]] = {
       nFun(arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1), f)
     }
 
     def apply(
-        f: (NatIdentifier, NatIdentifier) => TDSL[Expr]
-    ): TDSL[DepLambda[NatKind]] = {
+        f: (NatIdentifier, NatIdentifier) => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n = NatIdentifier(freshName("n"), r, isExplicit = true)
       depLambda[NatKind](n, nFun(f(n, _)))
     }
 
     def apply(
-        f: (NatIdentifier, NatIdentifier, NatIdentifier) => TDSL[Expr]
-    ): TDSL[DepLambda[NatKind]] = {
+        f: (NatIdentifier, NatIdentifier, NatIdentifier) => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n = NatIdentifier(freshName("n"), r, isExplicit = true)
       depLambda[NatKind](n, nFun((n1, n2) => f(n, n1, n2)))
@@ -772,8 +774,8 @@ object TypedDSL {
             NatIdentifier,
             NatIdentifier,
             NatIdentifier
-        ) => TDSL[Expr]
-    ): TDSL[DepLambda[NatKind]] = {
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n = NatIdentifier(freshName("n"), r, isExplicit = true)
       depLambda[NatKind](n, nFun((n1, n2, n3) => f(n, n1, n2, n3)))
@@ -786,8 +788,8 @@ object TypedDSL {
             NatIdentifier,
             NatIdentifier,
             NatIdentifier
-        ) => TDSL[Expr]
-    ): TDSL[DepLambda[NatKind]] = {
+        ) => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n = NatIdentifier(freshName("n"), r, isExplicit = true)
       depLambda[NatKind](n, nFun((n1, n2, n3, n4) => f(n, n1, n2, n3, n4)))
@@ -796,34 +798,34 @@ object TypedDSL {
 
   object dtFun {
     def apply(
-        f: DataTypeIdentifier => TDSL[Expr]
-    ): TDSL[DepLambda[DataKind]] = {
+        f: DataTypeIdentifier => ToBeTyped[Expr]
+    ): ToBeTyped[DepLambda[DataKind]] = {
       val x = DataTypeIdentifier(freshName("dt"), isExplicit = true)
       depLambda[DataKind](x, f(x))
     }
   }
 
   object letf {
-    def apply(in: TDSL[Expr] => TDSL[Expr]): TDSL[Expr] = {
+    def apply(in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] = {
       fun(e => primitives.let(e)(fun(in)))
     }
-    def apply(in: TDSL[Expr]): TDSL[Expr] = {
+    def apply(in: ToBeTyped[Expr]): ToBeTyped[Expr] = {
       fun(e => primitives.let(e)(in))
     }
   }
 
-  implicit def wrapInNatExpr(n: Nat): TDSL[Literal] = literal(NatData(n))
+  implicit def wrapInNatExpr(n: Nat): ToBeTyped[Literal] = literal(NatData(n))
 
-  def l(i: Int): TDSL[Literal] = literal(IntData(i))
-  def l(f: Float): TDSL[Literal] = literal(FloatData(f))
-  def l(d: Double): TDSL[Literal] = literal(DoubleData(d))
-  def lidx(i: Nat, n: Nat): TDSL[Literal] = literal(IndexData(i, n))
-  def lvec(v: Seq[ScalarData]): TDSL[Literal] = literal(VectorData(v))
-  def larr(a: Seq[Data]): TDSL[Literal] = literal(ArrayData(a))
+  def l(i: Int): ToBeTyped[Literal] = literal(IntData(i))
+  def l(f: Float): ToBeTyped[Literal] = literal(FloatData(f))
+  def l(d: Double): ToBeTyped[Literal] = literal(DoubleData(d))
+  def lidx(i: Nat, n: Nat): ToBeTyped[Literal] = literal(IndexData(i, n))
+  def lvec(v: Seq[ScalarData]): ToBeTyped[Literal] = literal(VectorData(v))
+  def larr(a: Seq[Data]): ToBeTyped[Literal] = literal(ArrayData(a))
 
   object foreignFun {
-    def apply(name: String, t: Type): TDSL[ForeignFunction] = {
-      toTDSL(ForeignFunction(ForeignFunction.Decl(name, None))(t))
+    def apply(name: String, t: Type): ToBeTyped[ForeignFunction] = {
+      toBeTyped(ForeignFunction(ForeignFunction.Decl(name, None))(t))
     }
 
     def apply(
@@ -831,8 +833,8 @@ object TypedDSL {
         params: Seq[String],
         body: String,
         t: Type
-    ): TDSL[ForeignFunction] = {
-      toTDSL(
+    ): ToBeTyped[ForeignFunction] = {
+      toBeTyped(
         ForeignFunction(
           ForeignFunction.Decl(name, Some(ForeignFunction.Def(params, body)))
         )(t)

--- a/src/main/scala/rise/core/TypedDSL.scala
+++ b/src/main/scala/rise/core/TypedDSL.scala
@@ -119,13 +119,13 @@ object TypedDSL {
           case (ts, ns, as, n2ds, n2ns, natColls) =>
             ftv match {
               case i: TypeIdentifier =>
-                (ts ++ Map(i -> implT(identity)), ns, as, n2ds, n2ns, natColls)
+                (ts ++ Map(i -> implType(identity)), ns, as, n2ds, n2ns, natColls)
               case i: DataTypeIdentifier =>
                 (ts ++ Map(i -> implDT(identity)), ns, as, n2ds, n2ns,  natColls)
               case i: NatIdentifier =>
-                (ts, ns ++ Map(i -> implN(identity)), as, n2ds, n2ns,  natColls)
+                (ts, ns ++ Map(i -> implNat(identity)), as, n2ds, n2ns,  natColls)
               case i: AddressSpaceIdentifier =>
-                (ts, ns, as ++ Map(i -> implA(identity)), n2ds, n2ns,  natColls)
+                (ts, ns, as ++ Map(i -> implAddr(identity)), n2ds, n2ns,  natColls)
               case i: NatToDataIdentifier =>
                 (ts, ns, as, n2ds ++ Map(i -> implN2DT(identity)), n2ns,  natColls)
               case i: NatToNatIdentifier =>
@@ -397,7 +397,7 @@ object TypedDSL {
           constraints += constraint
           (DepApp(tf, x)(exprT), ftvSubsF)
 
-        case Annotation(e, t) =>
+        case TypeAnnotation(e, t) =>
           val (te, ftvSubsE) = constrained(e)
           val ftvSubsT = Opaque.getFTVSubs(t)
           val constraint = TypeConstraint(te.t, Opaque.freeze(ftvSubsT, t))
@@ -446,54 +446,7 @@ object TypedDSL {
     f >>= (f => toTDSL(DepApp[K](f, x)()))
   def literal(d: semantics.Data): TDSL[Literal] = toTDSL(Literal(d))
 
-  def array(n: Int): TDSL[MakeArray] = toTDSL(primitives.MakeArray(n)())
-  def cast: TDSL[Cast] = toTDSL(primitives.Cast()())
-  def depJoin: TDSL[DepJoin] = toTDSL(primitives.DepJoin()())
-  def depMapSeq: TDSL[DepMapSeq] = toTDSL(primitives.DepMapSeq()())
-  def depZip: TDSL[DepZip] = toTDSL(primitives.DepZip()())
-  def drop: TDSL[Drop] = toTDSL(primitives.Drop()())
-  def fst: TDSL[Fst] = toTDSL(primitives.Fst()())
-  def gather: TDSL[Gather] = toTDSL(primitives.Gather()())
-  def generate: TDSL[Generate] = toTDSL(primitives.Generate()())
-  def idx: TDSL[Idx] = toTDSL(primitives.Idx()())
-  def id: TDSL[Id] = toTDSL(primitives.Id()())
-  def indexAsNat: TDSL[IndexAsNat] = toTDSL(primitives.IndexAsNat()())
-  def iterate: TDSL[Iterate] = toTDSL(primitives.Iterate()())
-  def join: TDSL[Join] = toTDSL(primitives.Join()())
-  def let: TDSL[Let] = toTDSL(primitives.Let()())
-  def letf: TDSL[Expr] = fun(k => fun(x => let(x)(k)))
-  def map: TDSL[Map] = toTDSL(primitives.Map()())
-  def mapFst: TDSL[MapFst] = toTDSL(primitives.MapFst()())
-  def mapSnd: TDSL[MapSnd] = toTDSL(primitives.MapSnd()())
-  def mapSeq: TDSL[MapSeq] = toTDSL(primitives.MapSeq()())
-  def mapSeqUnroll: TDSL[MapSeqUnroll] = toTDSL(primitives.MapSeqUnroll()())
-  def natAsIndex: TDSL[NatAsIndex] = toTDSL(primitives.NatAsIndex()())
-  def padCst: TDSL[PadCst] = toTDSL(primitives.PadCst()())
-  def padEmpty: TDSL[PadEmpty] = toTDSL(primitives.PadEmpty()())
-  def padClamp: TDSL[PadClamp] = toTDSL(primitives.PadClamp()())
-  def partition: TDSL[Partition] = toTDSL(primitives.Partition()())
-  def pair: TDSL[Pair] = toTDSL(primitives.Pair()())
-  def reduce: TDSL[Reduce] = toTDSL(primitives.Reduce()())
-  def reduceSeq: TDSL[ReduceSeq] = toTDSL(primitives.ReduceSeq()())
-  def reduceSeqUnroll: TDSL[ReduceSeqUnroll] =
-    toTDSL(primitives.ReduceSeqUnroll()())
-  def reorder: TDSL[Reorder] = toTDSL(primitives.Reorder()())
-  def scanSeq: TDSL[ScanSeq] = toTDSL(primitives.ScanSeq()())
-  def slide: TDSL[Slide] = toTDSL(primitives.Slide()())
-  def circularBuffer: TDSL[CircularBuffer] =
-    toTDSL(primitives.CircularBuffer()())
-  def rotateValues: TDSL[RotateValues] =
-    toTDSL(primitives.RotateValues()())
-  def snd: TDSL[Snd] = toTDSL(primitives.Snd()())
-  def split: TDSL[Split] = toTDSL(primitives.Split()())
-  def take: TDSL[Take] = toTDSL(primitives.Take()())
-  def toMem: TDSL[ToMem] = toTDSL(primitives.ToMem()())
-  def transpose: TDSL[Transpose] = toTDSL(primitives.Transpose()())
-  def select: TDSL[Select] = toTDSL(primitives.Select()())
-  def unzip: TDSL[Unzip] = toTDSL(primitives.Unzip()())
-  def zip: TDSL[Zip] = toTDSL(primitives.Zip()())
-  def dpair: TDSL[DPair] = toTDSL(primitives.DPair()())
-  def dmatch: TDSL[DMatch] = toTDSL(primitives.DMatch()())
+  def array(n: Int): TDSL[Primitive] = primitives.makeArray(n).apply
   def store(cont: TDSL[Expr] => TDSL[Expr]): TDSL[Expr] =
     fun(e => let(toMem(e))(fun(cont)))
   def store(how: TDSL[Expr])
@@ -501,25 +454,6 @@ object TypedDSL {
     fun(e => let(toMem(how(e)))(fun(in)))
   def store2(how: TDSL[Expr]): TDSL[Expr] =
     fun(e => let(toMem(how(e)))(fun(x => x)))
-  def neg: TDSL[Neg] = toTDSL(primitives.Neg()())
-  def add: TDSL[Add] = toTDSL(primitives.Add()())
-  def sub: TDSL[Sub] = toTDSL(primitives.Sub()())
-  def mul: TDSL[Mul] = toTDSL(primitives.Mul()())
-  def div: TDSL[Div] = toTDSL(primitives.Div()())
-  def mod: TDSL[Mod] = toTDSL(primitives.Mod()())
-  def gt: TDSL[Gt] = toTDSL(primitives.Gt()())
-  def lt: TDSL[Lt] = toTDSL(primitives.Lt()())
-  def equal: TDSL[Equal] = toTDSL(primitives.Equal()())
-
-  def asVector: TDSL[AsVector] = toTDSL(primitives.AsVector()())
-  def asVectorAligned: TDSL[AsVectorAligned] =
-    toTDSL(primitives.AsVectorAligned()())
-  def asScalar: TDSL[AsScalar] = toTDSL(primitives.AsScalar()())
-  def vectorFromScalar: TDSL[VectorFromScalar] =
-    toTDSL(primitives.VectorFromScalar()())
-
-  def printType(msg: String): TDSL[PrintType] = toTDSL(PrintType(msg)())
-  def typeHole(msg: String): TDSL[TypeHole] = toTDSL(TypeHole(msg)())
 
   implicit class Ops(lhs: TDSL[Expr]) {
 
@@ -556,9 +490,9 @@ object TypedDSL {
     def `:`[T <: Expr](e: TDSL[T]): TDSL[T] = e :: t
   }
    */
-  implicit class TypeAnnotation(t: Type) {
+  implicit class TypeAnnotationHelper(t: Type) {
     def ::[T <: Expr](e: TDSL[T]): TDSL[Expr] =
-      e >>= (e => toTDSL(Annotation(e, t)))
+      e >>= (e => toTDSL(TypeAnnotation(e, t)))
     def `:`[T <: Expr](e: TDSL[T]): TDSL[Expr] = e :: t
   }
 
@@ -609,12 +543,24 @@ object TypedDSL {
     def $(e: TDSL[Expr]): TDSL[App] = f.apply(e)
   }
 
+  implicit class FunPipeReversePrimitiveBuilde(f: Builder) {
+    def $(e: TDSL[Expr]): TDSL[App] = f.apply(e)
+  }
+
   implicit class FunComp(f: TDSL[Expr]) {
     def >>(g: TDSL[Expr]): TDSL[Lambda] = fun(x => g(f(x)))
   }
 
+  implicit class FunCompPrimitiveBuilder(f: Builder) {
+    def >>(g: TDSL[Expr]): TDSL[Lambda] = fun(x => g(f.apply(x)))
+  }
+
   implicit class FunCompReverse(f: TDSL[Expr]) {
     def o(g: TDSL[Expr]): TDSL[Lambda] = fun(x => f(g(x)))
+  }
+
+  implicit class FunCompReversePrimitiveBuilder(f: Builder) {
+    def o(g: TDSL[Expr]): TDSL[Lambda] = fun(x => f.apply(g(x)))
   }
 
   // function values
@@ -850,6 +796,15 @@ object TypedDSL {
     ): TDSL[DepLambda[DataKind]] = {
       val x = DataTypeIdentifier(freshName("dt"), isExplicit = true)
       depLambda[DataKind](x, f(x))
+    }
+  }
+
+  object letf {
+    def apply(in: TDSL[Expr] => TDSL[Expr]): TDSL[Expr] = {
+      fun(e => primitives.let(e)(fun(in)))
+    }
+    def apply(in: TDSL[Expr]): TDSL[Expr] = {
+      fun(e => primitives.let(e)(in))
     }
   }
 

--- a/src/main/scala/rise/core/dotPrinter.scala
+++ b/src/main/scala/rise/core/dotPrinter.scala
@@ -152,13 +152,13 @@ case object dotPrinter {
           s"$parent ${attr(fillWhite +
             Label(i.name).orange.italic.toString)}"
         case p: Primitive => p match {
-          case primitives.MapSeq() =>
+          case primitives.mapSeq() =>
             s"$parent ${attr(fillDarkGray + Label(p.name).bold.toString)}"
-          case primitives.ReduceSeq() =>
+          case primitives.reduceSeq() =>
             s"$parent ${attr(fillDarkGray + Label(p.name).bold.toString)}"
-          case primitives.ReduceSeqUnroll() =>
+          case primitives.reduceSeqUnroll() =>
             s"$parent ${attr(fillDarkGray + Label(p.name).bold.toString)}"
-          case rise.openMP.primitives.MapPar() =>
+          case rise.openMP.primitives.mapPar() =>
             s"$parent ${attr(fillDarkGray + Label(p.name).bold.toString)}"
           case _ =>
             s"$parent ${attr(fillGray + Label(p.toString.trim).bold.toString)}"

--- a/src/main/scala/rise/core/package.scala
+++ b/src/main/scala/rise/core/package.scala
@@ -2,6 +2,8 @@ package rise
 
 import rise.core.types._
 
+import scala.language.implicitConversions
+
 package object core {
   object freshName {
     private var counter = 0
@@ -40,4 +42,8 @@ package object core {
       case p: Primitive        => p.toString
     }
   }
+
+  implicit def primitiveBuilderToPrimitive(pb: Builder
+                                          ): TypedDSL.TDSL[Primitive] =
+    pb.apply
 }

--- a/src/main/scala/rise/core/package.scala
+++ b/src/main/scala/rise/core/package.scala
@@ -44,6 +44,6 @@ package object core {
   }
 
   implicit def primitiveBuilderToPrimitive(pb: Builder
-                                          ): TypedDSL.TDSL[Primitive] =
+                                          ): TypedDSL.ToBeTyped[Primitive] =
     pb.apply
 }

--- a/src/main/scala/rise/core/primitives.scala
+++ b/src/main/scala/rise/core/primitives.scala
@@ -9,544 +9,297 @@ import rise.macros.Primitive.primitive
 // scalastyle:off number.of.methods
 object primitives {
 
-  case class Annotation(e: Expr, annotation: Type) extends Primitive {
-    override val t: Type = TypePlaceholder
-    override def typeScheme: Type =
-      throw TypeException("cannot get the type scheme of an annotated Expr")
-    override def setType(t: Type): Annotation =
-      throw TypeException("cannot set the type of an annotated Expr")
-    override def name: String = s"Annotated Expr: $annotation"
+  @primitive case class makeArray(n: Int) extends Primitive with Builder {
+    implDT(t => {
+      def tRec(m: Int, dt: DataType): Type =
+        if (m <= 0) {
+          ArrayType(n, dt)
+        } else {
+          dt ->: tRec(m - 1, dt)
+        }
+      tRec(n, t)
+    })
   }
 
-  @primitive case class MakeArray(n: Int)(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    private def tRec(m: Int, dt: DataType): Type =
-      if (m <= 0) {
-        ArrayType(n, dt)
-      } else {
-        dt ->: tRec(m - 1, dt)
-      }
-    override def typeScheme: Type = implDT(t => tRec(n, t))
+  @primitive object cast extends Primitive with Builder {
+    implBT(s => implBT(t => s ->: t))
   }
 
-  @primitive case class Cast()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(s => implBT(t => s ->: t))
+  @primitive object depJoin extends Primitive with Builder {
+    implNat(n => implN2N(lenF => implDT(dt =>
+      (n `..` (i => lenF(i) `.` dt)) ->:
+        (BigSum(from = 0, upTo = n - 1, n => lenF(n)) `.` dt))))
   }
 
-  @primitive case class DepJoin()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN2N(lenF =>
-          implDT(dt => {
-            DepArrayType(n, n2dtFun(n)(i => ArrayType(lenF(i), dt))) ->:
-              ArrayType(BigSum(from = 0, upTo = n - 1, n => lenF(n)), dt)
-          })
-        )
-      )
+  @primitive object depMapSeq extends Primitive with Builder {
+    implNat(n =>
+      implN2DT(ft1 => implN2DT(ft2 =>
+        forallNat(k => ft1(k) ->: ft2(k)) ->: (n`..`ft1) ->: (n`..`ft2))))
   }
 
-  @primitive case class DepMapSeq()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    // format: off
-    override def typeScheme: Type =
-      implN(n =>
-        implN2DT(ft1 =>
-          implN2DT(ft2 =>
-            nFunT(k => ft1(k) ->: ft2(k)) ->: DepArrayType(n, ft1)
-              ->: DepArrayType(n,ft2)
-          )
-        )
-      )
-    // format: on
+  @primitive object depZip extends Primitive with Builder {
+    implNat(n => implN2DT(ft1 => implN2DT(ft2 =>
+      (n`..`ft1) ->: (n`..`ft2) ->: (n`..`(i => ft1(i) x ft2(i))))))
   }
 
-  @primitive case class DepZip()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN2DT(ft1 =>
-          implN2DT(ft2 =>
-            DepArrayType(n, ft1) ->: DepArrayType(n, ft2) ->: DepArrayType(
-              n,
-              n2dtFun(i => PairType(ft1(i), ft2(i)))
-            )
-          )
-        )
-      )
+  @primitive object drop extends Primitive with Builder {
+    forallNat(n => implNat(m => implDT(t =>
+      ((n + m)`.`t) ->: (m`.`t))))
   }
 
-  @primitive case class Drop()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      nFunT(n =>
-        implN(m => implDT(t => ArrayType(n + m, t) ->: ArrayType(m, t)))
-      )
+  @primitive object fst extends Primitive with Builder {
+    implDT(s => implDT(t =>
+      (s x t) ->: s))
   }
 
-  @primitive case class Fst()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s => implDT(t => PairType(s, t) ->: s))
+  @primitive object gather extends Primitive with Builder {
+    implNat(n => implNat(m => implDT(t =>
+      (m`.`IndexType(n)) ->: (n`.`t) ->: (m`.`t))))
   }
 
-  @primitive case class Gather()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN(m =>
-          implDT(t =>
-            ArrayType(m, IndexType(n)) ->: ArrayType(n, t) ->: ArrayType(m, t)
-          )
-        )
-      )
+  @primitive object generate extends Primitive with Builder {
+    implNat(n => implDT(t =>
+      (IndexType(n) ->: t) ->: ArrayType(n, t)))
   }
 
-  @primitive case class Generate()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => implDT(t => (IndexType(n) ->: t) ->: ArrayType(n, t)))
+  @primitive object idx extends Primitive with Builder {
+    implNat(n => implDT(t =>
+      IndexType(n) ->: (n`.`t) ->: t))
   }
 
-  @primitive case class Idx()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => implDT(t => IndexType(n) ->: ArrayType(n, t) ->: t))
+  @primitive object id extends Primitive with Builder { implDT(t => t ->: t) }
+
+  @primitive object indexAsNat extends Primitive with Builder {
+    implNat(n => IndexType(n) ->: NatType)
   }
 
-  @primitive case class Id()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implDT(t => t ->: t)
+  @primitive object iterate extends Primitive with Builder {
+    implNat(n => implNat(m =>
+      forallNat(k => implDT(t => forallNat(l =>
+        ((l * n)`.`t) ->: (l`.`t)) ->: ((m * n.pow(k))`.`t) ->: (m`.`t)))))
   }
 
-  @primitive case class IndexAsNat()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implN(n => IndexType(n) ->: NatType)
+  @primitive object join extends Primitive with Builder {
+    implNat(n => implNat(m => implDT(t =>
+      (n`.`m`.`t) ->: ((n * m)`.`t))))
   }
 
-  @primitive case class Iterate()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    // format: off
-    override def typeScheme: Type =
-      implN(n =>
-        implN(m =>
-          nFunT(k =>
-            implDT(t =>
-              nFunT(l =>
-                ArrayType(l * n, t) ->: ArrayType(l, t)) ->:
-                  ArrayType(m * n.pow(k), t)->: ArrayType(m, t)
-            )
-          )
-        )
-      )
-    // format: on
+  @primitive object let extends Primitive with Builder {
+    implDT(s => implDT(t =>
+      s ->: (s ->: t) ->: t))
   }
 
-  @primitive case class Join()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN(m =>
-          implDT(t => ArrayType(n, ArrayType(m, t)) ->: ArrayType(n * m, t))
-        )
-      )
+  @primitive object map extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n `.` s) ->: (n `.` t))))
   }
 
-  @primitive case class Let()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s => implDT(t => s ->: (s ->: t) ->: t))
+  @primitive object mapFst extends Primitive with Builder {
+    implDT(s => implDT(t => implDT(s2 =>
+      (s ->: s2) ->: (s x t) ->: (s2 x t))))
   }
 
-  @primitive case class Map()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive object mapSnd extends Primitive with Builder {
+    implDT(s => implDT(t => implDT(t2 =>
+      (t ->: t2) ->: (s x t) ->: (s x t2))))
   }
 
-  @primitive case class MapFst()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s =>
-        implDT(t =>
-          implDT(s2 => (s ->: s2) ->: PairType(s, t) ->: PairType(s2, t))
-        )
-      )
+  @primitive object mapSeq extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class MapSnd()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s =>
-        implDT(t =>
-          implDT(t2 => (t ->: t2) ->: PairType(s, t) ->: PairType(s, t2))
-        )
-      )
-  }
-
-  @primitive case class MapSeq()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implN(n => implDT(s => implDT(t =>
-      (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t)
-    )))
-  }
-
-  @primitive case class MapStream()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type = implN(n => implDT(s => implDT(t =>
+  @primitive object mapStream extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
       // stream to stream
-      (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t)
-    )))
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class IterateStream()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type = implN(n => implDT(s =>
+  @primitive object iterateStream extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
       // stream to array (or should it be stream to value?)
-      implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-    ))
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class MapSeqUnroll()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive object mapSeqUnroll extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n `.` s) ->: (n `.` t))))
   }
 
-  @primitive case class ToMem()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type = implDT(t => t ->: t)
-  }
+  @primitive object toMem extends Primitive with Builder { implDT(t => t ->: t) }
 
-  @primitive case class NatAsIndex()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = nFunT(n => NatType ->: IndexType(n))
+  @primitive object natAsIndex extends Primitive with Builder {
+    forallNat(n => NatType ->: IndexType(n))
   }
 
   // TODO? could be expressed in terms of a pad idx -> val
-  @primitive case class PadCst()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => nFunT(l => nFunT(q => implDT(t =>
-        t ->: ArrayType(n, t) ->: ArrayType(l + n + q, t))
-      )))
+  @primitive object padCst extends Primitive with Builder {
+    implNat(n =>
+      forallNat(l =>
+        forallNat(q => implDT(t => t ->: (n`.`t) ->: ((l + n + q)`.`t)))))
   }
 
-  @primitive case class PadEmpty()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type = implN(n => nFunT(r => implDT(t =>
-      ArrayType(n, t) ->: ArrayType(n + r, t))
-    ))
+  @primitive object padEmpty extends Primitive with Builder {
+    implNat(n =>
+      forallNat(r => implDT(t => (n`.`t) ->: ((n + r)`.`t))))
   }
 
   // TODO? could be expressed in terms of a pad idx -> idx or idx -> val
-  @primitive case class PadClamp()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        nFunT(l =>
-          nFunT(q => implDT(t => ArrayType(n, t) ->: ArrayType(l + n + q, t)))
-        )
-      )
+  @primitive object padClamp extends Primitive with Builder {
+    implNat(n =>
+      forallNat(l => forallNat(q => implDT(t =>
+        (n`.`t) ->: ((l + n + q)`.`t)))))
   }
 
-  @primitive case class Partition()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(dt =>
-          nFunT(m =>
-            n2nFunT(lenF =>
-              ArrayType(n, dt) ->: DepArrayType(
-                m,
-                n2dtFun(m)(i => ArrayType(lenF(i), dt))
-              )
-            )
-          )
-        )
-      )
+  @primitive object partition extends Primitive with Builder {
+    implNat(n => implDT(dt =>
+      forallNat(m =>
+        forallN2N(lenF =>
+          (n`.`dt) ->: (m`..`(i => lenF(i)`.`dt))))))
   }
 
-  @primitive case class Pair()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s => implDT(t => s ->: t ->: PairType(s, t)))
+  @primitive object pair extends Primitive with Builder {
+    implDT(s => implDT(t =>
+      s ->: t ->: (s x t)))
   }
 
-  @primitive case class DPair()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type =
-      implN2DT(fdt => nFunT(n => fdt(n) ->: n2dPairT(fdt(_))))
+  @primitive object dpair extends Primitive with Builder {
+    implN2DT(fdt => forallNat(n => fdt(n) ->: n2dPairT(fdt(_))))
   }
 
-  @primitive case class DMatch()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type =
-      implN2DT(ft => implDT(tOut =>
-        n2dPairT(ft(_)) ->: nFunT(m => ft(m) ->: tOut) ->: tOut
-      ))
+  @primitive object dmatch extends Primitive with Builder {
+    implN2DT(ft => implDT(tOut =>
+      n2dPairT(ft(_)) ->: forallNat(m => ft(m) ->: tOut) ->: tOut))
   }
 
-  @primitive case class Reduce()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => implDT(t => (t ->: t ->: t) ->: t ->: ArrayType(n, t) ->: t))
+  @primitive object reduce extends Primitive with Builder {
+    implNat(n => implDT(t =>
+      (t ->: t ->: t) ->: t ->: (n`.`t) ->: t))
   }
 
-  @primitive case class ReduceSeq()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s => implDT(t => (t ->: s ->: t) ->: t ->: ArrayType(n, s) ->: t)
-        )
-      )
+  @primitive object reduceSeq extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (t ->: s ->: t) ->: t ->: (n`.`s) ->: t)))
   }
 
-  @primitive case class ReduceSeqUnroll()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s => implDT(t => (t ->: s ->: t) ->: t ->: ArrayType(n, s) ->: t)
-        )
-      )
+  @primitive object reduceSeqUnroll extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (t ->: s ->: t) ->: t ->: (n`.`s) ->: t)))
   }
 
-  @primitive case class Reorder()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(t =>
-          (IndexType(n) ->: IndexType(n)) ->: // idxF
-            (IndexType(n) ->: IndexType(n)) ->: // idxFinv
-            ArrayType(n, t) ->: ArrayType(n, t)
-        )
-      )
+  @primitive object reorder extends Primitive with Builder {
+    implNat(n => implDT(t =>
+      (IndexType(n) ->: IndexType(n)) ->: // idxF
+        (IndexType(n) ->: IndexType(n)) ->: // idxFinv
+        (n`.`t) ->: (n`.`t)))
   }
 
-  @primitive case class ScanSeq()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t =>
-            (s ->: t ->: t) ->: t ->: ArrayType(n, s) ->: ArrayType(n, t)
-          )
-        )
-      )
+  @primitive object scanSeq extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t ->: t) ->: t ->: (n `.` s) ->: (n `.` t))))
   }
 
-  @primitive case class Slide()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => nFunT(sz => nFunT(sp => implDT(t =>
-        ArrayType(sp * n + sz, t) ->: ArrayType(1 + n, ArrayType(sz, t))
-      ))))
+  @primitive object slide extends Primitive with Builder {
+    implNat(n => forallNat(sz => forallNat(sp => implDT(t =>
+      ((sp * n + sz) `.` t) ->: ((1 + n) `.` sz `.` t)))))
   }
 
-  @primitive case class CircularBuffer()(
-    override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      // TODO: should return a stream / sequential array, not an array
-      implN(n => nFunT(alloc => nFunT(sz => implDT(s => implDT(t =>
-        (s ->: t) ->: // function to load an input
-          ArrayType(n + sz, s) ->: ArrayType(1 + n, ArrayType(sz, t))
-      )))))
+  @primitive object circularBuffer extends Primitive with Builder {
+    // TODO: should return a stream / sequential array, not an array
+    implNat(n => forallNat(alloc => forallNat(sz => implDT(s => implDT(t =>
+      (s ->: t) ->: // function to load an input
+        ((n + sz) `.` s) ->: ((1 + n) `.` sz `.` t))))))
   }
 
   // mainly to achieve register rotation
-  @primitive case class RotateValues()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      // TODO: should return a stream / sequential array, not an array
-      implN(n => nFunT(sz => implDT(s =>
-        (s ->: s) ->: // function to write a value
-          ArrayType(n + sz, s) ->: ArrayType(1 + n, ArrayType(sz, s))
-      )))
+  @primitive object rotateValues extends Primitive with Builder {
+    // TODO: should return a stream / sequential array, not an array
+    implNat(n => forallNat(sz => implDT(s =>
+      (s ->: s) ->: // function to write a value
+        ((n + sz) `.` s) ->: ((1 + n) `.` sz `.` s))))
   }
 
-  @primitive case class Snd()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implDT(s => implDT(t => PairType(s, t) ->: t))
+  @primitive object snd extends Primitive with Builder {
+    implDT(s => implDT(t => (s x t) ->: t))
   }
 
-  @primitive case class Split()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      nFunT(n =>
-        implN(m =>
-          implDT(t => ArrayType(m * n, t) ->: ArrayType(m, ArrayType(n, t)))
-        )
-      )
+  @primitive object split extends Primitive with Builder {
+    forallNat(n => implNat(m => implDT(t =>
+      ((m * n)`.`t) ->: (m`.`n`.`t))))
   }
 
-  @primitive case class Take()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      nFunT(n =>
-        implN(m => implDT(t => ArrayType(n + m, t) ->: ArrayType(n, t)))
-      )
+  @primitive object take extends Primitive with Builder {
+    forallNat(n => implNat(m => implDT(t =>
+      ((n + m)`.`t) ->: (n`.`t))))
   }
 
-  @primitive case class Transpose()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN(m =>
-          implDT(dt =>
-            ArrayType(n, ArrayType(m, dt)) ->: ArrayType(m, ArrayType(n, dt))
-          )
-        )
-      )
+  @primitive object transpose extends Primitive with Builder {
+    implNat(n => implNat(m => implDT(dt =>
+      (n`.`m`.`dt) ->: (m`.`n`.`dt))))
   }
 
   // if-then-else
-  @primitive case class Select()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implDT(t => bool ->: t ->: t ->: t)
+  @primitive object select extends Primitive with Builder {
+    implDT(t => bool ->: t ->: t ->: t)
   }
 
-  @primitive case class Unzip()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(dt1 =>
-          implDT(dt2 =>
-            ArrayType(n, PairType(dt1, dt2)) ->: PairType(
-              ArrayType(n, dt1),
-              ArrayType(n, dt2)
-            )
-          )
-        )
-      )
+  @primitive object unzip extends Primitive with Builder {
+    implNat(n => implDT(dt1 => implDT(dt2 =>
+      (n`.`(dt1 x dt2)) ->: ((n`.`dt1) x (n`.`dt2)))))
   }
 
-  @primitive case class Zip()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(a =>
-          implDT(b =>
-            ArrayType(n, a) ->: ArrayType(n, b) ->: ArrayType(n, PairType(a, b))
-          )
-        )
-      )
+  @primitive object zip extends Primitive with Builder {
+    implNat(n => implDT(a => implDT(b =>
+      (n`.`a) ->: (n`.`b) ->: (n`.`(a x b)))))
   }
 
-  @primitive case class Neg()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t)
+  @primitive object neg extends Primitive with Builder {
+    implBT(t => t ->: t)
   }
 
-  @primitive case class Not()(override val t: Type = TypePlaceholder)
-    extends Primitive {
-    override def typeScheme: Type = bool ->: bool
+  @primitive object not extends Primitive with Builder {
+    bool ->: bool
   }
 
-  @primitive case class Add()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: t)
-  }
+  @primitive object add extends Primitive with Builder { implBT(t => t ->: t ->: t) }
+  @primitive object sub extends Primitive with Builder { implBT(t => t ->: t ->: t) }
+  @primitive object mul extends Primitive with Builder { implBT(t => t ->: t ->: t) }
+  @primitive object div extends Primitive with Builder { implBT(t => t ->: t ->: t) }
+  @primitive object mod extends Primitive with Builder { implBT(t => t ->: t ->: t) }
 
-  @primitive case class Sub()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: t)
-  }
-
-  @primitive case class Mul()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: t)
-  }
-
-  @primitive case class Div()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: t)
-  }
-
-  @primitive case class Mod()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: t)
-  }
-
-  @primitive case class Gt()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: bool)
-  }
-
-  @primitive case class Lt()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: bool)
-  }
-
-  @primitive case class Equal()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implBT(t => t ->: t ->: bool)
-  }
+  @primitive object gt extends Primitive with Builder { implBT(t => t ->: t ->: bool) }
+  @primitive object lt extends Primitive with Builder { implBT(t => t ->: t ->: bool) }
+  @primitive object equal extends Primitive with Builder { implBT(t => t ->: t ->: bool) }
 
   // TODO: should vectorisation be in the core or not?
 
   // TODO: track alignment in type system?
-  @primitive case class AsVectorAligned()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      nFunT(n =>
-        implN(m =>
-          implDT(a => ArrayType(m * n, a) ->: ArrayType(m, VectorType(n, a)))
-        )
-      )
+  @primitive object asVectorAligned extends Primitive with Builder {
+    forallNat(n => implNat(m => implDT(a =>
+      ((m * n)`.`a) ->: (m`.`vec(n, a)))))
   }
 
-  @primitive case class AsVector()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      nFunT(n =>
-        implN(m =>
-          implST(t => ArrayType(m * n, t) ->: ArrayType(m, VectorType(n, t)))
-        )
-      )
+  @primitive object asVector extends Primitive with Builder {
+    forallNat(n => implNat(m => implST(t =>
+      ((m * n)`.`t) ->: (m`.`vec(n, t)))))
   }
 
-  @primitive case class AsScalar()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implN(m =>
-          implST(t => ArrayType(m, VectorType(n, t)) ->: ArrayType(m * n, t))
-        )
-      )
+  @primitive object asScalar extends Primitive with Builder {
+    implNat(n => implNat(m => implST(t =>
+      (m`.`vec(n, t)) ->: ((m * n)`.`t))))
   }
 
-  @primitive case class VectorFromScalar()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      implN(n => implST(t => t ->: VectorType(n, t)))
+  @primitive object vectorFromScalar extends Primitive with Builder {
+    implNat(n => implST(t =>
+      t ->: vec(n, t)))
   }
 
-  @primitive case class PrintType(msg: String = "")(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type = implT(t => t ->: t)
+  @primitive case class printType(msg: String = "") extends Primitive with Builder {
+    implType(t => t ->: t)
   }
 
-  @primitive case class TypeHole(msg: String = "")(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type = implT(t => t)
+  @primitive case class typeHole(msg: String = "") extends Primitive with Builder {
+    implType(t => t)
   }
 }
 // scalastyle:on number.of.methods

--- a/src/main/scala/rise/core/showRise.scala
+++ b/src/main/scala/rise/core/showRise.scala
@@ -1,7 +1,6 @@
 package rise.core
 
 import rise.core.DrawTree.UnicodeConfig
-import rise.core.primitives.Annotation
 
 case class RenderException(msg: String) extends Exception {
   override def toString: String = s"render exception: $msg"
@@ -275,7 +274,7 @@ class ShowRiseCompact {
 
     case Literal(d) => (true, dataSize(d), line(d.toString))
 
-    case Annotation(e, _) => drawAST(e, wrapped)
+    case TypeAnnotation(e, _) => drawAST(e, wrapped)
 
     case p: Primitive => (true, 1, line(p.name))
   }

--- a/src/main/scala/rise/core/types/infer.scala
+++ b/src/main/scala/rise/core/types/infer.scala
@@ -3,7 +3,7 @@ package rise.core.types
 import rise.core._
 import rise.core.types.InferenceException.error
 import rise.core.TypeLevelDSL._
-import rise.core.primitives.Annotation
+import rise.core.TypeAnnotation
 
 import scala.collection.mutable
 
@@ -99,7 +99,7 @@ object infer {
         constraints += constraint
         DepApp(tf, x)(exprT)
 
-      case Annotation(e, t) =>
+      case TypeAnnotation(e, t) =>
         val te = typed(e)
         val constraint = TypeConstraint(te.t, t)
         constraints += constraint
@@ -118,11 +118,11 @@ object infer {
       new traversal.Visitor {
         override def visitExpr(e: Expr): traversal.Result[Expr] = {
           e match {
-            case h: primitives.TypeHole =>
-              println(s"found type hole ${h.msg}: ${h.t}")
+            case h@primitives.typeHole(msg) =>
+              println(s"found type hole ${msg}: ${h.t}")
               holeFound = true
-            case p: primitives.PrintType =>
-              println(s"${p.msg} : ${p.t} (Lift level)")
+            case p@primitives.printType(msg) =>
+              println(s"${msg} : ${p.t} (Lift level)")
             case _ =>
           }
           traversal.Continue(e, this)

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -90,8 +90,8 @@ object uniqueNames {
               others + (x -> x2)
             ))
           ))
-        case rise.core.primitives.Annotation(a, t) =>
-          traversal.Stop(rise.core.primitives.Annotation(
+        case rise.core.TypeAnnotation(a, t) =>
+          traversal.Stop(rise.core.TypeAnnotation(
             traversal.DepthFirstLocalResult(a, this),
             traversal.types.DepthFirstLocalResult(t, TypeVisitor(others))
           ))

--- a/src/main/scala/rise/elevate/package.scala
+++ b/src/main/scala/rise/elevate/package.scala
@@ -17,9 +17,9 @@ package object elevate {
 
   object ReduceX {
     def unapply(e: Expr): Boolean = e match {
-      case Reduce() => true
-      case ReduceSeq() => true
-      case ReduceSeqUnroll() => true
+      case reduce() => true
+      case reduceSeq() => true
+      case reduceSeqUnroll() => true
       case _ => false
     }
   }

--- a/src/main/scala/rise/elevate/rules/algorithmic.scala
+++ b/src/main/scala/rise/elevate/rules/algorithmic.scala
@@ -28,11 +28,11 @@ object algorithmic {
 
   def  splitJoin(n: Nat): Strategy[Rise] = `*f -> S >> **f >> J`(n: Nat)
   @rule def `*f -> S >> **f >> J`(n: Nat): Strategy[Rise] = {
-    case e @ App(Map(), f) => Success((split(n) >> map(map(f)) >> join) :: e.t)
+    case e @ App(map(), f) => Success((split(n) >> map(map(f)) >> join) :: e.t)
   }
 
   @rule def splitJoin2(n: Nat): Strategy[Rise] = e => e.t match {
-    case ArrayType(_,_) => Success(join o split(n) $ e)
+    case ArrayType(_,_) => Success( (toTDSL(e) |> split(n) |> join) :: e.t )
     case _ => Failure(splitJoin2(n))
   }
 
@@ -40,43 +40,43 @@ object algorithmic {
 
   def mapFusion: Strategy[Rise] = `*g >> *f -> *(g >> f)`
   @rule def `*g >> *f -> *(g >> f)`: Strategy[Rise] = {
-    case e @ App(App(Map(), f), App(App(Map(), g), arg)) =>
+    case e @ App(App(map(), f), App(App(map(), g), arg)) =>
       Success(map(typed(g) >> f)(arg) :: e.t)
   }
 
     // mapFst g >> mapFst f -> mapFst (g >> f)
   @rule def mapFstFusion: Strategy[Rise] = {
-    case e @ App(App(MapFst(), f), App(App(MapFst(), g), in)) =>
-      Success(mapFst(typed(g) >> f, in) :: e.t)
+    case e @ App(App(mapFst(), f), App(App(mapFst(), g), in)) =>
+      Success(mapFst(typed(g) >> f)(in) :: e.t)
   }
 
   // mapSnd g >> mapSnd f -> mapSnd (g >> f)
   @rule def mapSndFusion: Strategy[Rise] = {
-    case e @ App(App(MapSnd(), f), App(App(MapSnd(), g), in)) =>
-      Success(mapSnd(typed(g) >> f, in) :: e.t)
+    case e @ App(App(mapSnd(), f), App(App(mapSnd(), g), in)) =>
+      Success(mapSnd(typed(g) >> f)(in) :: e.t)
   }
 
   // padEmpty n >> padEmpty m -> padEmpty n + m
   @rule def padEmptyFusion: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), m: Nat), App(DepApp(PadEmpty(), n: Nat), in)) =>
+    case e @ App(DepApp(padEmpty(), m: Nat), App(DepApp(padEmpty(), n: Nat), in)) =>
       Success(padEmpty(n+m)(in) :: e.t)
   }
 
   // *g >> reduce f init -> reduce (acc, x => f acc (g x)) init
   @rule def reduceMapFusion: Strategy[Rise] = {
-    case e @ App(App(App(r @ ReduceX(), f), init), App(App(Map(), g), in)) =>
+    case e @ App(App(App(r @ ReduceX(), f), init), App(App(map(), g), in)) =>
       val red = (r, g.t) match {
-        case (Reduce(), FunType(i, o)) if i == o => reduce
+        case (reduce(), FunType(i, o)) if i == o => reduce
         case _ => reduceSeq
       }
       Success(red(fun(acc => fun(x =>
-        typed(f)(acc)(typed(g)(x)))), init, in) :: e.t)
+        typed(f)(acc)(typed(g)(x)))))(init)(in) :: e.t)
   }
 
   @rule def fuseReduceMap: Strategy[Rise] = {
     case e @ App(
       App(App(ReduceX(), op), init), // reduce
-      App(App(Map(), f), mapArg)     // map
+      App(App(map(), f), mapArg)     // map
     ) =>
       val red = op.t match {
         case FunType(_, yToOutT) if f.t == yToOutT => reduce
@@ -107,7 +107,7 @@ object algorithmic {
     // gx == (e4: K.float)
     // in this case we would return some form of map(id):
     // ((map λe4. (e4: K.float)) e743))
-    case e @ App(Map(), Lambda(x, App(f, gx)))
+    case e @ App(map(), Lambda(x, App(f, gx)))
       if !contains[Rise](x).apply(f) && !isIdentifier(gx) =>
       gx.t match {
         case _: DataType =>
@@ -120,24 +120,24 @@ object algorithmic {
   @rule def idAfter: Strategy[Rise] = e => Success((typed(e) |> id) :: e.t)
 
   @rule def idToCopy: Strategy[Rise] = {
-    case App(Id() ::: FunType(in: ScalarType, out: ScalarType), arg ::: (argT: ScalarType))
+    case App(id() ::: FunType(in: ScalarType, out: ScalarType), arg ::: (argT: ScalarType))
       if in == out && in == argT =>
       Success(fun(x => x) $ arg)
   }
 
   @rule def liftId()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case App(Id() ::: FunType(ArrayType(_, _), _), arg) => Success(DFNF()(ev)((map(id) $ arg)).get)
+    case App(id() ::: FunType(ArrayType(_, _), _), arg) => Success(DFNF()(ev)((map(id) $ arg)).get)
   }
 
   @rule def createTransposePair: Strategy[Rise] = {
-    case e @ App(Id(), arg) => Success(app(transpose >> transpose, arg) :: e.t)
+    case e @ App(id(), arg) => Success(app(transpose >> transpose, arg) :: e.t)
   }
 
   // _-> T >> T
   def transposePairAfter: Strategy[Rise] = idAfter `;` createTransposePair
 
   @rule def removeTransposePair: Strategy[Rise] = {
-    case e @ App(Transpose(), App(Transpose(), x)) => Success(x :: e.t)
+    case e @ App(transpose(), App(transpose(), x)) => Success(x :: e.t)
   }
 
   // overlapped tiling
@@ -145,7 +145,7 @@ object algorithmic {
   // constraint: n - m = u - v
   // v = u + m - n
   @rule def slideOverlap(u: Nat): Strategy[Rise] = {
-    case e @ DepApp(DepApp(Slide(), n: Nat), m: Nat) =>
+    case e @ DepApp(DepApp(slide(), n: Nat), m: Nat) =>
       val v = u + m - n
       Success((slide(u)(v) >> map(slide(n)(m)) >> join) :: e.t)
   }
@@ -154,12 +154,12 @@ object algorithmic {
 
   // slide n 1 >> drop l -> slide (n+l) 1 >> map(drop l)
   @rule def dropInSlide: Strategy[Rise] = {
-    case e@App(DepApp(Drop(), l: Nat), App(DepApp(DepApp(Slide(), n: Nat), Cst(1)), in)) =>
+    case e@App(DepApp(drop(), l: Nat), App(DepApp(DepApp(slide(), n: Nat), Cst(1)), in)) =>
       Success(app(map(drop(l)), app(slide(n + l)(1), typed(in))) :: e.t)
   }
   // slide n 1 >> take (N - r) -> slide (n+r) 1 >> map(take (n - r))
   @rule def takeInSlide: Strategy[Rise] = {
-    case e@App(t@DepApp(Take(), rem: Nat), App(DepApp(DepApp(Slide(), n: Nat), Cst(1)), in)) =>
+    case e@App(t@DepApp(take(), rem: Nat), App(DepApp(DepApp(slide(), n: Nat), Cst(1)), in)) =>
       t.t match {
         case FunType(ArrayType(size, _), _) =>
           val r = size - rem
@@ -169,46 +169,46 @@ object algorithmic {
   }
 
   @rule def dropNothing: Strategy[Rise] = {
-    case expr @ DepApp(Drop(), Cst(0)) => Success(fun(x => x) :: expr.t)
+    case expr @ DepApp(drop(), Cst(0)) => Success(fun(x => x) :: expr.t)
   }
 
   @rule def takeAll: Strategy[Rise] = {
-    case expr @ DepApp(Take(), n: Nat) => expr.t match {
+    case expr @ DepApp(take(), n: Nat) => expr.t match {
       case FunType(ArrayType(m, _), _) if n == m => Success(fun(x => x) :: expr.t)
       case _ => Failure(takeAll)
     }
   }
 
   @rule def padEmptyNothing: Strategy[Rise] = {
-    case e @ DepApp(PadEmpty(), Cst(0)) => Success(fun(x => x) :: e.t)
+    case e @ DepApp(padEmpty(), Cst(0)) => Success(fun(x => x) :: e.t)
   }
 
   @rule def mapIdentity: Strategy[Rise] = {
-    case expr @ App(Map(), Lambda(x1, x2)) if x1 == x2 => Success(fun(x => x) :: expr.t)
+    case expr @ App(map(), Lambda(x1, x2)) if x1 == x2 => Success(fun(x => x) :: expr.t)
   }
 
   // x -> join (slide 1 1 x)
-  @rule def slideAfter: Strategy[Rise] = e => Success(join(slide(1)(1)(e)) :: e.t)
+  @rule def slideAfter: Strategy[Rise] = e => Success(join(slide(1: Nat)(1: Nat)(e)) :: e.t)
 
-  @rule def slideAfter2: Strategy[Rise] = e => Success(map(fun(x => x `@` lidx(0, 1)), slide(1)(1)(e)) :: e.t)
+  @rule def slideAfter2: Strategy[Rise] = e => Success(map(fun(x => x `@` lidx(0, 1)))(slide(1: Nat)(1: Nat)(e)) :: e.t)
 
   // s -> map snd (zip f s)
   @rule def zipFstAfter(f: Rise): Strategy[Rise] = s => (f.t, s.t) match {
     case (ArrayType(n, _), ArrayType(m, _)) if n == m =>
-      Success(map(snd, zip(f, s)) :: s.t)
+      Success(map(snd)(zip(f)(s)) :: s.t)
     case _ => Failure(zipFstAfter(f))
   }
 
   // f -> map fst (zip f s)
   @rule def zipSndAfter(s: Rise): Strategy[Rise] = f => (f.t, s.t) match {
     case (ArrayType(n, _), ArrayType(m, _)) if n == m =>
-      Success(map(fst, zip(f, s)) :: f.t)
+      Success(map(fst)(zip(f)(s)) :: f.t)
     case _ => Failure(zipSndAfter(s))
   }
 
   // J >> drop d -> drop (d / m) >> J >> drop (d % m)
   @rule def dropBeforeJoin: Strategy[Rise] = {
-    case e @ App(DepApp(Drop(), d: Nat), App(Join(), in)) => in.t match {
+    case e @ App(DepApp(drop(), d: Nat), App(join(), in)) => in.t match {
       case ArrayType(_, ArrayType(m, _)) =>
         Success(app(drop(d % m), join(drop(d / m)(in))) :: e.t)
       case _ => throw new Exception("this should not happen")
@@ -219,7 +219,7 @@ object algorithmic {
   // -> dropLast (d / m) >> J >> dropLast (d % m)
   // -> take (n - d / m) >> J >> take ((n - d / m)*m - d % m)
   @rule def takeBeforeJoin: Strategy[Rise] = {
-    case e @ App(DepApp(Take(), nmd: Nat), App(Join(), in)) => in.t match {
+    case e @ App(DepApp(take(), nmd: Nat), App(join(), in)) => in.t match {
       case ArrayType(n, ArrayType(m, _)) =>
         val d = n*m - nmd
         val t1 = n - d / m
@@ -231,7 +231,7 @@ object algorithmic {
 
   // take n >> padEmpty m -> padEmpty m'
   @rule def removeTakeBeforePadEmpty: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), m: Nat), App(DepApp(Take(), n: Nat), in)) =>
+    case e @ App(DepApp(padEmpty(), m: Nat), App(DepApp(take(), n: Nat), in)) =>
       in.t match {
         case ArrayType(size, _)
         if ArithExpr.isSmaller(size - n, m + 1).contains(true) =>
@@ -246,16 +246,16 @@ object algorithmic {
   // -> e |> map(x => makeArray(n)(f1 x)..(fn x)) |> transpose
   @rule def mapOutsideMakeArray: Strategy[Rise] = expr => {
     def matchExpectedMakeArray(mka: Rise): Option[Rise] = mka match {
-      case App(MakeArray(_), App(App(Map(), _), e)) => Some(e)
-      case App(f, App(App(Map(), _), e2)) =>
+      case App(makeArray(_), App(App(map(), _), e)) => Some(e)
+      case App(f, App(App(map(), _), e2)) =>
         matchExpectedMakeArray(f).flatMap(e =>
           if (e == e2) { Some(e) } else { None })
       case _ => None
     }
 
     def transformMakeArray(mka: Rise, x: TDSL[Rise]): TDSL[Rise] = mka match {
-      case MakeArray(n) => array(n)
-      case App(mka, App(App(Map(), f), _)) =>
+      case makeArray(n) => array(n)
+      case App(mka, App(App(map(), f), _)) =>
         app(transformMakeArray(mka, x), app(f, x))
       case _ => throw new Exception("this should not happen")
     }
@@ -271,19 +271,19 @@ object algorithmic {
   // generate (i => select t (map f e) (map g e))
   // -> e |> map (x => generate (i => select t (f x) (g x))) |> transpose
   @rule def mapOutsideGenerateSelect()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case expr @ App(Generate(), Lambda(i, App(App(App(Select(), t),
-      App(App(Map(), f), e1)),
-      App(App(Map(), g), e2))))
+    case expr @ App(generate(), Lambda(i, App(App(App(select(), t),
+      App(App(map(), f), e1)),
+      App(App(map(), g), e2))))
     if e1 == e2 && !contains[Rise](i).apply(e1) =>
       Success(transpose(map(
-        fun(x => generate(lambda(untyped(i), select(t, app(f, x), app(g, x))))),
+        fun(x => generate(lambda(untyped(i), select(t)(app(f, x), app(g, x))))))(
         e1
       )) :: expr.t)
   }
 
   // select t (f a) (f b) -> f (select t a b)
   @rule def fOutsideSelect: Strategy[Rise] = {
-    case expr @ App(App(App(Select(), t), App(f1, a)), App(f2, b)) if f1 == f2 =>
+    case expr @ App(App(App(select(), t), App(f1, a)), App(f2, b)) if f1 == f2 =>
       f1.t match {
         case FunType(_: DataType, _: DataType) => Success(app(f1, select(t)(a)(b)) :: expr.t)
         case _ => Failure(fOutsideSelect)
@@ -293,7 +293,7 @@ object algorithmic {
   // makeArray (f e1) .. (f en) -> map f (makeArray e1 .. en)
   @rule def fOutsideMakeArray: Strategy[Rise] = expr => {
     def matchExpectedMakeArray(mka: Rise): Option[(Int, Rise)] = mka match {
-      case App(MakeArray(n), App(f, _)) =>
+      case App(makeArray(n), App(f, _)) =>
         f.t match {
           case FunType(_: DataType, _: DataType) => Some((n - 1, f))
           case _ => None
@@ -306,7 +306,7 @@ object algorithmic {
     }
 
     def transformMakeArray(mka: Rise): TDSL[Rise] = mka match {
-      case MakeArray(n) => array(n)
+      case makeArray(n) => array(n)
       case App(mka, App(_, e)) => app(transformMakeArray(mka), e)
       case _ => throw new Exception("this should not happen")
     }
@@ -320,42 +320,42 @@ object algorithmic {
 
   // zip (map fa a) (map fb b) -> zip a b >> map (p => pair (fa (fst p)) (fb (snd p)))
   @rule def mapOutsideZip: Strategy[Rise] = {
-    case expr @ App(App(Zip(), App(App(Map(), fa), a)), App(App(Map(), fb), b)) =>
-      Success(map(fun(p => pair(app(fa, fst(p)), app(fb, snd(p)))), zip(a, b)) :: expr.t)
+    case expr @ App(App(zip(), App(App(map(), fa), a)), App(App(map(), fb), b)) =>
+      Success(map(fun(p => pair(app(fa, fst(p)))(app(fb, snd(p)))))(zip(a)(b)) :: expr.t)
   }
 
   // pair (map fa a) (map fb b)
   // -> zip a b >> map (p => pair (fa (fst p)) (fb (snd p))) >> unzip
   @rule def mapOutsidePair: Strategy[Rise] = {
-    case expr @ App(App(Pair(), App(App(Map(), fa), a)), App(App(Map(), fb), b)) =>
-      Success(unzip(map(fun(p => pair(app(fa, fst(p)), app(fb, snd(p)))), zip(a, b))) :: expr.t)
+    case expr @ App(App(pair(), App(App(map(), fa), a)), App(App(map(), fb), b)) =>
+      Success(unzip(map(fun(p => pair(app(fa, fst(p)))(app(fb, snd(p)))))(zip(a)(b))) :: expr.t)
   }
 
   // zip a a -> map (x => pair(x, x)) a
   @rule def zipSame: Strategy[Rise] = {
-    case expr @ App(App(Zip(), a), a2) if a == a2 =>
-      Success(map(fun(x => pair(x, x)), a) :: expr.t)
+    case expr @ App(App(zip(), a), a2) if a == a2 =>
+      Success(map(fun(x => pair(x)(x)))(a) :: expr.t)
   }
 
   // zip(a, b) -> map (x => pair(snd(x), fst(x))) zip(b, a)
   @rule def zipSwap: Strategy[Rise] = {
-    case expr @ App(App(Zip(), a), b) =>
-      Success(map(fun(x => pair(snd(x), fst(x))), zip(b, a)) :: expr.t)
+    case expr @ App(App(zip(), a), b) =>
+      Success(map(fun(x => pair(snd(x))(fst(x))))(zip(b)(a)) :: expr.t)
   }
 
   // zip(a, zip(b, c)) -> map (x => pair(.., pair(..))) zip(zip(a, b), c)
   @rule def zipRotateLeft: Strategy[Rise] = {
-    case expr @ App(App(Zip(), a), App(App(Zip(), b), c)) => Success(map(
-      fun(x => pair(fst(fst(x)), pair(snd(fst(x)), snd(x)))),
-      zip(zip(a, b), c)
+    case expr @ App(App(zip(), a), App(App(zip(), b), c)) => Success(map(
+      fun(x => pair(fst(fst(x)))(pair(snd(fst(x)))(snd(x)))))(
+      zip(zip(a)(b))(c)
     ) :: expr.t)
   }
 
   // zip(zip(a, b), c) -> map (x => pair(pair(..), ..)) zip(a, zip(b, c))
   @rule def zipRotateRight: Strategy[Rise] = {
-    case expr @ App(App(Zip(), App(App(Zip(), a), b)), c) => Success(map(
-      fun(x => pair(pair(fst(x), fst(snd(x))), snd(snd(x)))),
-      zip(a, zip(b, c))
+    case expr @ App(App(zip(), App(App(zip(), a), b)), c) => Success(map(
+      fun(x => pair(pair(fst(x))(fst(snd(x))))(snd(snd(x)))))(
+      zip(a)(zip(b)(c))
     ) :: expr.t)
   }
 
@@ -363,36 +363,36 @@ object algorithmic {
 
   // e -> map (x => x) e
   @rule def mapIdentityAfter: Strategy[Rise] = expr => expr.t match {
-    case ArrayType(_, _) => Success(map(fun(x => x), expr) :: expr.t)
+    case ArrayType(_, _) => Success(map(fun(x => x))(expr) :: expr.t)
     case _ => Failure(mapIdentityAfter)
   }
 
   // fst (pair a b) -> a
   @rule def fstReduction: Strategy[Rise] = {
-    case expr @ App(Fst(), App(App(Pair(), a), _)) => Success(a :: expr.t)
+    case expr @ App(fst(), App(App(pair(), a), _)) => Success(a :: expr.t)
   }
 
   // snd (pair a b) -> b
   @rule def sndReduction: Strategy[Rise] = {
-    case expr @ App(Snd(), App(App(Pair(), _), b)) => Success(b :: expr.t)
+    case expr @ App(snd(), App(App(pair(), _), b)) => Success(b :: expr.t)
   }
 
   // zip (slide n m a) (slide n m b) -> map unzip (slide n m (zip a b))
   @rule def slideOutsideZip: Strategy[Rise] = {
-    case expr @ App(App(Zip(),
-      App(DepApp(DepApp(Slide(), n: Nat), m: Nat), a)),
-      App(DepApp(DepApp(Slide(), n2: Nat), m2: Nat), b)
+    case expr @ App(App(zip(),
+      App(DepApp(DepApp(slide(), n: Nat), m: Nat), a)),
+      App(DepApp(DepApp(slide(), n2: Nat), m2: Nat), b)
     ) if n == n2 && m == m2 =>
-      Success(map(unzip, slide(n)(m)(zip(a, b))) :: expr.t)
+      Success(map(unzip)(slide(n)(m)(zip(a)(b))) :: expr.t)
   }
 
   // slide n m (zip a b) -> map zip (zip (slide n m a) (slide n m b))
   @rule def slideInsideZip: Strategy[Rise] = {
-    case expr @ App(DepApp(DepApp(Slide(), n: Nat), m: Nat),
-      App(App(Zip(), a), b)
+    case expr @ App(DepApp(DepApp(slide(), n: Nat), m: Nat),
+      App(App(zip(), a), b)
     ) =>
-      Success(map(fun(p => zip(fst(p), snd(p))),
-        zip(slide(n)(m)(a), slide(n)(m)(b))) :: expr.t)
+      Success(map(fun(p => zip(fst(p))(snd(p))))(
+        zip(slide(n)(m)(a))(slide(n)(m)(b))) :: expr.t)
   }
 
   // TODO?
@@ -402,36 +402,36 @@ object algorithmic {
   // def fBeforeZipMapSnd: Strategy[Rise] =
   @rule def fBeforeZipMap: Strategy[Rise] = {
     case expr @ App(
-      App(Map(), Lambda(x, App(App(Zip(),
-        App(f, App(Fst(), x2))),
-        App(g, App(Snd(), x3))))),
-      App(App(Zip(), a), b)
+      App(map(), Lambda(x, App(App(zip(),
+        App(f, App(fst(), x2))),
+        App(g, App(snd(), x3))))),
+      App(App(zip(), a), b)
     ) if x == x2 && x == x3 =>
       Success(app(
-        map(fun(x => zip(fst(x), snd(x)))),
-        zip(map(f, a), map(g, b))
+        map(fun(x => zip(fst(x))(snd(x)))),
+        zip(map(f)(a))(map(g)(b))
       ) :: expr.t)
   }
 
   // a |> map (zip b) |> transpose
   // -> transpose a |> zip2D (map (x => generate (_ => x) b)
   @rule def transposeBeforeMapZip: Strategy[Rise] = {
-    case e @ App(Transpose(), App(App(Map(), App(Zip(), b)), a)) =>
-      Success(map(fun(p => zip(fst(p), snd(p))),
-        zip(map(fun(x => generate(fun(_ => x))), b), transpose(a))) :: e.t)
+    case e @ App(transpose(), App(App(map(), App(zip(), b)), a)) =>
+      Success(map(fun(p => zip(fst(p))(snd(p))))(
+        zip(map(fun(x => generate(fun(_ => x))))(b))(transpose(a))) :: e.t)
   }
 
   // unzip (zip a b) -> pair a b
   @rule def unzipZipIsPair: Strategy[Rise] = {
-    case e @ App(Unzip(), App(App(Zip(), a), b)) =>
-      Success(pair(a, b) :: e.t)
+    case e @ App(unzip(), App(App(zip(), a), b)) =>
+      Success(pair(a)(b) :: e.t)
   }
 
   // FIXME: fighting against beta-reduction
   // unzip ((p => zip (fst p) (snd p)) in) -> in
   @rule def unzipZipIdentity: Strategy[Rise] = {
-    case e @ App(Unzip(), App(Lambda(p,
-      App(App(Zip(), App(Fst(), p2)), App(Snd(), p3))), in))
+    case e @ App(unzip(), App(Lambda(p,
+      App(App(zip(), App(fst(), p2)), App(snd(), p3))), in))
     if p == p2 && p == p3 =>
       Success(in :: e.t)
   }
@@ -440,26 +440,26 @@ object algorithmic {
   // zip (fst/snd unzip e) (fst/snd unzip e)
   // -> map (p => pair (fst/snd p) (fst/snd p)) e
   @rule def zipUnzipAccessSimplification: Strategy[Rise] = {
-    case e @ App(App(Zip(),
-      App(a1 @ (Fst() | Snd()), App(Unzip(), e1))),
-      App(a2 @ (Fst() | Snd()), App(Unzip(), e2))
+    case e @ App(App(zip(),
+      App(a1 @ (fst() | snd()), App(unzip(), e1))),
+      App(a2 @ (fst() | snd()), App(unzip(), e2))
     ) if e1 == e2 =>
-      Success(map(fun(p => pair(untyped(a1)(p), untyped(a2)(p))), e1) :: e.t)
+      Success(map(fun(p => pair(untyped(a1)(p))(untyped(a2)(p))))(e1) :: e.t)
   }
 
   // FIXME: this is very specific
   @rule def zipAsVectorUnzipSimplification: Strategy[Rise] = {
     case e @ App(
-      Lambda(x, App(App(Zip(),
-        App(DepApp(AsVector(), v: Nat), App(Fst(), x2))),
-        App(DepApp(AsVector(), v2: Nat), App(Snd(), x3)))),
-      App(Unzip(), in)
+      Lambda(x, App(App(zip(),
+        App(DepApp(asVector(), v: Nat), App(fst(), x2))),
+        App(DepApp(asVector(), v2: Nat), App(snd(), x3)))),
+      App(unzip(), in)
     ) if x == x2 && x == x3 && v == v2 =>
       println(in.t)
       println(e.t)
       val r = typed(in) |>
         mapFst(asVectorAligned(v)) |> mapSnd(asVectorAligned(v)) |>
-        fun(p => zip(fst(p), snd(p)))
+        fun(p => zip(fst(p))(snd(p)))
       Success(r :: e.t)
   }
 
@@ -467,16 +467,16 @@ object algorithmic {
   // map (p => g (fst p) (snd p)) (zip (fst/snd e) (fst/snd e))
   // -> map (p => g (fst/snd p) (fst/snd p)) (zip (fst e) (snd e))
   @rule def mapProjZipUnification()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case e @ App(App(Map(),
-      Lambda(p, App(App(g, App(Fst(), p1)), App(Snd(), p2)))),
-      App(App(Zip(),
-        App(a1 @ (Fst() | Snd()), e1)),
-        App(a2 @ (Fst() | Snd()), e2)))
+    case e @ App(App(map(),
+      Lambda(p, App(App(g, App(fst(), p1)), App(snd(), p2)))),
+      App(App(zip(),
+        App(a1 @ (fst() | snd()), e1)),
+        App(a2 @ (fst() | snd()), e2)))
     if e1 == e2 && p == p1 && p == p2 &&
       a1 == a2 && !contains[Rise](p).apply(g)
     =>
-      Success(map(fun(p => typed(g)(untyped(a1)(p), untyped(a2)(p))),
-        zip(fst(e1), snd(e1))) :: e.t)
+      Success(map(fun(p => typed(g)(untyped(a1)(p), untyped(a2)(p))))(
+        zip(fst(e1))(snd(e1))) :: e.t)
   }
 
   // TODO: should not be in this file?
@@ -520,7 +520,7 @@ object algorithmic {
   // different name for ICFP'20
   def splitStrategy(n: Nat)(implicit ev: Traversable[Rise]): Strategy[Rise] = blockedReduce(n)
   @rule def blockedReduce(n: Nat)(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case App(App(App(Reduce(), op ::: FunType(yT, FunType(initT, outT))),
+    case App(App(App(reduce(), op ::: FunType(yT, FunType(initT, outT))),
       init), arg) if yT == outT =>
       // avoid having two lambdas using the same identifiers
       val freshOp = tryAll(freshLambdaIdentifier()).apply(op).get
@@ -540,8 +540,8 @@ object algorithmic {
   ))
   // TODO: check separability property?
   @rule def separateDotHV(weights2d: Expr, wH: Expr, wV: Expr): Strategy[Rise] = {
-    case e @ App(App(App(Reduce(), rf), init), App(App(Map(), mf),
-      App(App(Zip(), App(Join(), weights)), App(Join(), nbh))
+    case e @ App(App(App(reduce(), rf), init), App(App(map(), mf),
+      App(App(zip(), App(join(), weights)), App(join(), nbh))
     )) if rf == ((add :: rf.t): Expr) &&
       init == (l(0.0f): Expr) &&
       mf == ((mulT :: mf.t): Expr) &&
@@ -551,8 +551,8 @@ object algorithmic {
   }
 
   @rule def separateDotVH(weights2d: Expr, wV: Expr, wH: Expr): Strategy[Rise] = {
-    case e @ App(App(App(Reduce(), rf), init), App(App(Map(), mf),
-    App(App(Zip(), App(Join(), weights)), App(Join(), nbh))
+    case e @ App(App(App(reduce(), rf), init), App(App(map(), mf),
+    App(App(zip(), App(join(), weights)), App(join(), nbh))
     )) if rf == ((add :: rf.t): Expr) &&
       init == (l(0.0f): Expr) &&
       mf == ((mulT :: mf.t): Expr) &&
@@ -562,12 +562,12 @@ object algorithmic {
   }
 
   @rule def separateSumHV: Strategy[Rise] = {
-    case e @ App(sum2, App(Join(), in)) if sum2 == ((sum :: sum2.t): Expr) =>
+    case e @ App(sum2, App(join(), in)) if sum2 == ((sum :: sum2.t): Expr) =>
       Success((typed(in) |> map(sum) |> sum) :: e.t)
   }
 
   @rule def separateSumVH: Strategy[Rise] = {
-    case e @ App(sum2, App(Join(), in)) if sum2 == ((sum :: sum2.t): Expr) =>
+    case e @ App(sum2, App(join(), in)) if sum2 == ((sum :: sum2.t): Expr) =>
       Success((typed(in) |> transpose |> map(sum) |> sum) :: e.t)
   }
 }

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -2,22 +2,20 @@ package rise.elevate.rules
 
 import arithexpr.arithmetic.Cst
 import elevate.core.strategies.basic._
+import elevate.core.strategies.{Traversable, predicate}
 import elevate.core.strategies.predicate._
 import elevate.core.strategies.traversal._
 import elevate.core.{Failure, Strategy, Success}
 import elevate.macros.RuleMacro.rule
+import rise.core.TypedDSL._
+import rise.core.{primitives => p, _}
+import rise.core.primitives.{not => _, _}
+import rise.core.types._
 import rise.elevate._
 import rise.elevate.rules.traversal._
 import rise.elevate.strategies.normalForm.DFNF
-import rise.elevate.strategies.predicate._
-import rise.elevate.strategies.predicate.isVectorArray
-import rise.core.TypedDSL._
-import rise.core.{TypedDSL, _}
-import rise.core.primitives._
-import rise.core.types._
-import arithexpr.arithmetic.Cst
-import elevate.core.strategies.Traversable
-import rise.openMP.TypedDSL.mapPar
+import rise.elevate.strategies.predicate.{isVectorArray, _}
+import rise.openMP.primitives.mapPar
 
 object lowering {
 
@@ -32,56 +30,56 @@ object lowering {
   }
 
   @rule def mapSeq: Strategy[Rise] = {
-    case m@Map() => Success(MapSeq()(m.t) :: m.t)
+    case m@map() => Success(p.mapSeq :: m.t)
   }
 
   @rule def mapStream: Strategy[Rise] = {
-    case m@Map() => Success(MapStream()(m.t) :: m.t)
+    case m@map() => Success(p.mapStream :: m.t)
   }
 
   @rule def iterateStream: Strategy[Rise] = {
-    case m@Map() => Success(IterateStream()(m.t) :: m.t)
+    case m@map() => Success(p.iterateStream :: m.t)
   }
 
   @rule def mapSeqUnroll: Strategy[Rise] = {
-    case m@Map() => Success(MapSeqUnroll()(m.t) :: m.t)
+    case m@map() => Success(p.mapSeqUnroll :: m.t)
   }
 
   @rule def mapGlobal(dim: Int = 0): Strategy[Rise] = {
-    case m@Map() => Success(rise.openCL.TypedDSL.mapGlobal(dim) :: m.t)
+    case m@map() => Success(rise.openCL.TypedDSL.mapGlobal(dim) :: m.t)
   }
 
   @rule def reduceSeq: Strategy[Rise] = {
-    case e@Reduce() => Success(TypedDSL.reduceSeq :: e.t)
+    case e@reduce() => Success(p.reduceSeq :: e.t)
   }
 
   // TODO shall we allow lowering from an already lowered reduceSeq?
   @rule def reduceSeqUnroll: Strategy[Rise] = {
-    case e@Reduce() => Success(TypedDSL.reduceSeqUnroll :: e.t)
-    case e@ReduceSeq() => Success(TypedDSL.reduceSeqUnroll :: e.t)
+    case e@reduce() => Success(p.reduceSeqUnroll :: e.t)
+    case e@p.reduceSeq() => Success(p.reduceSeqUnroll :: e.t)
   }
 
   // Specialized Lowering
 
   @rule def mapSeqCompute()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case e@App(Map(), f) if containsComputation()(ev)(f) && not(isMappingZip)(f) =>
-      Success(TypedDSL.mapSeq(f) :: e.t)
+    case e@App(map(), f) if containsComputation()(ev)(f) && predicate.not(isMappingZip)(f) =>
+      Success(p.mapSeq(f) :: e.t)
   }
 
   @rule def isMappingZip: Strategy[Rise] = {
-    case l@Lambda(_, App(App(Zip(), a), b)) => Success(l)
-    case m@Lambda(_, App(App(Map(), f), arg)) => isMappingZip(f)
+    case l@Lambda(_, App(App(zip(), a), b)) => Success(l)
+    case m@Lambda(_, App(App(map(), f), arg)) => isMappingZip(f)
   }
 
   // TODO: load identity instead, then change with other rules?
   @rule def circularBuffer(load: Expr): Strategy[Rise] = {
-    case e@DepApp(DepApp(Slide(), sz: Nat), Cst(1)) => Success(
-      TypedDSL.circularBuffer(sz)(sz)(untyped(load)) :: e.t)
+    case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
+      p.circularBuffer(sz)(sz)(untyped(load)) :: e.t)
   }
 
   @rule def rotateValues(write: Expr): Strategy[Rise] = {
-    case e@DepApp(DepApp(Slide(), sz: Nat), Cst(1)) => Success(
-      TypedDSL.rotateValues(sz)(untyped(write)) :: e.t)
+    case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
+      p.rotateValues(sz)(untyped(write)) :: e.t)
   }
 
   @rule def containsComputation()(implicit ev: Traversable[Rise]): Strategy[Rise] =
@@ -117,7 +115,7 @@ object lowering {
 
 //  case class slideSeq(rot: SlideSeq.Rotate, write_dt1: Expr) extends Strategy[Rise] {
 //    def apply(e: Rise): RewriteResult[Rise] = e match {
-//      case Slide() => Success(nFun(sz => nFun(sp =>
+//      case slide() => Success(nFun(sz => nFun(sp =>
 //        TypedDSL.slideSeq(rot)(sz)(sp)(untyped(write_dt))
 //      )) :: e.t)
 //      case _ => Failure(slideSeq(rot, write_dt))
@@ -130,14 +128,14 @@ object lowering {
   // TODO: think about more complex cases
   @rule def mapSeqUnrollWrite: Strategy[Rise] = e => e.t match {
     case ArrayType(_, t) if typeHasTrivialCopy(t) =>
-      Success(app(TypedDSL.mapSeqUnroll(fun(x => x)), typed(e)) :: e.t)
+      Success(app(p.mapSeqUnroll(fun(x => x)), typed(e)) :: e.t)
     case _ =>
       Failure(mapSeqUnrollWrite)
   }
 
   @rule def toMemAfterMapSeq: Strategy[Rise] = {
-    case a@App(App(MapSeq(), _), _) =>
-      Success((typed(a) |> TypedDSL.toMem) :: a.t)
+    case a@App(App(p.mapSeq(), _), _) =>
+      Success((typed(a) |> p.toMem) :: a.t)
   }
 
   // Lowerings used in PLDI submission
@@ -159,7 +157,7 @@ object lowering {
 
   @rule def insertCopyAfter: Strategy[Rise] = e => {
     def constructCopy(t: Type): TDSL[Rise] = t match {
-      case ArrayType(_, dt) => TypedDSL.mapSeq(fun(x => constructCopy(dt) $ x))
+      case ArrayType(_, dt) => p.mapSeq(fun(x => constructCopy(dt) $ x))
       case _ if typeHasTrivialCopy(t) => fun(x => x)
       case _ => ??? // shouldn't happen?
     }
@@ -169,9 +167,9 @@ object lowering {
 
   // todo currently only works for mapSeq
   @rule def isCopy: Strategy[Rise] = {
-    case c@App(Let(), id) if isId(id) => Success(c)
-    case c@App(App(MapSeq(), id), etaInput) if isId(id) => Success(c)
-    case App(App(MapSeq(), Lambda(_, f)), etaInput) => isCopy(f)
+    case c@App(let(), id) if isId(id) => Success(c)
+    case c@App(App(p.mapSeq(), id), etaInput) if isId(id) => Success(c)
+    case App(App(p.mapSeq(), Lambda(_, f)), etaInput) => isCopy(f)
     case c@App(id, _) if isId(id) => Success(c)
   }
 
@@ -196,8 +194,8 @@ object lowering {
   @rule def copyAfterReduce: Strategy[Rise] = e => {
     def constructCopy(t: Type): TDSL[Rise] = t match {
       case _ if typeHasTrivialCopy(t) => letf(fun(x => x))
-      case ArrayType(_, b) if typeHasTrivialCopy(b) => TypedDSL.mapSeq(fun(x => x))
-      case ArrayType(_, a: ArrayType) => TypedDSL.mapSeq(fun(x => constructCopy(a) $ x))
+      case ArrayType(_, b) if typeHasTrivialCopy(b) => p.mapSeq(fun(x => x))
+      case ArrayType(_, a: ArrayType) => p.mapSeq(fun(x => constructCopy(a) $ x))
       case _ => ??? // shouldn't happen?
     }
 
@@ -211,8 +209,8 @@ object lowering {
   @rule def copyAfterReduceInit: Strategy[Rise] = e => {
     def constructCopy(t: Type): TDSL[Rise] = t match {
       case _ if typeHasTrivialCopy(t) => letf(fun(x => x))
-      case ArrayType(_, b) if typeHasTrivialCopy(b) => TypedDSL.mapSeq(fun(x => x))
-      case ArrayType(_, a: ArrayType) => TypedDSL.mapSeq(fun(x => constructCopy(a) $ x))
+      case ArrayType(_, b) if typeHasTrivialCopy(b) => p.mapSeq(fun(x => x))
+      case ArrayType(_, a: ArrayType) => p.mapSeq(fun(x => constructCopy(a) $ x))
       case x => println(x) ; ??? // shouldn't happen?
     }
 
@@ -226,20 +224,20 @@ object lowering {
   // todo currently only works for mapSeq
   @rule def copyAfterGenerate: Strategy[Rise] = e => {
     def constructCopy(t: Type): TDSL[Rise] = t match {
-      case ArrayType(_, dt) => TypedDSL.mapSeq(fun(x => constructCopy(dt) $ x))
+      case ArrayType(_, dt) => p.mapSeq(fun(x => constructCopy(dt) $ x))
       case _ if typeHasTrivialCopy(t) => fun(x => x)
       case _ => ??? // shouldn't happen?
     }
 
     e match {
-      case a@App(Generate(), _) =>
+      case a@App(generate(), _) =>
         Success((typed(a) |> constructCopy(a.t)) :: e.t)
       case _ => Failure(copyAfterGenerate)
     }
   }
 
   @rule def vectorize(n: Nat)(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case a@App(App(Map(), f), input) if
+    case a@App(App(map(), f), input) if
       isComputation()(ev)(f) && !isVectorArray(a.t) =>
 
       def vectorizeArrayBasedOnType(t: Type): TDSL[Rise] = {
@@ -260,7 +258,7 @@ object lowering {
 
       val newF = untyped(f)
       Success(
-        (asScalar o map(newF)) $ (vectorizeArrayBasedOnType(input.t) $ input)
+        toTDSL(input) |> vectorizeArrayBasedOnType(input.t) |> (map(newF) >> asScalar)
       )
     case _ => Failure(vectorize(n))
   }
@@ -268,43 +266,42 @@ object lowering {
   @rule def untype: Strategy[Rise] = p => Success(p.setType(TypePlaceholder))
 
   @rule def parallel()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case e@App(Map(), f) if containsComputation()(ev)(f) => Success(mapPar(f) :: e.t)
+    case e@App(map(), f) if containsComputation()(ev)(f) => Success(mapPar(f) :: e.t)
   }
 
   @rule def unroll: Strategy[Rise] = {
-    case e@ReduceSeq() => Success(TypedDSL.reduceSeqUnroll :: e.t)
+    case e@p.reduceSeq() => Success(p.reduceSeqUnroll :: e.t)
   }
 
   object ocl {
     import rise.core.types.AddressSpace
-    import rise.openCL.TypedDSL
     import rise.openCL.primitives._
 
     // TODO shall we allow lowering from an already lowered reduceSeq?
     @rule def reduceSeqUnroll(a: AddressSpace): Strategy[Rise] = {
-      case e@Reduce() => Success(TypedDSL.oclReduceSeqUnroll(a) :: e.t)
-      case e@ReduceSeq() => Success(TypedDSL.oclReduceSeqUnroll(a) :: e.t)
+      case e@reduce() => Success(oclReduceSeqUnroll(a) :: e.t)
+      case e@p.reduceSeq() => Success(oclReduceSeqUnroll(a) :: e.t)
     }
 
     @rule def circularBuffer(a: AddressSpace): Strategy[Rise] = {
-      case e@DepApp(DepApp(Slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
         Success(
-          TypedDSL.oclCircularBuffer(a)(n)(n)(fun(x => x))
+          oclCircularBuffer(a)(n)(n)(fun(x => x))
             :: e.t)
     }
 
     @rule def circularBufferLoadFusion: Strategy[Rise] = {
       case e@App(App(
-        cb @ DepApp(DepApp(DepApp(OclCircularBuffer(), _), _), _),
-        load), App(App(Map(), f), in)
+        cb @ DepApp(DepApp(DepApp(oclCircularBuffer(), _), _), _),
+        load), App(App(map(), f), in)
       ) =>
         Success(untyped(cb)(typed(f) >> load, in) :: e.t)
     }
 
     @rule def rotateValues(a: AddressSpace, write: Expr): Strategy[Rise] = {
-      case e@DepApp(DepApp(Slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
         Success(
-          TypedDSL.oclRotateValues(a)(n)(untyped(write))
+          oclRotateValues(a)(n)(untyped(write))
             :: e.t)
     }
   }

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -128,14 +128,14 @@ object lowering {
   // TODO: think about more complex cases
   @rule def mapSeqUnrollWrite: Strategy[Rise] = e => e.t match {
     case ArrayType(_, t) if typeHasTrivialCopy(t) =>
-      Success(app(p.mapSeqUnroll(fun(x => x)), isTyped(e)) :: e.t)
+      Success(app(p.mapSeqUnroll(fun(x => x)), preserveType(e)) :: e.t)
     case _ =>
       Failure(mapSeqUnrollWrite)
   }
 
   @rule def toMemAfterMapSeq: Strategy[Rise] = {
     case a@App(App(p.mapSeq(), _), _) =>
-      Success((isTyped(a) |> p.toMem) :: a.t)
+      Success((preserveType(a) |> p.toMem) :: a.t)
   }
 
   // Lowerings used in PLDI submission
@@ -201,7 +201,7 @@ object lowering {
 
     e match {
       case reduceResult@App(App(App(ReduceX(), _), _), _) =>
-        Success((isTyped(e) |> constructCopy(reduceResult.t) ) :: e.t)
+        Success((preserveType(e) |> constructCopy(reduceResult.t) ) :: e.t)
       case _ => Failure(copyAfterReduce)
     }
   }
@@ -216,7 +216,7 @@ object lowering {
 
     e match {
       case App(a@App(ReduceX(), _), init) =>
-        Success((isTyped(init) |> constructCopy(init.t) |> a) :: e.t)
+        Success((preserveType(init) |> constructCopy(init.t) |> a) :: e.t)
       case _ => Failure(copyAfterReduceInit)
     }
   }
@@ -231,7 +231,7 @@ object lowering {
 
     e match {
       case a@App(generate(), _) =>
-        Success((isTyped(a) |> constructCopy(a.t)) :: e.t)
+        Success((preserveType(a) |> constructCopy(a.t)) :: e.t)
       case _ => Failure(copyAfterGenerate)
     }
   }
@@ -295,7 +295,7 @@ object lowering {
         cb @ DepApp(DepApp(DepApp(oclCircularBuffer(), _), _), _),
         load), App(App(map(), f), in)
       ) =>
-        Success(eraseType(cb)(isTyped(f) >> load, in) :: e.t)
+        Success(eraseType(cb)(preserveType(f) >> load, in) :: e.t)
     }
 
     @rule def rotateValues(a: AddressSpace, write: Expr): Strategy[Rise] = {

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -35,7 +35,7 @@ object movement {
     case e@App(
       transpose(),
       App(App(map(), App(map(), f)), y)) =>
-        Success((isTyped(y) |> transpose |> map(map(f))) :: e.t)
+        Success((preserveType(y) |> transpose |> map(map(f))) :: e.t)
     // LCNF
     case e@App(transpose(),
     App(
@@ -44,13 +44,13 @@ object movement {
       arg)
     ) if etaReduction()(ev)(lamA) && etaReduction()(ev)(lamB) =>
       // Success((typed(arg) |> transpose |> map(map(f))) :: e.t)
-      Success((isTyped(arg) |> transpose |> map(fun(a => map(fun(b => isTyped(f)(b)))(a)))) :: e.t)
+      Success((preserveType(arg) |> transpose |> map(fun(a => map(fun(b => preserveType(f)(b)))(a)))) :: e.t)
   }
 
   def transposeBeforeMapMapF: Strategy[Rise] = `T >> **f -> **f >> T`
   @rule def `T >> **f -> **f >> T`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(transpose(), y)) =>
-      Success((isTyped(y) |> map(map(f)) |> transpose) :: e.t)
+      Success((preserveType(y) |> map(map(f)) |> transpose) :: e.t)
   }
 
 
@@ -65,19 +65,19 @@ object movement {
   def slideBeforeMapMapF: Strategy[Rise] = `S >> **f -> *f >> S`
   @rule def `S >> **f -> *f >> S`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(s, y)) if isSplitOrSlide(s) =>
-      Success((isTyped(y) |> map(f) |> eraseType(s)) :: e.t)
+      Success((preserveType(y) |> map(f) |> eraseType(s)) :: e.t)
   }
 
   def slideBeforeMap: Strategy[Rise] = `*f >> S -> S >> **f`
   @rule def `*f >> S -> S >> **f`: Strategy[Rise] = {
     case e@App(s @ DepApp(DepApp(slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
-      Success((isTyped(y) |> eraseType(s) |> map(map(f))) :: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(map(f))) :: e.t)
   }
 
   // *f >> S -> S >> **f
   @rule def splitBeforeMap: Strategy[Rise] = {
     case e@App(s @ DepApp(split(), _: Nat), App(App(map(), f), y)) =>
-      Success((isTyped(y) |> eraseType(s) |> map(map(f))) :: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(map(f))) :: e.t)
   }
 
   // join
@@ -85,13 +85,13 @@ object movement {
   def joinBeforeMapF: Strategy[Rise] = `J >> *f -> **f >> J`
   @rule def `J >> *f -> **f >> J`: Strategy[Rise] = {
     case e@App(App(map(), f),App(join(), y)) =>
-      Success((isTyped(y) |> map(map(f)) >> join) :: e.t)
+      Success((preserveType(y) |> map(map(f)) >> join) :: e.t)
   }
 
   def mapMapFBeforeJoin: Strategy[Rise] = `**f >> J -> J >> *f`
   @rule def `**f >> J -> J >> *f`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), App(map(), f)), y)) =>
-      Success((isTyped(y) |> join |> map(f)) :: e.t)
+      Success((preserveType(y) |> join |> map(f)) :: e.t)
   }
 
   // drop and take
@@ -99,13 +99,13 @@ object movement {
   def dropBeforeMap: Strategy[Rise] = `*f >> drop n -> drop n >> *f`
   @rule def `*f >> drop n -> drop n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(drop(n), isTyped(in))) :: expr.t)
+      Success(app(map(f), app(drop(n), preserveType(in))) :: expr.t)
   }
 
   def takeBeforeMap: Strategy[Rise] = `*f >> take n -> take n >> *f`
   @rule def `*f >> take n -> take n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(take(n), isTyped(in))) :: expr.t)
+      Success(app(map(f), app(take(n), preserveType(in))) :: expr.t)
   }
 
   // take n >> *f -> *f >> take n
@@ -158,13 +158,13 @@ object movement {
   def dropBeforeTake: Strategy[Rise] = `take (n+m) >> drop m -> drop m >> take n`
   @rule def `take (n+m) >> drop m -> drop m >> take n`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), m: Nat), App(DepApp(take(), nm: Nat), in)) =>
-      Success(app(take(nm - m), app(drop(m), isTyped(in))) :: expr.t)
+      Success(app(take(nm - m), app(drop(m), preserveType(in))) :: expr.t)
   }
 
   def takeBeforeDrop: Strategy[Rise] = `drop m >> take n -> take (n+m) >> drop m`
   @rule def `drop m >> take n -> take (n+m) >> drop m`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(DepApp(drop(), m: Nat), in)) =>
-      Success(app(drop(m), app(take(n+m), isTyped(in))) :: expr.t)
+      Success(app(drop(m), app(take(n+m), preserveType(in))) :: expr.t)
   }
 
   def takeBeforeSlide: Strategy[Rise] = `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`
@@ -212,7 +212,7 @@ object movement {
     case e @ App(DepApp(padEmpty(), n: Nat),
       App(App(zip(), App(fst(), e1)), App(snd(), e2)))
     if e1 == e2 =>
-      Success((isTyped(e1) |>
+      Success((preserveType(e1) |>
         mapFst(padEmpty(n)) |> mapSnd(padEmpty(n)) |>
         fun(p => zip(fst(p))(snd(p)))) :: e.t)
   }
@@ -223,19 +223,19 @@ object movement {
   def transposeBeforeSlide: Strategy[Rise] = `T >> S -> *S >> T >> *T`
   @rule def `T >> S -> *S >> T >> *T`: Strategy[Rise] = {
     case e@App(s, App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((isTyped(y) |> map(eraseType(s)) |> transpose.apply |> map(transpose)) :: e.t)
+      Success((preserveType(y) |> map(eraseType(s)) |> transpose.apply |> map(transpose)) :: e.t)
   }
 
   def transposeBeforeMapSlide: Strategy[Rise] = `T >> *S -> S >> *T >> T`
   @rule def `T >> *S -> S >> *T >> T`: Strategy[Rise] = {
     case e@App(App(map(), s), App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((isTyped(y) |> eraseType(s) |> map(transpose) |> transpose) :: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(transpose) |> transpose) :: e.t)
   }
 
   def mapSlideBeforeTranspose: Strategy[Rise] = `*S >> T -> T >> S >> *T`
   @rule def `*S >> T -> T >> S >> *T`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), s), y)) if isSplitOrSlide(s) =>
-      Success((isTyped(y) |> transpose.apply |> eraseType(s) |> map(transpose)) :: e.t)
+      Success((preserveType(y) |> transpose.apply |> eraseType(s) |> map(transpose)) :: e.t)
   }
 
   // transpose + join
@@ -243,25 +243,25 @@ object movement {
   def joinBeforeTranspose: Strategy[Rise] = `J >> T -> *T >> T >> *J`
   @rule def `J >> T -> *T >> T >> *J`: Strategy[Rise] = {
     case e@App(transpose(), App(join(), y)) =>
-      Success((isTyped(y) |> map(transpose) |> transpose |> map(join)) :: e.t)
+      Success((preserveType(y) |> map(transpose) |> transpose |> map(join)) :: e.t)
   }
 
   def transposeBeforeMapJoin: Strategy[Rise] = `T >> *J -> *T >> J >> T`
   @rule def `T >> *J -> *T >> J >> T`: Strategy[Rise] = {
     case e@App(App(map(), join()), App(transpose(), y)) =>
-      Success((isTyped(y) |> map(transpose) |> join |> transpose) :: e.t)
+      Success((preserveType(y) |> map(transpose) |> join |> transpose) :: e.t)
   }
 
   def mapTransposeBeforeJoin: Strategy[Rise] = `*T >> J -> T >> *J >> T`
   @rule def `*T >> J -> T >> *J >> T`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), transpose()), y)) =>
-      Success((isTyped(y) |> transpose |> map(join) |> transpose) :: e.t)
+      Success((preserveType(y) |> transpose |> map(join) |> transpose) :: e.t)
   }
 
   def mapJoinBeforeTranspose: Strategy[Rise] = `*J >> T -> T >> *T >> J`
   @rule def `*J >> T -> T >> *T >> J`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), join()), y)) =>
-      Success((isTyped(y) |> transpose |> map(transpose) |> join) :: e.t)
+      Success((preserveType(y) |> transpose |> map(transpose) |> join) :: e.t)
   }
 
   // join + join
@@ -269,13 +269,13 @@ object movement {
   def joinBeforeJoin: Strategy[Rise] = `J >> J -> *J >> J`
   @rule def `J >> J -> *J >> J`: Strategy[Rise] = {
     case e@App(join(), App(join(), y)) =>
-      Success((isTyped(y) |> map(join) >> join) :: e.t)
+      Success((preserveType(y) |> map(join) >> join) :: e.t)
   }
 
   def mapJoinBeforeJoin: Strategy[Rise] = `*J >> J -> J >> J`
   @rule def `*J >> J -> J >> J`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), join()), y)) =>
-      Success((isTyped(y) |> join |> join) :: e.t)
+      Success((preserveType(y) |> join |> join) :: e.t)
   }
 
   // split + slide
@@ -283,7 +283,7 @@ object movement {
   def slideBeforeSplit: Strategy[Rise] = `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`
   @rule def `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`: Strategy[Rise] = {
     case e@App(DepApp(split(), k: Nat), App(DepApp(DepApp(slide(), n: Nat), s: Nat), y)) =>
-      Success((isTyped(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) :: e.t)
+      Success((preserveType(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) :: e.t)
   }
 
   // TODO: what if s != 1?
@@ -292,7 +292,7 @@ object movement {
     case e@App(DepApp(DepApp(slide(), m: Nat), k: Nat),
             App(DepApp(DepApp(slide(), n: Nat), s: Nat), in)
          ) if s == (1: Nat) =>
-      Success((isTyped(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) :: e.t)
+      Success((preserveType(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) :: e.t)
   }
 
   // nested map + reduce
@@ -310,7 +310,7 @@ object movement {
 
       val result: ToBeTyped[Rise] = (fun(x =>
         (reduceSeq(fun((acc, y) =>
-          map(fun(a => isTyped(op)(a._1)(a._2))) $ zip(acc)(y)
+          map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
         ))(x._1 :: resultT) o // x._1 :: 2D array
           // transpose2D
           transpose o map(transpose) $ x._2)) o
@@ -340,7 +340,7 @@ object movement {
         (fun(x =>
           reduceSeq(
             fun((acc, y) => // acc::32.float, y::32.(float,float)
-              map(fun(a => isTyped(op)(a._1)(a._2))) $ zip(acc)(y)
+              map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
             )
           )(x._1 :: resultT) o
             transpose $ x._2) o unzip) :: e.t

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -386,9 +386,9 @@ object movement {
           // todo implement recursively
           val reduceArgTransposed: TDSL[Rise] = inputT match {
             case ArrayType(_, ArrayType(_, ArrayType(_,ArrayType(_,_)))) =>
-              transpose.apply >> map(transpose.apply) >> map(map(transpose))
+              transpose o map(transpose) o map(map(transpose))
             case ArrayType(_, ArrayType(_, ArrayType(_,_))) =>
-              transpose.apply >> map(transpose)
+              transpose o map(transpose)
             case ArrayType(_, ArrayType(_,_)) => transpose
             case _ => ???
           }

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -35,7 +35,7 @@ object movement {
     case e@App(
       transpose(),
       App(App(map(), App(map(), f)), y)) =>
-        Success((typed(y) |> transpose |> map(map(f))) :: e.t)
+        Success((isTyped(y) |> transpose |> map(map(f))) :: e.t)
     // LCNF
     case e@App(transpose(),
     App(
@@ -44,13 +44,13 @@ object movement {
       arg)
     ) if etaReduction()(ev)(lamA) && etaReduction()(ev)(lamB) =>
       // Success((typed(arg) |> transpose |> map(map(f))) :: e.t)
-      Success((typed(arg) |> transpose |> map(fun(a => map(fun(b => typed(f)(b)))(a)))) :: e.t)
+      Success((isTyped(arg) |> transpose |> map(fun(a => map(fun(b => isTyped(f)(b)))(a)))) :: e.t)
   }
 
   def transposeBeforeMapMapF: Strategy[Rise] = `T >> **f -> **f >> T`
   @rule def `T >> **f -> **f >> T`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(transpose(), y)) =>
-      Success((typed(y) |> map(map(f)) |> transpose) :: e.t)
+      Success((isTyped(y) |> map(map(f)) |> transpose) :: e.t)
   }
 
 
@@ -65,19 +65,19 @@ object movement {
   def slideBeforeMapMapF: Strategy[Rise] = `S >> **f -> *f >> S`
   @rule def `S >> **f -> *f >> S`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(s, y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> map(f) |> untyped(s)) :: e.t)
+      Success((isTyped(y) |> map(f) |> eraseType(s)) :: e.t)
   }
 
   def slideBeforeMap: Strategy[Rise] = `*f >> S -> S >> **f`
   @rule def `*f >> S -> S >> **f`: Strategy[Rise] = {
     case e@App(s @ DepApp(DepApp(slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
-      Success((typed(y) |> untyped(s) |> map(map(f))) :: e.t)
+      Success((isTyped(y) |> eraseType(s) |> map(map(f))) :: e.t)
   }
 
   // *f >> S -> S >> **f
   @rule def splitBeforeMap: Strategy[Rise] = {
     case e@App(s @ DepApp(split(), _: Nat), App(App(map(), f), y)) =>
-      Success((typed(y) |> untyped(s) |> map(map(f))) :: e.t)
+      Success((isTyped(y) |> eraseType(s) |> map(map(f))) :: e.t)
   }
 
   // join
@@ -85,13 +85,13 @@ object movement {
   def joinBeforeMapF: Strategy[Rise] = `J >> *f -> **f >> J`
   @rule def `J >> *f -> **f >> J`: Strategy[Rise] = {
     case e@App(App(map(), f),App(join(), y)) =>
-      Success((typed(y) |> map(map(f)) >> join) :: e.t)
+      Success((isTyped(y) |> map(map(f)) >> join) :: e.t)
   }
 
   def mapMapFBeforeJoin: Strategy[Rise] = `**f >> J -> J >> *f`
   @rule def `**f >> J -> J >> *f`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), App(map(), f)), y)) =>
-      Success((typed(y) |> join |> map(f)) :: e.t)
+      Success((isTyped(y) |> join |> map(f)) :: e.t)
   }
 
   // drop and take
@@ -99,13 +99,13 @@ object movement {
   def dropBeforeMap: Strategy[Rise] = `*f >> drop n -> drop n >> *f`
   @rule def `*f >> drop n -> drop n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(drop(n), typed(in))) :: expr.t)
+      Success(app(map(f), app(drop(n), isTyped(in))) :: expr.t)
   }
 
   def takeBeforeMap: Strategy[Rise] = `*f >> take n -> take n >> *f`
   @rule def `*f >> take n -> take n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(take(n), typed(in))) :: expr.t)
+      Success(app(map(f), app(take(n), isTyped(in))) :: expr.t)
   }
 
   // take n >> *f -> *f >> take n
@@ -158,13 +158,13 @@ object movement {
   def dropBeforeTake: Strategy[Rise] = `take (n+m) >> drop m -> drop m >> take n`
   @rule def `take (n+m) >> drop m -> drop m >> take n`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), m: Nat), App(DepApp(take(), nm: Nat), in)) =>
-      Success(app(take(nm - m), app(drop(m), typed(in))) :: expr.t)
+      Success(app(take(nm - m), app(drop(m), isTyped(in))) :: expr.t)
   }
 
   def takeBeforeDrop: Strategy[Rise] = `drop m >> take n -> take (n+m) >> drop m`
   @rule def `drop m >> take n -> take (n+m) >> drop m`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(DepApp(drop(), m: Nat), in)) =>
-      Success(app(drop(m), app(take(n+m), typed(in))) :: expr.t)
+      Success(app(drop(m), app(take(n+m), isTyped(in))) :: expr.t)
   }
 
   def takeBeforeSlide: Strategy[Rise] = `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`
@@ -212,7 +212,7 @@ object movement {
     case e @ App(DepApp(padEmpty(), n: Nat),
       App(App(zip(), App(fst(), e1)), App(snd(), e2)))
     if e1 == e2 =>
-      Success((typed(e1) |>
+      Success((isTyped(e1) |>
         mapFst(padEmpty(n)) |> mapSnd(padEmpty(n)) |>
         fun(p => zip(fst(p))(snd(p)))) :: e.t)
   }
@@ -223,19 +223,19 @@ object movement {
   def transposeBeforeSlide: Strategy[Rise] = `T >> S -> *S >> T >> *T`
   @rule def `T >> S -> *S >> T >> *T`: Strategy[Rise] = {
     case e@App(s, App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> map(untyped(s)) |> transpose.apply |> map(transpose)) :: e.t)
+      Success((isTyped(y) |> map(eraseType(s)) |> transpose.apply |> map(transpose)) :: e.t)
   }
 
   def transposeBeforeMapSlide: Strategy[Rise] = `T >> *S -> S >> *T >> T`
   @rule def `T >> *S -> S >> *T >> T`: Strategy[Rise] = {
     case e@App(App(map(), s), App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> untyped(s) |> map(transpose) |> transpose) :: e.t)
+      Success((isTyped(y) |> eraseType(s) |> map(transpose) |> transpose) :: e.t)
   }
 
   def mapSlideBeforeTranspose: Strategy[Rise] = `*S >> T -> T >> S >> *T`
   @rule def `*S >> T -> T >> S >> *T`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), s), y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> transpose.apply |> untyped(s) |> map(transpose)) :: e.t)
+      Success((isTyped(y) |> transpose.apply |> eraseType(s) |> map(transpose)) :: e.t)
   }
 
   // transpose + join
@@ -243,25 +243,25 @@ object movement {
   def joinBeforeTranspose: Strategy[Rise] = `J >> T -> *T >> T >> *J`
   @rule def `J >> T -> *T >> T >> *J`: Strategy[Rise] = {
     case e@App(transpose(), App(join(), y)) =>
-      Success((typed(y) |> map(transpose) |> transpose |> map(join)) :: e.t)
+      Success((isTyped(y) |> map(transpose) |> transpose |> map(join)) :: e.t)
   }
 
   def transposeBeforeMapJoin: Strategy[Rise] = `T >> *J -> *T >> J >> T`
   @rule def `T >> *J -> *T >> J >> T`: Strategy[Rise] = {
     case e@App(App(map(), join()), App(transpose(), y)) =>
-      Success((typed(y) |> map(transpose) |> join |> transpose) :: e.t)
+      Success((isTyped(y) |> map(transpose) |> join |> transpose) :: e.t)
   }
 
   def mapTransposeBeforeJoin: Strategy[Rise] = `*T >> J -> T >> *J >> T`
   @rule def `*T >> J -> T >> *J >> T`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), transpose()), y)) =>
-      Success((typed(y) |> transpose |> map(join) |> transpose) :: e.t)
+      Success((isTyped(y) |> transpose |> map(join) |> transpose) :: e.t)
   }
 
   def mapJoinBeforeTranspose: Strategy[Rise] = `*J >> T -> T >> *T >> J`
   @rule def `*J >> T -> T >> *T >> J`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), join()), y)) =>
-      Success((typed(y) |> transpose |> map(transpose) |> join) :: e.t)
+      Success((isTyped(y) |> transpose |> map(transpose) |> join) :: e.t)
   }
 
   // join + join
@@ -269,13 +269,13 @@ object movement {
   def joinBeforeJoin: Strategy[Rise] = `J >> J -> *J >> J`
   @rule def `J >> J -> *J >> J`: Strategy[Rise] = {
     case e@App(join(), App(join(), y)) =>
-      Success((typed(y) |> map(join) >> join) :: e.t)
+      Success((isTyped(y) |> map(join) >> join) :: e.t)
   }
 
   def mapJoinBeforeJoin: Strategy[Rise] = `*J >> J -> J >> J`
   @rule def `*J >> J -> J >> J`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), join()), y)) =>
-      Success((typed(y) |> join |> join) :: e.t)
+      Success((isTyped(y) |> join |> join) :: e.t)
   }
 
   // split + slide
@@ -283,7 +283,7 @@ object movement {
   def slideBeforeSplit: Strategy[Rise] = `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`
   @rule def `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`: Strategy[Rise] = {
     case e@App(DepApp(split(), k: Nat), App(DepApp(DepApp(slide(), n: Nat), s: Nat), y)) =>
-      Success((typed(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) :: e.t)
+      Success((isTyped(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) :: e.t)
   }
 
   // TODO: what if s != 1?
@@ -292,7 +292,7 @@ object movement {
     case e@App(DepApp(DepApp(slide(), m: Nat), k: Nat),
             App(DepApp(DepApp(slide(), n: Nat), s: Nat), in)
          ) if s == (1: Nat) =>
-      Success((typed(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) :: e.t)
+      Success((isTyped(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) :: e.t)
   }
 
   // nested map + reduce
@@ -308,9 +308,9 @@ object movement {
     // PairType is new here
     )) ::: FunType(ArrayType(_, ArrayType(_,PairType(_,_))), resultT) =>
 
-      val result: TDSL[Rise] = (fun(x =>
+      val result: ToBeTyped[Rise] = (fun(x =>
         (reduceSeq(fun((acc, y) =>
-          map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc)(y)
+          map(fun(a => isTyped(op)(a._1)(a._2))) $ zip(acc)(y)
         ))(x._1 :: resultT) o // x._1 :: 2D array
           // transpose2D
           transpose o map(transpose) $ x._2)) o
@@ -336,11 +336,11 @@ object movement {
     ) ::: FunType(PairType(_,ArrayType(_,_)), _) // lambda.t
     ) ::: FunType(ArrayType(_,_), resultT) =>    // outermost app.t
 
-      val result: TDSL[Rise] =
+      val result: ToBeTyped[Rise] =
         (fun(x =>
           reduceSeq(
             fun((acc, y) => // acc::32.float, y::32.(float,float)
-              map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc)(y)
+              map(fun(a => isTyped(op)(a._1)(a._2))) $ zip(acc)(y)
             )
           )(x._1 :: resultT) o
             transpose $ x._2) o unzip) :: e.t
@@ -354,10 +354,10 @@ object movement {
          init ::: (dt: DataType)), reduceArg)
     )) ::: FunType(inputT@ArrayType(size, ArrayType(_,_)), _) =>
 
-    def reduceMap(zippedMapArg : (TDSL[Rise], TDSL[Rise]) => TDSL[Rise],
-                  reduceArgFun: TDSL[Rise]): RewriteResult[Rise] = {
+    def reduceMap(zippedMapArg : (ToBeTyped[Rise], ToBeTyped[Rise]) => ToBeTyped[Rise],
+                  reduceArgFun: ToBeTyped[Rise]): RewriteResult[Rise] = {
         Success((
-          untyped(rx)(fun((acc, y) =>
+          eraseType(rx)(fun((acc, y) =>
             map(fun(x => app(app(op, fst(x)), snd(x)))) $ zippedMapArg(acc, y)
           ))(generate(fun(IndexType(size) ->: dt)(_ => init))) o reduceArgFun
         ) :: e.t)
@@ -384,7 +384,7 @@ object movement {
 
         case _ =>
           // todo implement recursively
-          val reduceArgTransposed: TDSL[Rise] = inputT match {
+          val reduceArgTransposed: ToBeTyped[Rise] = inputT match {
             case ArrayType(_, ArrayType(_, ArrayType(_,ArrayType(_,_)))) =>
               transpose o map(transpose) o map(map(transpose))
             case ArrayType(_, ArrayType(_, ArrayType(_,_))) =>

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -33,14 +33,14 @@ object movement {
   def mapMapFBeforeTranspose()(implicit ev: Traversable[Rise]): Strategy[Rise] = `**f >> T -> T >> **f`()(ev)
   @rule def `**f >> T -> T >> **f`()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
     case e@App(
-      Transpose(),
-      App(App(Map(), App(Map(), f)), y)) =>
+      transpose(),
+      App(App(map(), App(map(), f)), y)) =>
         Success((typed(y) |> transpose |> map(map(f))) :: e.t)
     // LCNF
-    case e@App(Transpose(),
+    case e@App(transpose(),
     App(
-      App(Map(), lamA @ Lambda(_, App(
-              App(Map(), lamB @ Lambda(_, App(f, _))), _))),
+      App(map(), lamA @ Lambda(_, App(
+              App(map(), lamB @ Lambda(_, App(f, _))), _))),
       arg)
     ) if etaReduction()(ev)(lamA) && etaReduction()(ev)(lamB) =>
       // Success((typed(arg) |> transpose |> map(map(f))) :: e.t)
@@ -49,7 +49,7 @@ object movement {
 
   def transposeBeforeMapMapF: Strategy[Rise] = `T >> **f -> **f >> T`
   @rule def `T >> **f -> **f >> T`: Strategy[Rise] = {
-    case e@App(App(Map(), App(Map(), f)), App(Transpose(), y)) =>
+    case e@App(App(map(), App(map(), f)), App(transpose(), y)) =>
       Success((typed(y) |> map(map(f)) |> transpose) :: e.t)
   }
 
@@ -57,26 +57,26 @@ object movement {
   // split/slide
 
   def isSplitOrSlide(s: Expr): Boolean = s match {
-    case DepApp(DepApp(Slide(), _: Nat), _: Nat) => true
-    case DepApp(Split(), _: Nat)                 => true
+    case DepApp(DepApp(slide(), _: Nat), _: Nat) => true
+    case DepApp(split(), _: Nat)                 => true
     case _                                       => false
   }
 
   def slideBeforeMapMapF: Strategy[Rise] = `S >> **f -> *f >> S`
   @rule def `S >> **f -> *f >> S`: Strategy[Rise] = {
-    case e@App(App(Map(), App(Map(), f)), App(s, y)) if isSplitOrSlide(s) =>
+    case e@App(App(map(), App(map(), f)), App(s, y)) if isSplitOrSlide(s) =>
       Success((typed(y) |> map(f) |> untyped(s)) :: e.t)
   }
 
   def slideBeforeMap: Strategy[Rise] = `*f >> S -> S >> **f`
   @rule def `*f >> S -> S >> **f`: Strategy[Rise] = {
-    case e@App(s @ DepApp(DepApp(Slide(), _: Nat), _: Nat), App(App(Map(), f), y)) =>
+    case e@App(s @ DepApp(DepApp(slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
       Success((typed(y) |> untyped(s) |> map(map(f))) :: e.t)
   }
 
   // *f >> S -> S >> **f
   @rule def splitBeforeMap: Strategy[Rise] = {
-    case e@App(s @ DepApp(Split(), _: Nat), App(App(Map(), f), y)) =>
+    case e@App(s @ DepApp(split(), _: Nat), App(App(map(), f), y)) =>
       Success((typed(y) |> untyped(s) |> map(map(f))) :: e.t)
   }
 
@@ -84,13 +84,13 @@ object movement {
 
   def joinBeforeMapF: Strategy[Rise] = `J >> *f -> **f >> J`
   @rule def `J >> *f -> **f >> J`: Strategy[Rise] = {
-    case e@App(App(Map(), f),App(Join(), y)) =>
+    case e@App(App(map(), f),App(join(), y)) =>
       Success((typed(y) |> map(map(f)) >> join) :: e.t)
   }
 
   def mapMapFBeforeJoin: Strategy[Rise] = `**f >> J -> J >> *f`
   @rule def `**f >> J -> J >> *f`: Strategy[Rise] = {
-    case e@App(Join(), App(App(Map(), App(Map(), f)), y)) =>
+    case e@App(join(), App(App(map(), App(map(), f)), y)) =>
       Success((typed(y) |> join |> map(f)) :: e.t)
   }
 
@@ -98,123 +98,123 @@ object movement {
 
   def dropBeforeMap: Strategy[Rise] = `*f >> drop n -> drop n >> *f`
   @rule def `*f >> drop n -> drop n >> *f`: Strategy[Rise] = {
-    case expr @ App(DepApp(Drop(), n: Nat), App(App(Map(), f), in)) =>
+    case expr @ App(DepApp(drop(), n: Nat), App(App(map(), f), in)) =>
       Success(app(map(f), app(drop(n), typed(in))) :: expr.t)
   }
 
   def takeBeforeMap: Strategy[Rise] = `*f >> take n -> take n >> *f`
   @rule def `*f >> take n -> take n >> *f`: Strategy[Rise] = {
-    case expr @ App(DepApp(Take(), n: Nat), App(App(Map(), f), in)) =>
+    case expr @ App(DepApp(take(), n: Nat), App(App(map(), f), in)) =>
       Success(app(map(f), app(take(n), typed(in))) :: expr.t)
   }
 
   // take n >> *f -> *f >> take n
   @rule def takeAfterMap: Strategy[Rise] = {
-    case e @ App(App(Map(), f), App(DepApp(Take(), n: Nat), in)) =>
-      Success(take(n)(map(f, in)) :: e.t)
+    case e @ App(App(map(), f), App(DepApp(take(), n: Nat), in)) =>
+      Success(take(n)(map(f)(in)) :: e.t)
   }
 
   def takeInZip: Strategy[Rise] = `take n (zip a b) -> zip (take n a) (take n b)`
   @rule def `take n (zip a b) -> zip (take n a) (take n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(Take(), n), App(App(Zip(), a), b)) =>
-      Success(zip(depApp(take, n)(a), depApp(take, n)(b)) :: expr.t)
+    case expr @ App(DepApp(take(), n), App(App(zip(), a), b)) =>
+      Success(zip(depApp(take, n)(a))(depApp(take, n)(b)) :: expr.t)
   }
 
   // zip (take n a) (take n b) -> take n (zip a b)
   @rule def takeOutisdeZip: Strategy[Rise] = {
-    case e @ App(App(Zip(),
-      App(DepApp(Take(), n1: Nat), a)), App(DepApp(Take(), n2: Nat), b)
+    case e @ App(App(zip(),
+      App(DepApp(take(), n1: Nat), a)), App(DepApp(take(), n2: Nat), b)
     ) if n1 == n2 =>
-      Success(take(n1)(zip(a, b)) :: e.t)
+      Success(take(n1)(zip(a)(b)) :: e.t)
   }
 
   // pair (take n a) (take m b) -> pair a b >> mapFst take n >> mapSnd take m
   // TODO: can get any function out, see asScalarOutsidePair
   @rule def takeOutsidePair: Strategy[Rise] = {
-    case e @ App(App(Pair(),
-      App(DepApp(Take(), n: Nat), a)), App(DepApp(Take(), m: Nat), b)
+    case e @ App(App(pair(),
+      App(DepApp(take(), n: Nat), a)), App(DepApp(take(), m: Nat), b)
     ) =>
-      Success((pair(a, b) |> mapFst(take(n)) |> mapSnd(take(m))) :: e.t)
+      Success((pair(a)(b) |> mapFst(take(n)) |> mapSnd(take(m))) :: e.t)
   }
 
   def dropInZip: Strategy[Rise] = `drop n (zip a b) -> zip (drop n a) (drop n b)`
   @rule def `drop n (zip a b) -> zip (drop n a) (drop n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(Drop(), n), App(App(Zip(), a), b)) =>
-      Success(zip(depApp(drop, n)(a), depApp(drop, n)(b)) :: expr.t)
+    case expr @ App(DepApp(drop(), n), App(App(zip(), a), b)) =>
+      Success(zip(depApp(drop, n)(a))(depApp(drop, n)(b)) :: expr.t)
   }
 
   def takeInSelect: Strategy[Rise] = `take n (select t a b) -> select t (take n a) (take n b)`
   @rule def `take n (select t a b) -> select t (take n a) (take n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(Take(), n), App(App(App(Select(), t), a), b)) =>
-      Success(select(t, depApp(take, n)(a), depApp(take, n)(b)) :: expr.t)
+    case expr @ App(DepApp(take(), n), App(App(App(select(), t), a), b)) =>
+      Success(select(t)(depApp(take, n)(a), depApp(take, n)(b)) :: expr.t)
   }
 
   def dropInSelect: Strategy[Rise] = `drop n (select t a b) -> select t (drop n a) (drop n b)`
   @rule def `drop n (select t a b) -> select t (drop n a) (drop n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(Drop(), n), App(App(App(Select(), t), a), b)) =>
-      Success(select(t, depApp(drop, n)(a), depApp(drop, n)(b)) :: expr.t)
+    case expr @ App(DepApp(drop(), n), App(App(App(select(), t), a), b)) =>
+      Success(select(t)(depApp(drop, n)(a), depApp(drop, n)(b)) :: expr.t)
   }
 
   def dropBeforeTake: Strategy[Rise] = `take (n+m) >> drop m -> drop m >> take n`
   @rule def `take (n+m) >> drop m -> drop m >> take n`: Strategy[Rise] = {
-    case expr @ App(DepApp(Drop(), m: Nat), App(DepApp(Take(), nm: Nat), in)) =>
+    case expr @ App(DepApp(drop(), m: Nat), App(DepApp(take(), nm: Nat), in)) =>
       Success(app(take(nm - m), app(drop(m), typed(in))) :: expr.t)
   }
 
   def takeBeforeDrop: Strategy[Rise] = `drop m >> take n -> take (n+m) >> drop m`
   @rule def `drop m >> take n -> take (n+m) >> drop m`: Strategy[Rise] = {
-    case expr @ App(DepApp(Take(), n: Nat), App(DepApp(Drop(), m: Nat), in)) =>
+    case expr @ App(DepApp(take(), n: Nat), App(DepApp(drop(), m: Nat), in)) =>
       Success(app(drop(m), app(take(n+m), typed(in))) :: expr.t)
   }
 
   def takeBeforeSlide: Strategy[Rise] = `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`
   @rule def `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`: Strategy[Rise] = {
-    case expr @ App(DepApp(Take(), t: Nat), App(DepApp(DepApp(Slide(), n: Nat), m: Nat), in)) =>
+    case expr @ App(DepApp(take(), t: Nat), App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)) =>
       Success(app(slide(n)(m), take(m * (t - 1) + n)(in)) :: expr.t)
   }
 
   def dropBeforeSlide: Strategy[Rise] = `slide n m >> drop d -> drop (d * m) >> slide n m`
   @rule def `slide n m >> drop d -> drop (d * m) >> slide n m`: Strategy[Rise] = {
-    case expr @ App(DepApp(Drop(), d: Nat), App(DepApp(DepApp(Slide(), n: Nat), m: Nat), in)) =>
+    case expr @ App(DepApp(drop(), d: Nat), App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)) =>
       Success(app(slide(n)(m), drop(d * m)(in)) :: expr.t)
   }
 
   // slide n m >> padEmpty p -> padEmpty (p * m) >> slide n m
   @rule def padEmptyBeforeSlide: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), p: Nat),
-      App(DepApp(DepApp(Slide(), n: Nat), m: Nat), in)
+    case e @ App(DepApp(padEmpty(), p: Nat),
+      App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)
     ) =>
       Success(slide(n)(m)(padEmpty(p * m)(in)) :: e.t)
   }
 
   // map f >> padEmpty n -> padEmpty n >> map f
   @rule def padEmptyBeforeMap: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), n: Nat), App(App(Map(), f), in)) =>
-      Success(map(f, padEmpty(n)(in)) :: e.t)
+    case e @ App(DepApp(padEmpty(), n: Nat), App(App(map(), f), in)) =>
+      Success(map(f)(padEmpty(n)(in)) :: e.t)
   }
 
   // transpose >> padEmpty n -> map (padEmpty n) >> transpose
   @rule def padEmptyBeforeTranspose: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), n: Nat), App(Transpose(), in)) =>
-      Success(transpose(map(padEmpty(n), in)) :: e.t)
+    case e @ App(DepApp(padEmpty(), n: Nat), App(transpose(), in)) =>
+      Success(transpose(map(padEmpty(n))(in)) :: e.t)
   }
 
   // padEmpty n (zip a b) -> zip (padEmpty n a) (padEmpty n b)
   @rule def padEmptyInsideZip: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), n: Nat), App(App(Zip(), a), b)) =>
-      Success(zip(padEmpty(n)(a), padEmpty(n)(b)) :: e.t)
+    case e @ App(DepApp(padEmpty(), n: Nat), App(App(zip(), a), b)) =>
+      Success(zip(padEmpty(n)(a))(padEmpty(n)(b)) :: e.t)
   }
 
   // FIXME: this is very specific
   // zip (fst e) (snd e) |> padEmpty n ->
   // (mapFst padEmpty n) (mapSnd padEmpty n) |> fun(p => zip (fst p) (snd(p))
   @rule def padEmptyBeforeZip: Strategy[Rise] = {
-    case e @ App(DepApp(PadEmpty(), n: Nat),
-      App(App(Zip(), App(Fst(), e1)), App(Snd(), e2)))
+    case e @ App(DepApp(padEmpty(), n: Nat),
+      App(App(zip(), App(fst(), e1)), App(snd(), e2)))
     if e1 == e2 =>
       Success((typed(e1) |>
         mapFst(padEmpty(n)) |> mapSnd(padEmpty(n)) |>
-        fun(p => zip(fst(p), snd(p)))) :: e.t)
+        fun(p => zip(fst(p))(snd(p)))) :: e.t)
   }
 
   // special-cases
@@ -222,45 +222,45 @@ object movement {
 
   def transposeBeforeSlide: Strategy[Rise] = `T >> S -> *S >> T >> *T`
   @rule def `T >> S -> *S >> T >> *T`: Strategy[Rise] = {
-    case e@App(s, App(Transpose(), y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> map(untyped(s)) |> transpose >> map(transpose)) :: e.t)
+    case e@App(s, App(transpose(), y)) if isSplitOrSlide(s) =>
+      Success((typed(y) |> map(untyped(s)) |> transpose.apply |> map(transpose)) :: e.t)
   }
 
   def transposeBeforeMapSlide: Strategy[Rise] = `T >> *S -> S >> *T >> T`
   @rule def `T >> *S -> S >> *T >> T`: Strategy[Rise] = {
-    case e@App(App(Map(), s), App(Transpose(), y)) if isSplitOrSlide(s) =>
+    case e@App(App(map(), s), App(transpose(), y)) if isSplitOrSlide(s) =>
       Success((typed(y) |> untyped(s) |> map(transpose) |> transpose) :: e.t)
   }
 
   def mapSlideBeforeTranspose: Strategy[Rise] = `*S >> T -> T >> S >> *T`
   @rule def `*S >> T -> T >> S >> *T`: Strategy[Rise] = {
-    case e@App(Transpose(), App(App(Map(), s), y)) if isSplitOrSlide(s) =>
-      Success((typed(y) |> transpose >> untyped(s) >> map(transpose)) :: e.t)
+    case e@App(transpose(), App(App(map(), s), y)) if isSplitOrSlide(s) =>
+      Success((typed(y) |> transpose.apply |> untyped(s) |> map(transpose)) :: e.t)
   }
 
   // transpose + join
 
   def joinBeforeTranspose: Strategy[Rise] = `J >> T -> *T >> T >> *J`
   @rule def `J >> T -> *T >> T >> *J`: Strategy[Rise] = {
-    case e@App(Transpose(), App(Join(), y)) =>
+    case e@App(transpose(), App(join(), y)) =>
       Success((typed(y) |> map(transpose) |> transpose |> map(join)) :: e.t)
   }
 
   def transposeBeforeMapJoin: Strategy[Rise] = `T >> *J -> *T >> J >> T`
   @rule def `T >> *J -> *T >> J >> T`: Strategy[Rise] = {
-    case e@App(App(Map(), Join()), App(Transpose(), y)) =>
+    case e@App(App(map(), join()), App(transpose(), y)) =>
       Success((typed(y) |> map(transpose) |> join |> transpose) :: e.t)
   }
 
   def mapTransposeBeforeJoin: Strategy[Rise] = `*T >> J -> T >> *J >> T`
   @rule def `*T >> J -> T >> *J >> T`: Strategy[Rise] = {
-    case e@App(Join(), App(App(Map(), Transpose()), y)) =>
+    case e@App(join(), App(App(map(), transpose()), y)) =>
       Success((typed(y) |> transpose |> map(join) |> transpose) :: e.t)
   }
 
   def mapJoinBeforeTranspose: Strategy[Rise] = `*J >> T -> T >> *T >> J`
   @rule def `*J >> T -> T >> *T >> J`: Strategy[Rise] = {
-    case e@App(Transpose(), App(App(Map(), Join()), y)) =>
+    case e@App(transpose(), App(App(map(), join()), y)) =>
       Success((typed(y) |> transpose |> map(transpose) |> join) :: e.t)
   }
 
@@ -268,13 +268,13 @@ object movement {
 
   def joinBeforeJoin: Strategy[Rise] = `J >> J -> *J >> J`
   @rule def `J >> J -> *J >> J`: Strategy[Rise] = {
-    case e@App(Join(), App(Join(), y)) =>
+    case e@App(join(), App(join(), y)) =>
       Success((typed(y) |> map(join) >> join) :: e.t)
   }
 
   def mapJoinBeforeJoin: Strategy[Rise] = `*J >> J -> J >> J`
   @rule def `*J >> J -> J >> J`: Strategy[Rise] = {
-    case e@App(Join(), App(App(Map(), Join()), y)) =>
+    case e@App(join(), App(App(map(), join()), y)) =>
       Success((typed(y) |> join |> join) :: e.t)
   }
 
@@ -282,15 +282,15 @@ object movement {
 
   def slideBeforeSplit: Strategy[Rise] = `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`
   @rule def `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`: Strategy[Rise] = {
-    case e@App(DepApp(Split(), k: Nat), App(DepApp(DepApp(Slide(), n: Nat), s: Nat), y)) =>
+    case e@App(DepApp(split(), k: Nat), App(DepApp(DepApp(slide(), n: Nat), s: Nat), y)) =>
       Success((typed(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) :: e.t)
   }
 
   // TODO: what if s != 1?
   // slide(n)(s=1) >> slide(m)(k) -> slide(m+n-1)(k) >> map(slide(n)(1))
   @rule def slideBeforeSlide: Strategy[Rise] = {
-    case e@App(DepApp(DepApp(Slide(), m: Nat), k: Nat),
-            App(DepApp(DepApp(Slide(), n: Nat), s: Nat), in)
+    case e@App(DepApp(DepApp(slide(), m: Nat), k: Nat),
+            App(DepApp(DepApp(slide(), n: Nat), s: Nat), in)
          ) if s == (1: Nat) =>
       Success((typed(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) :: e.t)
   }
@@ -302,7 +302,7 @@ object movement {
   @rule def liftReduce: Strategy[Rise] = {
 
      // 2D array of pairs ----------------------------------------------------
-    case e@App(Map(), Lambda(_,
+    case e@App(map(), Lambda(_,
     App(App(App(ReduceX(), op),
     _), _)
     // PairType is new here
@@ -310,7 +310,7 @@ object movement {
 
       val result: TDSL[Rise] = (fun(x =>
         (reduceSeq(fun((acc, y) =>
-          map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc,y)
+          map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc)(y)
         ))(x._1 :: resultT) o // x._1 :: 2D array
           // transpose2D
           transpose o map(transpose) $ x._2)) o
@@ -327,7 +327,7 @@ object movement {
   (32.float, 4.32.(float,float)) [transpose $ x._2]
   now reducing (map(+)) x._2, using x_.1 as init,
    */
-    case e@App(Map(), Lambda(_,
+    case e@App(map(), Lambda(_,
     App(_, // <- this function contained add, do I need this? ...
     // or can we get rid of this somehow?
     App(App(App(ReduceX(), op), _), _))
@@ -340,7 +340,7 @@ object movement {
         (fun(x =>
           reduceSeq(
             fun((acc, y) => // acc::32.float, y::32.(float,float)
-              map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc,y)
+              map(fun(a => typed(op)(a._1)(a._2))) $ zip(acc)(y)
             )
           )(x._1 :: resultT) o
             transpose $ x._2) o unzip) :: e.t
@@ -349,8 +349,8 @@ object movement {
 
       // "usual" case below --------------------------------------------------
       // this case already works for multiple dimensions (taken from old repo)
-    case e@App(Map(), Lambda(mapVar,
-         App(App(App(rx@(Reduce() | ReduceSeq()), op),
+    case e@App(map(), Lambda(mapVar,
+         App(App(App(rx@(reduce() | reduceSeq()), op),
          init ::: (dt: DataType)), reduceArg)
     )) ::: FunType(inputT@ArrayType(size, ArrayType(_,_)), _) =>
 
@@ -367,15 +367,15 @@ object movement {
         // simple case (see test "lift reduce")
         case x if x == mapVar =>
           reduceMap(
-            (acc, y) => zip(acc, y),
+            (acc, y) => zip(acc)(y),
             transpose
           )
         // zipped input (see test "MM to MM-LoopMKN")
-        case App(App(Zip(), u), v) =>
+        case App(App(zip(), u), v) =>
           val notToBeTransposed = if (mapVar == u) v else u
           reduceMap(
             zippedMapArg = (acc, y) =>
-              zip(acc, map(fun(bs => pair(bs, fst(y)))) $ snd(y)),
+              zip(acc)(map(fun(bs => pair(bs)(fst(y)))) $ snd(y)),
             reduceArgFun = zip(notToBeTransposed) o transpose
           )
 
@@ -384,17 +384,17 @@ object movement {
 
         case _ =>
           // todo implement recursively
-          val reduceArgTransposed = inputT match {
+          val reduceArgTransposed: TDSL[Rise] = inputT match {
             case ArrayType(_, ArrayType(_, ArrayType(_,ArrayType(_,_)))) =>
-              transpose o map(transpose) o map(map(transpose))
+              transpose.apply >> map(transpose.apply) >> map(map(transpose))
             case ArrayType(_, ArrayType(_, ArrayType(_,_))) =>
-              transpose o map(transpose)
+              transpose.apply >> map(transpose)
             case ArrayType(_, ArrayType(_,_)) => transpose
             case _ => ???
           }
 
           val result = reduceMap(
-            (acc, y) => zip(acc, y),
+            (acc, y) => zip(acc)(y),
             reduceArgTransposed
           )
           result
@@ -403,7 +403,7 @@ object movement {
 
   // mapSnd f >> mapFst g -> mapFst g >> mapSnd f
   @rule def mapFstBeforeMapSnd: Strategy[Rise] = {
-    case e @ App(App(MapFst(), g), App(App(MapSnd(), f), in)) =>
-      Success(mapSnd(f)(mapFst(g, in)) :: e.t)
+    case e @ App(App(mapFst(), g), App(App(mapSnd(), f), in)) =>
+      Success(mapSnd(f)(mapFst(g)(in)) :: e.t)
   }
 }

--- a/src/main/scala/rise/elevate/rules/package.scala
+++ b/src/main/scala/rise/elevate/rules/package.scala
@@ -29,7 +29,7 @@ package object rules {
   def gentleBetaReduction()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
     case App(Lambda(x, b), v: Identifier) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
-    case App(Lambda(x, b), v @ App(App(primitives.Pair(), _), _)) =>
+    case App(Lambda(x, b), v @ App(App(primitives.pair(), _), _)) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
     case App(Lambda(x, b), v) if !containsAtLeast(1, x)(ev)(b) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
@@ -58,7 +58,7 @@ package object rules {
 
     @scala.annotation.tailrec
     def isMakeArray(e: Rise): Boolean = e match {
-      case MakeArray(_) => true
+      case makeArray(_) => true
       case App(f, _) => isMakeArray(f)
       case _ => false
     }
@@ -71,7 +71,7 @@ package object rules {
     }
 
     e match {
-      case App(App(Idx(), Literal(IndexData(Cst(i), Cst(n)))), mka)
+      case App(App(idx(), Literal(IndexData(Cst(i), Cst(n)))), mka)
         if isMakeArray(mka) =>
         Success(indexMakeArray(mka, i, n))
       case _ =>

--- a/src/main/scala/rise/elevate/strategies/algorithmic.scala
+++ b/src/main/scala/rise/elevate/strategies/algorithmic.scala
@@ -36,7 +36,7 @@ object algorithmic {
           if (gx2 == x) {
             map(f2) >> map(f)
           } else {
-            mapFirstFissionRec(x, fun(e => f(isTyped(f2)(e))), gx2)
+            mapFirstFissionRec(x, fun(e => f(preserveType(f2)(e))), gx2)
           }
       }
     }

--- a/src/main/scala/rise/elevate/strategies/algorithmic.scala
+++ b/src/main/scala/rise/elevate/strategies/algorithmic.scala
@@ -30,13 +30,13 @@ object algorithmic {
     // TODO: this should be expressed with elevate strategies
     @silent
     @scala.annotation.tailrec
-    def mapFirstFissionRec(x: Identifier, f: TDSL[Rise], gx: Rise): TDSL[Rise] = {
+    def mapFirstFissionRec(x: Identifier, f: ToBeTyped[Rise], gx: Rise): ToBeTyped[Rise] = {
       gx match {
         case App(f2, gx2) =>
           if (gx2 == x) {
             map(f2) >> map(f)
           } else {
-            mapFirstFissionRec(x, fun(e => f(typed(f2)(e))), gx2)
+            mapFirstFissionRec(x, fun(e => f(isTyped(f2)(e))), gx2)
           }
       }
     }
@@ -52,7 +52,7 @@ object algorithmic {
   @strategy def mapFullFission: Strategy[Rise] = e => {
     // TODO: this should be expressed with elevate strategies
     @silent
-    def mapFullFissionRec(x: Identifier, gx: Rise): TDSL[Rise] = {
+    def mapFullFissionRec(x: Identifier, gx: Rise): ToBeTyped[Rise] = {
       gx match {
         case App(f, gx2) =>
           if (gx2 == x) {

--- a/src/main/scala/rise/elevate/strategies/algorithmic.scala
+++ b/src/main/scala/rise/elevate/strategies/algorithmic.scala
@@ -17,7 +17,7 @@ import rise.elevate.strategies.predicate.{isApplied, isMap, isReduceSeq}
 import rise.elevate.strategies.traversal.fmap
 import rise.core.TypedDSL._
 import rise.core._
-import rise.core.primitives.ReduceSeq
+import rise.core.primitives.{map, reduceSeq}
 import rise.elevate._
 
 object algorithmic {
@@ -42,7 +42,7 @@ object algorithmic {
     }
 
     e match {
-      case App(primitives.Map(), Lambda(x, gx)) => Success(mapFirstFissionRec(x, fun(e => e), gx) :: e.t)
+      case App(primitives.map(), Lambda(x, gx)) => Success(mapFirstFissionRec(x, fun(e => e), gx) :: e.t)
       case _                                    => Failure(mapFirstFission)
     }
   }
@@ -64,7 +64,7 @@ object algorithmic {
     }
 
     e match {
-      case App(primitives.Map(), Lambda(x, gx)) => Success(mapFullFissionRec(x, gx) :: e.t)
+      case App(primitives.map(), Lambda(x, gx)) => Success(mapFullFissionRec(x, gx) :: e.t)
       case _                                    => Failure(mapFullFission)
     }
   }
@@ -80,9 +80,9 @@ object algorithmic {
   @strategy def reorderRec(l: List[Int])(implicit ev: Traversable[Rise]): Strategy[Rise] = e => {
 
     def freduce(s: Strategy[Rise]): Strategy[Rise] =
-      function(function(argumentOf(ReduceSeq()(), body(body(s)))))
+      function(function(argumentOf(reduceSeq.primitive, body(body(s)))))
     def freduceX(s: Strategy[Rise]): Strategy[Rise] =
-      argument(function(function(argumentOf(ReduceSeq()(), body(body(s))))))
+      argument(function(function(argumentOf(reduceSeq.primitive, body(body(s))))))
     def stepDown(s: Strategy[Rise]): Strategy[Rise] = freduceX(s) <+ freduce(s) <+ fmap(s)
 
     val isFullyAppliedReduceSeq: Strategy[Rise] = isApplied(isApplied(isApplied(isReduceSeq))) <+

--- a/src/main/scala/rise/elevate/strategies/lowering.scala
+++ b/src/main/scala/rise/elevate/strategies/lowering.scala
@@ -18,7 +18,7 @@ object lowering {
 
         replaceAll(what, idx)(ev)(p) match {
           case Success(replaced) =>
-            Success(let(toMem(storedSubExpr))(lambda(TDSL(idx), replaced)) :: p.t)
+            Success(let(toMem(storedSubExpr))(lambda(ToBeTyped(idx), replaced)) :: p.t)
           case Failure(_) => Failure(storeInMemory(what, how))
         }
       })

--- a/src/main/scala/rise/elevate/strategies/lowering.scala
+++ b/src/main/scala/rise/elevate/strategies/lowering.scala
@@ -6,6 +6,7 @@ import elevate.core.strategies.traversal.tryAll
 import rise.elevate.Rise
 import rise.core.TypedDSL._
 import rise.core._
+import rise.core.primitives.{let, toMem}
 
 object lowering {
 

--- a/src/main/scala/rise/elevate/strategies/normalForm.scala
+++ b/src/main/scala/rise/elevate/strategies/normalForm.scala
@@ -6,7 +6,7 @@ import elevate.core.strategies.basic._
 import elevate.core.strategies.predicate._
 import elevate.core.strategies.traversal.one
 import elevate.macros.StrategyMacro.strategy
-import rise.core.primitives._
+import rise.core.{primitives => p}
 import rise.elevate.Rise
 import rise.elevate.rules._
 import rise.elevate.rules.algorithmic._
@@ -24,10 +24,10 @@ object normalForm {
   @strategy def DFNF()(implicit ev: Traversable[Rise]): Strategy[Rise] =
     (BENF() `;`
       // there is no argument of a map which is not eta-abstracted, i.e., every argument of a map is a lambda
-      normalize(ev)(argumentOf(Map()(), (not(isLambda) `;` etaAbstraction))) `;`
+      normalize(ev)(argumentOf(p.map.primitive, (not(isLambda) `;` etaAbstraction))) `;`
       // a reduce always contains two lambdas declaring y and acc
-      normalize(ev)(argumentOf(Reduce()(), (not(isLambda) `;` etaAbstraction))) `;`
-      normalize(ev)(argumentOf(Reduce()(), body((not(isLambda) `;` etaAbstraction)))) `;`
+      normalize(ev)(argumentOf(p.reduce.primitive, (not(isLambda) `;` etaAbstraction))) `;`
+      normalize(ev)(argumentOf(p.reduce.primitive, body((not(isLambda) `;` etaAbstraction)))) `;`
       // there is no map(f) without an argument == there is no way to get to a map without visiting two applies
       // same for reduce and three applies
       normalize(ev)(

--- a/src/main/scala/rise/elevate/strategies/predicate.scala
+++ b/src/main/scala/rise/elevate/strategies/predicate.scala
@@ -32,7 +32,7 @@ object predicate {
 
   case object isMakeArray extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case m: MakeArray => Success(m)
+      case m@makeArray(_) => Success(m)
       case _            => Failure(isMakeArray)
     }
     override def toString: String = "isMakeArray"
@@ -48,7 +48,7 @@ object predicate {
 
   case object isReduce extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case r@Reduce() => Success(r)
+      case r@reduce() => Success(r)
       case _          => Failure(isReduce)
     }
     override def toString: String = "isReduce"
@@ -56,7 +56,7 @@ object predicate {
 
   case object isTranspose extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case t@Transpose() => Success(t)
+      case t@transpose() => Success(t)
       case _             => Failure(isTranspose)
     }
     override def toString = "isTranspose"
@@ -64,7 +64,7 @@ object predicate {
 
   case object isReduceSeq extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case r@ReduceSeq() => Success(r)
+      case r@reduceSeq() => Success(r)
       case _             => Failure(isReduceSeq)
     }
     override def toString = "isReduce"
@@ -72,7 +72,7 @@ object predicate {
 
   case object isReduceSeqUnroll extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case r@ReduceSeqUnroll() => Success(r)
+      case r@reduceSeqUnroll() => Success(r)
       case _                   => Failure(isReduceSeqUnroll)
     }
     override def toString = "isReduce"
@@ -89,7 +89,7 @@ object predicate {
 
   case object isGenerate extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case g@Generate() => Success(g)
+      case g@generate() => Success(g)
       case _            => Failure(isGenerate)
     }
     override def toString: String = "isGenerate"
@@ -105,7 +105,7 @@ object predicate {
 
   case object isMap extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case m@Map() => Success(m)
+      case m@map() => Success(m)
       case _       => Failure(isMap)
     }
     override def toString: String = "isMap"
@@ -113,7 +113,7 @@ object predicate {
 
   case object isLet extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case l@Let() => Success(l)
+      case l@let() => Success(l)
       case _       => Failure(isLet)
     }
     override def toString = "isLet"
@@ -131,7 +131,7 @@ object predicate {
 
   case object isAppliedLet extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case a@App(App(Let(), _), _) => Success(a)
+      case a@App(App(let(), _), _) => Success(a)
       case _                       => Failure(isAppliedLet)
     }
     override def toString: String = "isAppliedLet"
@@ -139,7 +139,7 @@ object predicate {
 
   case object isAppliedMap extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case m@App(App(Map(), f), arg) => Success(m)
+      case m@App(App(map(), f), arg) => Success(m)
       case _                         => Failure(isMap)
     }
     override def toString: String = "isAppliedMap"
@@ -147,7 +147,7 @@ object predicate {
 
   case object isAppliedZip extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case z@App(App(Zip(), a), b) => Success(z)
+      case z@App(App(zip(), a), b) => Success(z)
       case _                       => Failure(isAppliedZip)
     }
     override def toString: String = "isAppliedZip"
@@ -155,7 +155,7 @@ object predicate {
 
   case object isAppliedReduce extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case r@App(App(App(Reduce(), op), init), arg) => Success(r)
+      case r@App(App(App(reduce(), op), init), arg) => Success(r)
       case _                                        => Failure(isMap)
     }
     override def toString: String = "isAppliedReduce"
@@ -170,8 +170,8 @@ object predicate {
 
   case class isVectorizeablePrimitive()(implicit ev: Traversable[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case a@App(App(Map(), f), input) if isComputation()(ev)(f) && !isVectorArray(a.t) => Success(a)
-      case r@App(App(App(Reduce(), op), init), input) if isComputation()(ev)(op) => Success(r)
+      case a@App(App(map(), f), input) if isComputation()(ev)(f) && !isVectorArray(a.t) => Success(a)
+      case r@App(App(App(reduce(), op), init), input) if isComputation()(ev)(op) => Success(r)
       case _ => Failure(isVectorizeablePrimitive())
     }
   }

--- a/src/main/scala/rise/elevate/strategies/traversal.scala
+++ b/src/main/scala/rise/elevate/strategies/traversal.scala
@@ -1,7 +1,7 @@
 package rise.elevate.strategies
 
 import elevate.core._
-import elevate.core.strategies.Traversable
+import elevate.core.strategies.{Traversable, basic}
 import rise.core.primitives._
 import rise.elevate.rules.algorithmic._
 import elevate.core.strategies.traversal._
@@ -20,7 +20,7 @@ object traversal {
   //  (map λe14. (transpose ((map (map e12)) e14)))      // result of `function`
   //       λe14. (transpose ((map (map e12)) e14))       // result of `argument`
   //             (transpose ((map (map e12)) e14))       // result of 'body' -> here we can apply s
-  def fmap: Strategy[Rise] => Strategy[Rise] = s => function(argumentOf(Map()(), body(s)))
+  def fmap: Strategy[Rise] => Strategy[Rise] = s => function(argumentOf(map.primitive, body(s)))
 
   // fmap applied for expressions in rewrite normal form:
   // fuse -> fmap -> fission
@@ -75,7 +75,7 @@ object traversal {
   })
 
   def blocking(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    id `@` outermost(ev)(mapNest(2))
-    id `@` outermost(ev)(isReduce)
+    basic.id `@` outermost(ev)(mapNest(2))
+    basic.id `@` outermost(ev)(isReduce)
   }
 }

--- a/src/main/scala/rise/openCL/DSL.scala
+++ b/src/main/scala/rise/openCL/DSL.scala
@@ -1,34 +1,29 @@
 package rise.openCL
 
 import rise.core.DSL._
-import rise.core.Expr
-import rise.openCL.primitives._
-import scala.language.implicitConversions
+import rise.core.{Expr, Primitive}
+import rise.openCL
 
 object DSL {
   object mapGlobal {
-    def apply(): MapGlobal = MapGlobal(0)()
-    def apply(e: Expr): Expr = MapGlobal(0)()(e)
-    def apply(dim: Int): Expr = MapGlobal(dim)()
-    implicit def toMapGlobal(m: MapGlobal.type): MapGlobal = MapGlobal(0)()
+    def apply(): Expr = openCL.primitives.mapGlobal(0).primitive
+    def apply(e: Expr): Expr = mapGlobal(0)(e)
+    def apply(dim: Int): Expr = openCL.primitives.mapGlobal(dim).primitive
   }
 
   object mapLocal {
-    def apply(): MapLocal = MapLocal(0)()
-    def apply(e: Expr): Expr = MapLocal(0)()(e)
-    def apply(dim: Int): Expr = MapLocal(dim)()
-    implicit def toMapLocal(m: MapLocal.type): MapLocal = MapLocal(0)()
+    def apply(): Expr = openCL.primitives.mapLocal(0).primitive
+    def apply(e: Expr): Expr = mapLocal(0)(e)
+    def apply(dim: Int): Expr = openCL.primitives.mapLocal(dim).primitive
   }
 
   object mapWorkGroup {
-    def apply(): MapWorkGroup = MapWorkGroup(0)()
-    def apply(e: Expr): Expr = MapWorkGroup(0)()(e)
-    def apply(dim: Int): Expr = MapWorkGroup(dim)()
-    implicit def toMapWorkGroup(m: MapWorkGroup.type): MapWorkGroup =
-      MapWorkGroup(0)()
+    def apply(): Expr = openCL.primitives.mapWorkGroup(0).primitive
+    def apply(e: Expr): Expr = mapWorkGroup(0)(e)
+    def apply(dim: Int): Expr = openCL.primitives.mapWorkGroup(dim).primitive
   }
 
-  def toMem: OclToMem = OclToMem()()
+  def toMem: Primitive = openCL.primitives.oclToMem.primitive
   def toFun(to: Expr, f: Expr): Expr = fun(x => to(f(x)))
   val toGlobal: Expr = toMem(rise.core.types.AddressSpace.Global)
   def toGlobalFun(f: Expr): Expr = toFun(toGlobal, f)
@@ -37,9 +32,9 @@ object DSL {
   val toPrivate: Expr = toMem(rise.core.types.AddressSpace.Private)
   def toPrivateFun(f: Expr): Expr = toFun(toPrivate, f)
 
-  def oclReduceSeq: OclReduceSeq = OclReduceSeq()()
-  def oclReduceSeqUnroll: OclReduceSeqUnroll = OclReduceSeqUnroll()()
-  def oclIterate: OclIterate = OclIterate()()
-  def oclCircularBuffer: OclCircularBuffer = OclCircularBuffer()()
-  def oclRotateValues: OclRotateValues = OclRotateValues()()
+  def oclReduceSeq: Primitive = openCL.primitives.oclReduceSeq.primitive
+  def oclReduceSeqUnroll: Primitive = openCL.primitives.oclReduceSeqUnroll.primitive
+  def oclIterate: Primitive = openCL.primitives.oclIterate.primitive
+  def oclCircularBuffer: Primitive = openCL.primitives.oclCircularBuffer.primitive
+  def oclRotateValues: Primitive = openCL.primitives.oclRotateValues.primitive
 }

--- a/src/main/scala/rise/openCL/TypedDSL.scala
+++ b/src/main/scala/rise/openCL/TypedDSL.scala
@@ -6,44 +6,44 @@ import rise.core.types.AddressSpaceKind
 
 object TypedDSL {
   object mapGlobal {
-    def apply(): TDSL[Primitive] = primitives.mapGlobal(0)
-    def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
+    def apply(): ToBeTyped[Primitive] = primitives.mapGlobal(0)
+    def apply[T <: Expr](e: ToBeTyped[T]): ToBeTyped[rise.core.App] =
       primitives.mapGlobal(0)(e)
-    def apply(dim: Int): TDSL[Primitive] = primitives.mapGlobal(dim)
+    def apply(dim: Int): ToBeTyped[Primitive] = primitives.mapGlobal(dim)
   }
 
   object mapLocal {
-    def apply(): TDSL[Primitive] = primitives.mapLocal(0)
-    def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
+    def apply(): ToBeTyped[Primitive] = primitives.mapLocal(0)
+    def apply[T <: Expr](e: ToBeTyped[T]): ToBeTyped[rise.core.App] =
       primitives.mapLocal(0)(e)
-    def apply(dim: Int): TDSL[Primitive] = primitives.mapLocal(dim)
+    def apply(dim: Int): ToBeTyped[Primitive] = primitives.mapLocal(dim)
   }
 
   object mapWorkGroup {
-    def apply(): TDSL[Primitive] = primitives.mapWorkGroup(0)
-    def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
+    def apply(): ToBeTyped[Primitive] = primitives.mapWorkGroup(0)
+    def apply[T <: Expr](e: ToBeTyped[T]): ToBeTyped[rise.core.App] =
       primitives.mapWorkGroup(0)(e)
-    def apply(dim: Int): TDSL[Primitive] = primitives.mapWorkGroup(dim)
+    def apply(dim: Int): ToBeTyped[Primitive] = primitives.mapWorkGroup(dim)
   }
 
-  def toMem: TDSL[Primitive] = primitives.oclToMem
+  def toMem: ToBeTyped[Primitive] = primitives.oclToMem
   def toFun[A <: Expr, B <: Expr](
-                                   to: TDSL[A],
-                                   f: TDSL[B]
-                                 ): TDSL[rise.core.Lambda] = fun(x => to(f(x)))
-  val toGlobal: TDSL[rise.core.DepApp[AddressSpaceKind]] = toMem(
+                                   to: ToBeTyped[A],
+                                   f: ToBeTyped[B]
+                                 ): ToBeTyped[rise.core.Lambda] = fun(x => to(f(x)))
+  val toGlobal: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
     rise.core.types.AddressSpace.Global
   )
-  def toGlobalFun[T <: Expr](f: TDSL[T]): TDSL[rise.core.Lambda] =
+  def toGlobalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toGlobal, f)
-  val toLocal: TDSL[rise.core.DepApp[AddressSpaceKind]] = toMem(
+  val toLocal: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
     rise.core.types.AddressSpace.Local
   )
-  def toLocalFun[T <: Expr](f: TDSL[T]): TDSL[rise.core.Lambda] =
+  def toLocalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toLocal, f)
-  val toPrivate: TDSL[rise.core.DepApp[AddressSpaceKind]] = toMem(
+  val toPrivate: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
     rise.core.types.AddressSpace.Private
   )
-  def toPrivateFun[T <: Expr](f: TDSL[T]): TDSL[rise.core.Lambda] =
+  def toPrivateFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toPrivate, f)
 }

--- a/src/main/scala/rise/openCL/TypedDSL.scala
+++ b/src/main/scala/rise/openCL/TypedDSL.scala
@@ -1,45 +1,36 @@
 package rise.openCL
 
 import rise.core.TypedDSL._
-import rise.core.Expr
-import rise.openCL.primitives._
+import rise.core.{Expr, Primitive}
 import rise.core.types.AddressSpaceKind
-
-import scala.language.implicitConversions
 
 object TypedDSL {
   object mapGlobal {
-    def apply(): TDSL[MapGlobal] = toTDSL(MapGlobal(0)())
+    def apply(): TDSL[Primitive] = primitives.mapGlobal(0)
     def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
-      toTDSL(MapGlobal(0)())(e)
-    def apply(dim: Int): TDSL[MapGlobal] = toTDSL(MapGlobal(dim)())
-    implicit def toMapGlobal(m: MapGlobal.type): TDSL[MapGlobal] =
-      toTDSL(MapGlobal(0)())
+      primitives.mapGlobal(0)(e)
+    def apply(dim: Int): TDSL[Primitive] = primitives.mapGlobal(dim)
   }
 
   object mapLocal {
-    def apply(): TDSL[MapLocal] = toTDSL(MapLocal(0)())
+    def apply(): TDSL[Primitive] = primitives.mapLocal(0)
     def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
-      toTDSL(MapLocal(0)())(e)
-    def apply(dim: Int): TDSL[MapLocal] = toTDSL(MapLocal(dim)())
-    implicit def toMapLocal(m: MapLocal.type): TDSL[MapLocal] =
-      toTDSL(MapLocal(0)())
+      primitives.mapLocal(0)(e)
+    def apply(dim: Int): TDSL[Primitive] = primitives.mapLocal(dim)
   }
 
   object mapWorkGroup {
-    def apply(): TDSL[MapWorkGroup] = toTDSL(MapWorkGroup(0)())
+    def apply(): TDSL[Primitive] = primitives.mapWorkGroup(0)
     def apply[T <: Expr](e: TDSL[T]): TDSL[rise.core.App] =
-      toTDSL(MapWorkGroup(0)())(e)
-    def apply(dim: Int): TDSL[MapWorkGroup] = toTDSL(MapWorkGroup(dim)())
-    implicit def toMapWorkGroup(m: MapWorkGroup.type): TDSL[MapWorkGroup] =
-      toTDSL(MapWorkGroup(0)())
+      primitives.mapWorkGroup(0)(e)
+    def apply(dim: Int): TDSL[Primitive] = primitives.mapWorkGroup(dim)
   }
 
-  def toMem: TDSL[OclToMem] = toTDSL(OclToMem()())
+  def toMem: TDSL[Primitive] = primitives.oclToMem
   def toFun[A <: Expr, B <: Expr](
-      to: TDSL[A],
-      f: TDSL[B]
-  ): TDSL[rise.core.Lambda] = fun(x => to(f(x)))
+                                   to: TDSL[A],
+                                   f: TDSL[B]
+                                 ): TDSL[rise.core.Lambda] = fun(x => to(f(x)))
   val toGlobal: TDSL[rise.core.DepApp[AddressSpaceKind]] = toMem(
     rise.core.types.AddressSpace.Global
   )
@@ -55,13 +46,4 @@ object TypedDSL {
   )
   def toPrivateFun[T <: Expr](f: TDSL[T]): TDSL[rise.core.Lambda] =
     toFun(toPrivate, f)
-
-  def oclReduceSeq: TDSL[OclReduceSeq] = toTDSL(OclReduceSeq()())
-  def oclReduceSeqUnroll: TDSL[OclReduceSeqUnroll] =
-    toTDSL(OclReduceSeqUnroll()())
-  def oclIterate: TDSL[OclIterate] = toTDSL(OclIterate()())
-  def oclCircularBuffer: TDSL[OclCircularBuffer] =
-    toTDSL(OclCircularBuffer()())
-  def oclRotateValues: TDSL[OclRotateValues] =
-    toTDSL(OclRotateValues()())
 }

--- a/src/main/scala/rise/openCL/primitives.scala
+++ b/src/main/scala/rise/openCL/primitives.scala
@@ -1,117 +1,61 @@
 package rise.openCL
 
 import rise.core.TypeLevelDSL._
-import rise.core.types._
+import rise.core.{Builder, Primitive}
 import rise.macros.Primitive.primitive
 
 // noinspection DuplicatedCode
 object primitives {
-  sealed trait Primitive extends rise.core.Primitive
-
   // TODO? depMapGlobal, depMapLocal, depMapWorkGroup
 
-  @primitive case class MapGlobal(dim: Int)(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive case class mapGlobal(dim: Int) extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class MapLocal(dim: Int)(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive case class mapLocal(dim: Int) extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class MapWorkGroup(dim: Int)(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive case class mapWorkGroup(dim: Int) extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class OclToMem()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type = implDT(t => aFunT(_ => t ->: t))
+  @primitive object oclToMem extends Primitive with Builder {
+    implDT(t => forallAddr(_ => t ->: t))
   }
 
-  @primitive case class OclReduceSeq()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      aFunT(_ =>
-        implN(n =>
-          implDT(s =>
-            implDT(t => (t ->: s ->: t) ->: t ->: ArrayType(n, s) ->: t)
-          )
-        )
-      )
+  @primitive object oclReduceSeq extends Primitive with Builder {
+    forallAddr(_ => implNat(n => implDT(s => implDT(t =>
+      (t ->: s ->: t) ->: t ->: (n`.`s) ->: t))))
   }
 
-  @primitive case class OclReduceSeqUnroll()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      aFunT(_ =>
-        implN(n =>
-          implDT(s =>
-            implDT(t => (t ->: s ->: t) ->: t ->: ArrayType(n, s) ->: t)
-          )
-        )
-      )
+  @primitive object oclReduceSeqUnroll extends Primitive with Builder {
+    forallAddr(_ => implNat(n => implDT(s => implDT(t =>
+      (t ->: s ->: t) ->: t ->: (n`.`s) ->: t))))
   }
 
-  @primitive case class OclIterate()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    // format: off
-    override def typeScheme: Type =
-      aFunT(_ =>
-        implN(n =>
-          implN(m =>
-            nFunT(k =>
-              implDT(t =>
-                nFunT(l =>
-                  ArrayType(l * n, t) ->: ArrayType(l, t)) ->:
-                    ArrayType(m * n.pow(k), t) ->: ArrayType(m, t)
-              )
-            )
-          )
-        )
-      )
-    // format: on
+  @primitive object oclIterate extends Primitive with Builder {
+    forallAddr(_ => implNat(n => implNat(m =>
+      forallNat(k => implDT(t =>
+        forallNat(l => ((l * n)`.`t) ->: (l`.`t)) ->:
+          ((m * n.pow(k))`.`t) ->: (m`.`t))))))
   }
 
-  @primitive case class OclCircularBuffer()(
-      override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      // TODO: should return a stream / sequential array, not an array
-      aFunT(_ => implN(n => nFunT(alloc => nFunT(sz => implDT(s => implDT(t =>
+  @primitive object oclCircularBuffer extends Primitive with Builder {
+    // TODO: should return a stream / sequential array, not an array
+    forallAddr(_ => implNat(n =>
+      forallNat(alloc => forallNat(sz => implDT(s => implDT(t =>
         (s ->: t) ->: // function to load an input
-          ArrayType(n + sz, s) ->: ArrayType(1 + n, ArrayType(sz, t))
-      ))))))
+          ((n + sz)`.`s) ->: ((1 + n)`.`sz`.`t)))))))
   }
 
-  @primitive case class OclRotateValues()(
-    override val t: Type = TypePlaceholder
-  ) extends Primitive {
-    override def typeScheme: Type =
-      // TODO: should return a stream / sequential array, not an array
-      aFunT(_ => implN(n => nFunT(sz => implDT(s =>
-        (s ->: s) ->: // function to write a value
-          ArrayType(n + sz, s) ->: ArrayType(1 + n, ArrayType(sz, s))
-      ))))
+  @primitive object oclRotateValues extends Primitive with Builder {
+    // TODO: should return a stream / sequential array, not an array
+    forallAddr(_ => implNat(n => forallNat(sz => implDT(s =>
+      (s ->: s) ->: // function to write a value
+        ((n + sz)`.`s) ->: ((1 + n)`.`sz`.`s)))))
   }
 }

--- a/src/main/scala/rise/openMP/DSL.scala
+++ b/src/main/scala/rise/openMP/DSL.scala
@@ -1,8 +1,8 @@
 package rise.openMP
 
-import rise.openMP.primitives._
+import rise.core.Primitive
 
 object DSL {
-  def mapPar: MapPar = MapPar()()
-  def reducePar: ReducePar = ReducePar()()
+  def mapPar: Primitive = primitives.mapPar.primitive
+  def reducePar: Primitive = primitives.reducePar.primitive
 }

--- a/src/main/scala/rise/openMP/TypedDSL.scala
+++ b/src/main/scala/rise/openMP/TypedDSL.scala
@@ -1,9 +1,0 @@
-package rise.openMP
-
-import rise.openMP.primitives._
-import rise.core.TypedDSL._
-
-object TypedDSL {
-  def mapPar: TDSL[MapPar] = toTDSL(MapPar()())
-  def reducePar: TDSL[ReducePar] = toTDSL(ReducePar()())
-}

--- a/src/main/scala/rise/openMP/primitives.scala
+++ b/src/main/scala/rise/openMP/primitives.scala
@@ -1,28 +1,20 @@
 package rise.openMP
 
 import rise.core.TypeLevelDSL._
-import rise.core.types._
+import rise.core.{Builder, Primitive}
 import rise.macros.Primitive.primitive
 
 // noinspection DuplicatedCode
 object primitives {
-  sealed trait Primitive extends rise.core.Primitive
-
   // TODO? depMapPar
 
-  @primitive case class MapPar()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n =>
-        implDT(s =>
-          implDT(t => (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t))
-        )
-      )
+  @primitive object mapPar extends Primitive with Builder {
+    implNat(n => implDT(s => implDT(t =>
+      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
   }
 
-  @primitive case class ReducePar()(override val t: Type = TypePlaceholder)
-      extends Primitive {
-    override def typeScheme: Type =
-      implN(n => implDT(t => (t ->: t ->: t) ->: t ->: ArrayType(n, t) ->: t))
+  @primitive object reducePar extends Primitive with Builder {
+    implNat(n => implDT(t =>
+      (t ->: t ->: t) ->: t ->: (n`.`t) ->: t))
   }
 }

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -118,13 +118,13 @@ object fromRise {
     }
 
     p match {
-      case core.PrintType(msg) => fromType {
+      case core.printType(msg) => fromType {
         case expT(dt: DataType, w) ->: _
         =>
         fun[ExpType](expT(dt, w), e => PrintType(msg, dt, w, e))
       }
 
-      case core.NatAsIndex() => fromType {
+      case core.natAsIndex() => fromType {
         case nFunT(n, expT(`NatType`, `read`) ->:
           expT(IndexType(_), `read`))
         =>
@@ -133,7 +133,7 @@ object fromRise {
             NatAsIndex(n, e)))
       }
 
-      case core.Map() => fromType {
+      case core.map() => fromType {
         case ( expT(s, ai) ->: expT(t, _) ) ->:
           expT(ArrayType(n, _), _) ->:
           expT(ArrayType(_, _), _)
@@ -143,7 +143,7 @@ object fromRise {
             Map(n, s, t, ai, f, e)))
       }
 
-      case core.MapSeq() => fromType {
+      case core.mapSeq() => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -153,7 +153,7 @@ object fromRise {
             MapSeq(n, s, t, f, e)))
       }
 
-      case core.MapStream() => fromType {
+      case core.mapStream() => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `read`)
@@ -163,7 +163,7 @@ object fromRise {
             MapStream(n, s, t, f, e)))
       }
 
-      case core.IterateStream() => fromType {
+      case core.iterateStream() => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -173,7 +173,7 @@ object fromRise {
             IterateStream(n, s, t, f, e)))
       }
 
-      case core.MapSeqUnroll() => fromType {
+      case core.mapSeqUnroll() => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -183,7 +183,7 @@ object fromRise {
             MapSeqUnroll(n, s, t, f, e)))
       }
 
-      case omp.MapPar() => fromType {
+      case omp.mapPar() => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -193,7 +193,7 @@ object fromRise {
             MapPar(n, s, t, f, e)))
       }
 
-      case ocl.MapGlobal(dim) => fromType {
+      case ocl.mapGlobal(dim) => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -203,7 +203,7 @@ object fromRise {
             MapGlobal(dim)(n, s, t, f, e)))
       }
 
-      case ocl.MapLocal(dim) => fromType {
+      case ocl.mapLocal(dim) => fromType {
         case ( expT(s, `read`) ->: expT(t, `write`) ) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -213,7 +213,7 @@ object fromRise {
             MapLocal(dim)(n, s, t, f, e)))
       }
 
-      case ocl.MapWorkGroup(dim) => fromType {
+      case ocl.mapWorkGroup(dim) => fromType {
         case (expT(s, `read`) ->: expT(t, `write`)) ->:
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `write`)
@@ -223,7 +223,7 @@ object fromRise {
               MapWorkGroup(dim)(n, s, t, f, e)))
       }
 
-      case core.DepMapSeq() => fromType {
+      case core.depMapSeq() => fromType {
         case nFunT(k, expT(_, `read`) ->: expT(_, `write`)) ->:
           expT(DepArrayType(n, ft1), `read`) ->:
           expT(DepArrayType(_, ft2), `write`)
@@ -234,7 +234,7 @@ object fromRise {
               DepMapSeq(n, ft1, ft2, f, e)))
       }
 
-      case core.ReduceSeq() => fromType {
+      case core.reduceSeq() => fromType {
         case (expT(t, `read`) ->: expT(s, `read`) ->: expT(_, `write`)) ->:
           expT(_, `write`) ->:
           expT(ArrayType(n, _), `read`) ->:
@@ -247,7 +247,7 @@ object fromRise {
                 ReduceSeq(n, s, t, f, i, e))))
       }
 
-      case core.ReduceSeqUnroll() => fromType {
+      case core.reduceSeqUnroll() => fromType {
         case (expT(t, `read`) ->: expT(s, `read`) ->: expT(_, `write`)) ->:
           expT(_, `write`) ->:
           expT(ArrayType(n, _), `read`) ->:
@@ -260,7 +260,7 @@ object fromRise {
                 ReduceSeqUnroll(n, s, t, f, i, e))))
       }
 
-      case ocl.OclReduceSeq() => fromType {
+      case ocl.oclReduceSeq() => fromType {
         case aFunT(a,
         (expT(t, `read`) ->: expT(s, `read`) ->: expT(_, `write`)) ->:
           expT(_, `write`) ->:
@@ -275,7 +275,7 @@ object fromRise {
                   OpenCLReduceSeq(n, a, s, t, f, i, e, unroll = false)))))
       }
 
-      case ocl.OclReduceSeqUnroll() => fromType {
+      case ocl.oclReduceSeqUnroll() => fromType {
         case aFunT(a,
         (expT(t, `read`) ->: expT(s, `read`) ->: expT(_, `write`)) ->:
           expT(_, `write`) ->:
@@ -290,7 +290,7 @@ object fromRise {
                   OpenCLReduceSeq(n, a, s, t, f, i, e, unroll = true)))))
       }
 
-      case core.ScanSeq() => fromType {
+      case core.scanSeq() => fromType {
         case (expT(s, `read`) ->: expT(t, `read`) ->: expT(_, `write`)) ->:
           expT(_, `write`) ->:
           expT(ArrayType(n, _), `read`) ->:
@@ -303,7 +303,7 @@ object fromRise {
                 ScanSeq(n, s, t, f, i, e))))
       }
 
-      case core.DepJoin() => fromType {
+      case core.depJoin() => fromType {
         case expT(DepArrayType(n, n2d), `read`) ->:
           expT(ArrayType(_, dt), `read`)
         =>
@@ -312,7 +312,7 @@ object fromRise {
           DepJoin(n, lenF, dt, e))
       }
 
-      case core.Join() => fromType {
+      case core.join() => fromType {
         case expT(ArrayType(n, ArrayType(m, t)), a) ->:
           expT(ArrayType(_, _), _)
         =>
@@ -320,7 +320,7 @@ object fromRise {
           Join(n, m, a, t, e))
       }
 
-      case core.Split() => fromType {
+      case core.split() => fromType {
         case nFunT(n, expT(ArrayType(_, t), a) ->:
           expT(ArrayType(m, ArrayType(_, _)), _))
         =>
@@ -329,7 +329,7 @@ object fromRise {
             Split(n, m, a, t, e)))
       }
 
-      case core.Slide() => fromType {
+      case core.slide() => fromType {
         case nFunT(sz, nFunT(sp,
           expT(ArrayType(insz, t), `read`) ->:
           expT(ArrayType(n, ArrayType(_, _)), `read`)))
@@ -340,7 +340,7 @@ object fromRise {
               Slide(n, sz, sp, t, e))))
       }
 
-      case core.CircularBuffer() => fromType {
+      case core.circularBuffer() => fromType {
         case nFunT(alloc, nFunT(sz,
           (expT(s, `read`) ->: expT(t, `write`)) ->:
             expT(ArrayType(insz, _), `read`) ->:
@@ -355,7 +355,7 @@ object fromRise {
                   SlideSeq(SlideSeq.Indices, n, sz, 1, s, t, load, e)))))
       }
 
-      case core.RotateValues() => fromType {
+      case core.rotateValues() => fromType {
         case nFunT(sz,
           (expT(s, `read`) ->: expT(_, `write`)) ->:
             expT(ArrayType(insz, _), `read`) ->:
@@ -368,7 +368,7 @@ object fromRise {
                 SlideSeq(SlideSeq.Values, n, sz, 1, s, s, wr, e))))
       }
 
-      case ocl.OclCircularBuffer() => fromType {
+      case ocl.oclCircularBuffer() => fromType {
         case aFunT(a, nFunT(alloc, nFunT(sz,
         (expT(s, `read`) ->: expT(t, `write`)) ->:
           expT(ArrayType(insz, _), `read`) ->:
@@ -383,7 +383,7 @@ object fromRise {
                     OpenCLCircularBuffer(a, n, alloc, sz, s, t, load, e))))))
       }
 
-      case ocl.OclRotateValues() => fromType {
+      case ocl.oclRotateValues() => fromType {
         case aFunT(a, nFunT(sz,
         (expT(s, `read`) ->: expT(t, `write`)) ->:
           expT(ArrayType(insz, _), `read`) ->:
@@ -397,7 +397,7 @@ object fromRise {
                     OpenCLRotateValues(a, n, sz, t, write_t, e)))))
       }
 
-      case core.Reorder() => fromType {
+      case core.reorder() => fromType {
         case (expT(IndexType(n), `read`) ->: expT(IndexType(_), `read`)) ->:
           (expT(IndexType(_), `read`) ->: expT(IndexType(_), `read`)) ->:
           expT(ArrayType(_, t), a) ->: expT(ArrayType(_, _), _)
@@ -410,7 +410,7 @@ object fromRise {
                   Reorder(n, t, a, idxF, idxFinv, e))))
       }
 
-      case core.Gather() => fromType {
+      case core.gather() => fromType {
         case expT(ArrayType(m, IndexType(n)), `read`) ->:
           expT(ArrayType(_, t), `read`) ->:
           expT(ArrayType(_, _), `read`)
@@ -420,7 +420,7 @@ object fromRise {
             Gather(n, m, t, y, x)))
       }
 
-      case core.Transpose() => fromType {
+      case core.transpose() => fromType {
         case expT(ArrayType(n, ArrayType(m, t)), a) ->:
           expT(ArrayType(_, ArrayType(_, _)), _)
         =>
@@ -428,7 +428,7 @@ object fromRise {
           Transpose(n, m, t, a, e))
       }
 
-      case core.Take() => fromType {
+      case core.take() => fromType {
         case nFunT(n, expT(ArrayType(nm, t), `read`) ->:
           expT(ArrayType(_, _), `read`))
         =>
@@ -436,7 +436,7 @@ object fromRise {
           fun[ExpType](expT(nm`.`t, read), e => Take(n, nm-n, t, e)))
       }
 
-      case core.Drop() => fromType {
+      case core.drop() => fromType {
         case nFunT(n, expT(ArrayType(nm, t), `read`) ->:
           expT(ArrayType(_, _), `read`))
         =>
@@ -445,7 +445,7 @@ object fromRise {
             Drop(n, nm-n, t, e)))
       }
 
-      case core.PadCst() => fromType {
+      case core.padCst() => fromType {
         case nFunT(l, nFunT(q,
           expT(t, `read`) ->:
           expT(ArrayType(n, _), `read`) ->:
@@ -458,7 +458,7 @@ object fromRise {
                 Pad(n, l, q, t, cst, e)))))
       }
 
-      case core.PadEmpty() => fromType {
+      case core.padEmpty() => fromType {
         case nFunT(r,
           expT(ArrayType(n, t), `write`) ->: _)
         =>
@@ -467,7 +467,7 @@ object fromRise {
             PadEmpty(n, r, t, e)))
       }
 
-      case core.PadClamp() => fromType {
+      case core.padClamp() => fromType {
         case nFunT(l, nFunT(q,
           expT(ArrayType(n, t), `read`) ->:
           expT(ArrayType(_, _), `read`)))
@@ -478,7 +478,7 @@ object fromRise {
               PadClamp(n, l, q, t, e))))
       }
 
-      case core.Unzip() => fromType {
+      case core.unzip() => fromType {
         case expT(ArrayType(n, PairType(s, t)), a) ->:
           expT(PairType(ArrayType(_, _), ArrayType(_, _)), _)
         =>
@@ -486,7 +486,7 @@ object fromRise {
           Unzip(n, s, t, a, e))
       }
 
-      case core.Zip() => fromType {
+      case core.zip() => fromType {
         case expT(ArrayType(n, s), a) ->:
           expT(ArrayType(_, t), _) ->:
           expT(ArrayType(_, PairType(_, _)), _)
@@ -496,19 +496,19 @@ object fromRise {
             Zip(n, s, t, a, x, y)))
       }
 
-      case core.Fst() => fromType {
+      case core.fst() => fromType {
         case expT(PairType(s, t), `read`) ->: expT(_, read)
         =>
         fun[ExpType](expT(s x t, read), e => Fst(s, t, e))
       }
 
-      case core.Snd() => fromType {
+      case core.snd() => fromType {
         case expT(PairType(s, t), `read`) ->: expT(_, read)
         =>
         fun[ExpType](expT(s x t, read), e => Snd(s, t, e))
       }
 
-      case core.MapFst() => fromType {
+      case core.mapFst() => fromType {
         case (expT(s, a) ->: expT(s2, _)) ->:
           expT(PairType(_, t), _) ->:
           expT(PairType(_, _), _)
@@ -517,7 +517,7 @@ object fromRise {
           fun[ExpType](expT(s x t, a), e => MapFst(a, s, t, s2, f, e)))
       }
 
-      case core.MapSnd() => fromType {
+      case core.mapSnd() => fromType {
         case (expT(t, a) ->: expT(t2, _)) ->:
           expT(PairType(s, _), _) ->:
           expT(PairType(_, _), _) =>
@@ -525,7 +525,7 @@ object fromRise {
           fun[ExpType](expT(s x t, a), e => MapSnd(a, s, t, t2, f, e)))
       }
 
-      case core.Pair() => fromType {
+      case core.pair() => fromType {
         case expT(s, a) ->:
           expT(t, _) ->:
           expT(PairType(_, _), _)
@@ -535,7 +535,7 @@ object fromRise {
             Pair(s, t, a, x, y)))
         }
 
-      case core.Idx() => fromType {
+      case core.idx() => fromType {
         case expT(IndexType(n), `read`) ->:
           expT(ArrayType(_, t), `read`) ->:
           expT(_, `read`)
@@ -545,7 +545,7 @@ object fromRise {
             FunctionalPrimitives.Idx(n, t, i, e)))
       }
 
-      case core.Select() => fromType {
+      case core.select() => fromType {
         case expT(`bool`, `read`) ->:
           expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
@@ -555,19 +555,19 @@ object fromRise {
               IfThenElse(cond, tExpr, fExpr))))
       }
 
-      case core.Neg() => fromType {
+      case core.neg() => fromType {
         case expT(t, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e => UnaryOp(Operators.Unary.NEG, e))
       }
 
-      case core.Not() => fromType {
+      case core.not() => fromType {
         case expT(`bool`, `read`) ->: expT(`bool`, `read`)
         =>
         fun[ExpType](expT(bool, read), e => UnaryOp(Operators.Unary.NOT, e))
       }
 
-      case core.Add() => fromType {
+      case core.add() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -575,7 +575,7 @@ object fromRise {
             BinOp(Operators.Binary.ADD, e1, e2)))
       }
 
-      case core.Sub() => fromType {
+      case core.sub() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -583,7 +583,7 @@ object fromRise {
             BinOp(Operators.Binary.SUB, e1, e2)))
       }
 
-      case core.Mul() => fromType {
+      case core.mul() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -591,7 +591,7 @@ object fromRise {
             BinOp(Operators.Binary.MUL, e1, e2)))
       }
 
-      case core.Div() => fromType {
+      case core.div() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -599,7 +599,7 @@ object fromRise {
             BinOp(Operators.Binary.DIV, e1, e2)))
       }
 
-      case core.Mod() => fromType {
+      case core.mod() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -607,7 +607,7 @@ object fromRise {
             BinOp(Operators.Binary.MOD, e1, e2)))
       }
 
-      case core.Gt() => fromType {
+      case core.gt() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(`bool`, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -615,7 +615,7 @@ object fromRise {
             BinOp(Operators.Binary.GT, e1, e2)))
       }
 
-      case core.Lt() => fromType {
+      case core.lt() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(`bool`, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -623,7 +623,7 @@ object fromRise {
             BinOp(Operators.Binary.LT, e1, e2)))
       }
 
-      case core.Equal() => fromType {
+      case core.equal() => fromType {
         case expT(t, `read`) ->: expT(_, `read`) ->: expT(`bool`, `read`)
         =>
         fun[ExpType](expT(t, read), e1 =>
@@ -631,13 +631,13 @@ object fromRise {
             BinOp(Operators.Binary.EQ, e1, e2)))
       }
 
-      case core.Cast() => fromType {
+      case core.cast() => fromType {
         case expT(s: BasicType, `read`) ->: expT(t: BasicType, `read`)
         =>
         fun[ExpType](ExpType(s, read), x => Cast(s, t, x))
       }
 
-      case core.Let() => fromType {
+      case core.let() => fromType {
         case expT(s, `read`) ->:
           (expT(_, `read`) ->: expT(t, a)) ->: expT(_, _)
         =>
@@ -672,7 +672,7 @@ object fromRise {
         }
         buildFFPrimitive(Vector())
 
-      case core.Generate() => fromType {
+      case core.generate() => fromType {
         case (expT(IndexType(n), `read`) ->: expT(t, `read`)) ->:
           expT(ArrayType(n_, _), `read`)
         =>
@@ -681,7 +681,7 @@ object fromRise {
             Generate(n, t, f))
       }
 
-      case core.MakeArray(_) =>
+      case core.makeArray(_) =>
         def buildArrayPrimitive(t: PhraseType, elements: Vector[Phrase[ExpType]]
                      ): Phrase[_ <: PhraseType] = t match {
           case FunType(in: ExpType, out) =>
@@ -691,7 +691,7 @@ object fromRise {
         }
         buildArrayPrimitive(t, Vector())
 
-      case core.Iterate() => fromType {
+      case core.iterate() => fromType {
         case nFunT(k,
           nFunT(l, expT(ArrayType(ln, t), `read`) ->:
             expT(ArrayType(_, _), `write`)) ->:
@@ -705,7 +705,7 @@ object fromRise {
                 Iterate(ln /^ l, m, k, t, f, e))))
       }
 
-      case ocl.OclIterate() => fromType {
+      case ocl.oclIterate() => fromType {
         case aFunT(a, nFunT(k,
           nFunT(l, expT(ArrayType(ln, t), `read`) ->:
             expT(ArrayType(_, _), `write`)) ->:
@@ -719,7 +719,7 @@ object fromRise {
                 OpenCLIterate(a, ln /^ l, m, k, t, f, e)))))
       }
 
-      case core.AsVector() => fromType {
+      case core.asVector() => fromType {
         case nFunT(n,
           expT(ArrayType(mn, _), a) ->:
           expT(ArrayType(m, VectorType(_, t)), _))
@@ -729,7 +729,7 @@ object fromRise {
             AsVector(n, m, t, a, e)))
       }
 
-      case core.AsVectorAligned() => fromType {
+      case core.asVectorAligned() => fromType {
         case nFunT(n,
           expT(ArrayType(mn, _), a) ->:
           expT(ArrayType(m, VectorType(_, t)), _))
@@ -739,7 +739,7 @@ object fromRise {
             AsVectorAligned(n, m, a, t, e)))
       }
 
-      case core.AsScalar() => fromType {
+      case core.asScalar() => fromType {
         case expT(ArrayType(m, VectorType(n, t)), a) ->:
           expT(ArrayType(_, _), _)
         =>
@@ -747,7 +747,7 @@ object fromRise {
           AsScalar(m, n, t, a, e))
       }
 
-      case core.VectorFromScalar() => fromType {
+      case core.vectorFromScalar() => fromType {
         case expT(_, `read`) ->:
           expT(VectorType(n, t), `read`)
         =>
@@ -755,7 +755,7 @@ object fromRise {
           VectorFromScalar(n, t, e))
       }
 
-      case core.IndexAsNat() => fromType {
+      case core.indexAsNat() => fromType {
         case expT(IndexType(n), `read`) ->:
           expT(`NatType`, `read`)
         =>
@@ -763,13 +763,13 @@ object fromRise {
           IndexAsNat(n, e))
       }
 
-      case core.ToMem() => fromType {
+      case core.toMem() => fromType {
         case expT(t, `write`) ->: expT(_, `read`)
         =>
         fun[ExpType](expT(t, write), e => ToMem(t, e))
       }
 
-      case ocl.OclToMem() => fromType {
+      case ocl.oclToMem() => fromType {
         case aFunT(a, expT(t, `write`) ->: expT(_, `read`))
         =>
         depFun[AddressSpaceKind](a)(
@@ -777,7 +777,7 @@ object fromRise {
             OclToMem(a, t, e)))
       }
 
-      case core.Reduce() =>
+      case core.reduce() =>
         throw new Exception(s"$p has no implementation")
 
       case _ => throw new Exception(s"Missing rule for $p")

--- a/src/test/scala/apps/cameraPipeCheck.scala
+++ b/src/test/scala/apps/cameraPipeCheck.scala
@@ -354,7 +354,7 @@ ${fName}(output, ${2*H}, ${2*W}, input, ${sharpen_strength});
       )(a =>
         interpolate(Image(0, w, 0, h, a)).expr
       ))),
-      nFunT(h => nFunT(w => (h`.`w`.`2`.`i16) ->: (h`.`w`.`i16)))
+      forallNat(h => forallNat(w => (h`.`w`.`2`.`i16) ->: (h`.`w`.`i16)))
     )
 
     assertClosedT(
@@ -363,7 +363,7 @@ ${fName}(output, ${2*H}, ${2*W}, input, ${sharpen_strength});
       )(a =>
         pointAbsDiff(Image(0, w, 0, h, a)).expr
       ))),
-      nFunT(h => nFunT(w => (h`.`w`.`2`.`i16) ->: (h`.`w`.`u16)))
+      forallNat(h => forallNat(w => (h`.`w`.`2`.`i16) ->: (h`.`w`.`u16)))
     )
 
     val cameraPipeT = (1968`.`2592`.`u16) ->:
@@ -372,7 +372,7 @@ ${fName}(output, ${2*H}, ${2*W}, input, ${sharpen_strength});
       f32 ->:
       (3`.`1920`.`2560`.`u8)
     assertClosedT(
-      implN(h => implN(w => camera_pipe(h)(w)(3)(4))) :: cameraPipeT,
+      implNat(h => implNat(w => camera_pipe(h)(w)(3)(4))) :: cameraPipeT,
       cameraPipeT
     )
   }

--- a/src/test/scala/apps/gemv.scala
+++ b/src/test/scala/apps/gemv.scala
@@ -12,7 +12,7 @@ class gemv extends test_util.Tests {
   // we can use implicit type parameters and type annotations to specify the function type of mult
   val mult = implDT(dt => fun(x => x._1 * x._2) :: ((dt x dt) ->: dt))
   val add = fun(x => fun(y => x + y))
-  val scal = implN(n =>
+  val scal = implNat(n =>
     fun(xs => fun(a =>
       mapSeq(fun(x => a * x), xs)
     )) :: (ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32))

--- a/src/test/scala/apps/scal.scala
+++ b/src/test/scala/apps/scal.scala
@@ -15,7 +15,7 @@ class scal extends test_util.Tests {
     val typed = infer(simpleScal)
 
     assert(
-      nFunT(n => ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32))
+      forallNat(n => ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32))
         ==
       typed.t
     )

--- a/src/test/scala/apps/separableConvolution2DRewrite.scala
+++ b/src/test/scala/apps/separableConvolution2DRewrite.scala
@@ -25,20 +25,20 @@ class separableConvolution2DRewrite extends test_util.Tests {
   private val weightsV = binomialWeightsV
   private val weightsH = binomialWeightsH
 
-  private val * : TDSL[Rise] = map
-  private val T: TDSL[Rise] = transpose
-  private val P = toTDSL(padClamp2D(1))
+  private val * : ToBeTyped[Rise] = map
+  private val T: ToBeTyped[Rise] = transpose
+  private val P = toBeTyped(padClamp2D(1))
   private val Sh = slide(3)(1)
   private val Sv = slide(3)(1)
-  private val Dh = toTDSL(dot)(weightsH)
-  private val Dv = toTDSL(dot)(weightsV)
+  private val Dh = toBeTyped(dot)(weightsH)
+  private val Dv = toBeTyped(dot)(weightsV)
 
   private val BENF = rise.elevate.strategies.normalForm.BENF()(alternative.RiseTraversable)
 
   private def ben_eq(a: Expr, b: Expr): Boolean = {
     val na = BENF(a).get
     val nb = BENF(b).get
-    val uab: Rise = toTDSL(na) :: nb.t
+    val uab: Rise = toBeTyped(na) :: nb.t
     makeClosed(uab)._1 == makeClosed(nb)._1
   }
 
@@ -66,15 +66,15 @@ class separableConvolution2DRewrite extends test_util.Tests {
   //// algorithmic
 
   test("base to factorise") {
-    rewrite_steps(toTDSL(base)(weights2d), scala.collection.Seq(
-      topDown(separateDot) -> toTDSL(factorised)(weightsV)(weightsH)
+    rewrite_steps(toBeTyped(base)(weights2d), scala.collection.Seq(
+      topDown(separateDot) -> toBeTyped(factorised)(weightsV)(weightsH)
     ))
   }
 
   test("base to scanline") {
-    rewrite_steps(toTDSL(base)(weights2d), scala.collection.Seq(
+    rewrite_steps(toBeTyped(base)(weights2d), scala.collection.Seq(
       idS
-        -> (P >> *(Sh) >> Sv >> *(T) >> *(*(fun(nbh => toTDSL(dot)(join(weights2d))(join(nbh)))))),
+        -> (P >> *(Sh) >> Sv >> *(T) >> *(*(fun(nbh => toBeTyped(dot)(join(weights2d))(join(nbh)))))),
       topDown(separateDotT)
         -> (P >> *(Sh) >> Sv >> *(T) >> *(*(T >> *(Dv) >> Dh))),
       topDown(`*f >> S -> S >> **f`)
@@ -94,12 +94,12 @@ class separableConvolution2DRewrite extends test_util.Tests {
       topDown(`S >> **f -> *f >> S`)
         -> (P >> Sv >> *(T >> *(Dv) >> Sh >> *(Dh))),
       idS
-        -> toTDSL(scanline)(weightsV)(weightsH)
+        -> toBeTyped(scanline)(weightsV)(weightsH)
     ))
   }
 
   test("scanline to separated") {
-    rewrite_steps(toTDSL(scanline)(weightsV)(weightsH), scala.collection.Seq(
+    rewrite_steps(toBeTyped(scanline)(weightsV)(weightsH), scala.collection.Seq(
       idS
         -> (P >> Sv >> *(T >> *(Dv) >> Sh >> *(Dh))),
       repeatNTimes(2)(topDown(mapFirstFission))
@@ -107,54 +107,54 @@ class separableConvolution2DRewrite extends test_util.Tests {
       skip(1)(mapFusion)
         -> (P >> Sv >> *(T >> *(Dv)) >> *(Sh >> *(Dh))),
       idS
-        -> toTDSL(separated)(weightsV)(weightsH)
+        -> toBeTyped(separated)(weightsV)(weightsH)
     ))
   }
 
   //// lowering
 
   test("base to baseSeq") {
-    rewrite_steps(toTDSL(base)(weights2d), scala.collection.Seq(
+    rewrite_steps(toBeTyped(base)(weights2d), scala.collection.Seq(
       (topDown(lowering.reduceSeqUnroll) `;`
         repeatNTimes(2)(topDown(lowering.mapSeq)))
-        -> toTDSL(baseSeq)(weights2d)
+        -> toBeTyped(baseSeq)(weights2d)
     ))
   }
 
   test("factorised to factorisedSeq") {
-    rewrite_steps(toTDSL(factorised)(weightsV)(weightsH), scala.collection.Seq(
+    rewrite_steps(toBeTyped(factorised)(weightsV)(weightsH), scala.collection.Seq(
       (repeatNTimes(2)(topDown(lowering.reduceSeqUnroll)) `;`
         repeatNTimes(2)(topDown(lowering.mapSeq)))
-        -> toTDSL(factorisedSeq)(weightsV)(weightsH)
+        -> toBeTyped(factorisedSeq)(weightsV)(weightsH)
     ))
   }
 
   test("separated to separatedSeq") {
-    rewrite_steps(toTDSL(separated)(weightsV)(weightsH), scala.collection.Seq(
+    rewrite_steps(toBeTyped(separated)(weightsV)(weightsH), scala.collection.Seq(
       (repeatNTimes(2)(topDown(lowering.reduceSeqUnroll)) `;`
         repeatNTimes(2)(topDown(lowering.mapSeq)) `;`
         repeatNTimes(2)(skip(1)(lowering.mapSeq)) `;`
         body(argument(lowering.toMemAfterMapSeq)))
-        -> toTDSL(separatedSeq)(weightsV)(weightsH)
+        -> toBeTyped(separatedSeq)(weightsV)(weightsH)
     ))
   }
 
   test("scanline to scanlineSeq") {
-    rewrite_steps(toTDSL(scanline)(weightsV)(weightsH), scala.collection.Seq(
+    rewrite_steps(toBeTyped(scanline)(weightsV)(weightsH), scala.collection.Seq(
       (repeatNTimes(2)(topDown(lowering.reduceSeqUnroll)) `;`
         repeatNTimes(2)(topDown(lowering.mapSeq)) `;`
         skip(1)(lowering.mapSeq))
-        -> toTDSL(scanlineSeq)(weightsV)(weightsH)
+        -> toBeTyped(scanlineSeq)(weightsV)(weightsH)
     ))
   }
 
   test("scanline to regRotSeq") {
-    rewrite_steps(toTDSL(scanline)(weightsV)(weightsH), scala.collection.Seq(
+    rewrite_steps(toBeTyped(scanline)(weightsV)(weightsH), scala.collection.Seq(
       (repeatNTimes(2)(topDown(lowering.reduceSeqUnroll)) `;`
         topDown(lowering.mapSeq) `;`
         topDown(lowering.rotateValues(idE)) `;`
         topDown(lowering.iterateStream))
-        -> toTDSL(regRotSeq)(weightsV)(weightsH)
+        -> toBeTyped(regRotSeq)(weightsV)(weightsH)
     ))
   }
 }

--- a/src/test/scala/apps/separableConvolution2DRewrite.scala
+++ b/src/test/scala/apps/separableConvolution2DRewrite.scala
@@ -15,6 +15,7 @@ import rise.elevate.strategies.algorithmic._
 import rise.elevate.rules.traversal._
 import rise.elevate.rules.traversal.alternative._
 import rise.elevate.util.makeClosed
+import rise.core.primitives._
 
 class separableConvolution2DRewrite extends test_util.Tests {
   private val idE: Expr = fun(x => x)
@@ -24,8 +25,8 @@ class separableConvolution2DRewrite extends test_util.Tests {
   private val weightsV = binomialWeightsV
   private val weightsH = binomialWeightsH
 
-  private val * = map
-  private val T = transpose
+  private val * : TDSL[Rise] = map
+  private val T: TDSL[Rise] = transpose
   private val P = toTDSL(padClamp2D(1))
   private val Sh = slide(3)(1)
   private val Sv = slide(3)(1)

--- a/src/test/scala/rise/core/dependentTypes.scala
+++ b/src/test/scala/rise/core/dependentTypes.scala
@@ -3,6 +3,7 @@ package rise.core
 import rise.core.TypedDSL._
 import rise.core.TypeLevelDSL._
 import rise.core.types._
+import rise.core.primitives._
 
 class dependentTypes extends test_util.Tests {
   ignore("Infer int addition type") {

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -17,7 +17,7 @@ class showRise extends test_util.Tests {
       val pixel = pair._1
       val weight = pair._2
       acc + (pixel * weight)
-    }))(l(0.0f))(zip(join(elem))(weights))
+    }))(l(0.0f))(DSL.zip(DSL.join(elem))(weights))
   )
 
   private val blurXTiled2D: Expr = nFun(n =>
@@ -39,8 +39,8 @@ class showRise extends test_util.Tests {
 
   test("show blurXTiled2D as an example") {
     val probe: Expr => Boolean = {
-      case _: PadClamp => true
-      case _           => false
+      case padClamp() => true
+      case _          => false
     }
     val example = blurXTiled2D
     val show = trackWith(probe, example, 10, defaultUnicodeConfig)
@@ -59,7 +59,7 @@ class showRise extends test_util.Tests {
           block(s"Λ${x.name}:${dl.kindName}", drawASTSimp(e))
         case DepApp(f, x)     => line(x.toString) <+: drawASTSimp(f)
         case Literal(d)       => line(d.toString)
-        case Annotation(e, _) => drawASTSimp(e)
+        case TypeAnnotation(e, _) => drawASTSimp(e)
         case p: Primitive     => line(p.name)
       }
     }
@@ -97,7 +97,7 @@ class showRise extends test_util.Tests {
 
         case Literal(d) => d.toString
 
-        case Annotation(e, _) => lessBrackets(e, wrapped)
+        case TypeAnnotation(e, _) => lessBrackets(e, wrapped)
 
         case p: Primitive => p.name
       }

--- a/src/test/scala/rise/core/structuralEquality.scala
+++ b/src/test/scala/rise/core/structuralEquality.scala
@@ -75,9 +75,9 @@ class structuralEquality extends test_util.Tests {
 
   test("dependent function type using an array") {
     assert(
-      nFunT(n => dtFunT(a => dtFunT(t => ArrayType(n, a) ->: t)))
+      forallNat(n => forallDT(a => forallDT(t => ArrayType(n, a) ->: t)))
         ==
-          nFunT(m => dtFunT(b => dtFunT(t => ArrayType(m, b) ->: t)))
+          forallNat(m => forallDT(b => forallDT(t => ArrayType(m, b) ->: t)))
     )
   }
 }

--- a/src/test/scala/rise/core/traverse.scala
+++ b/src/test/scala/rise/core/traverse.scala
@@ -1,16 +1,15 @@
 package rise.core
 
-import rise.core.types._
-import rise.core.primitives._
-import rise.core.traversal._
 import rise.core.DSL._
+import rise.core.traversal._
+import rise.core.types._
 
 import scala.collection.mutable
 
 class traverse extends test_util.Tests {
   val e: DepLambda[NatKind] = nFun(h =>
     nFun(w =>
-      fun(ArrayType(h, ArrayType(w, f32)))(input => map(map(fun(x => x)))(input)
+      fun(ArrayType(h, ArrayType(w, f32)))(input => DSL.map(DSL.map(fun(x => x)))(input)
       )
     )
   )
@@ -47,10 +46,10 @@ class traverse extends test_util.Tests {
         { case ArrayType(_, ArrayType(_, _: ScalarType)) => () },
         { case _: App                                    => () },
         { case _: App                                    => () },
-        { case _: Map                                    => () },
+        { case primitives.map()                          => () },
         { case TypePlaceholder                           => () },
         { case _: App                                    => () },
-        { case _: Map                                    => () },
+        { case primitives.map()                          => () },
         { case TypePlaceholder                           => () },
         { case _: Lambda                                 => () },
         { case _: Identifier                             => () },
@@ -101,7 +100,7 @@ class traverse extends test_util.Tests {
     class Visitor extends TraceVisitor(trace) {
       override def visitExpr(expr: Expr): Result[Expr] = {
         expr match {
-          case App(App(Map(), _), e) =>
+          case App(App(primitives.map(), _), e) =>
             val r = app(fun(x => x), e)
             println(r)
             Stop(r)
@@ -135,14 +134,14 @@ class traverse extends test_util.Tests {
   test("traverse an expression depth-first with global stop") {
     val e = nFun(n =>
       fun(ArrayType(n, f32))(input =>
-        input |> map(fun(x => x)) |> map(fun(x => x))
+        input |> DSL.map(fun(x => x)) |> DSL.map(fun(x => x))
       )
     )
 
     class Visitor extends traversal.Visitor {
       override def visitExpr(expr: Expr): Result[Expr] = {
         expr match {
-          case App(Map(), f) =>
+          case App(primitives.map(), f) =>
             println(f)
             Stop(f)
           case _ => Continue(expr, this)
@@ -158,7 +157,7 @@ class traverse extends test_util.Tests {
         val expected = nFun(n =>
           fun(ArrayType(n, f32))(input => {
             val x = identifier(freshName("x"))
-            app(lambda(x, x), input |> map(fun(x => x)))
+            app(lambda(x, x), input |> DSL.map(fun(x => x)))
           })
         )
         assert(r == expected)

--- a/src/test/scala/rise/elevate/algorithmic.scala
+++ b/src/test/scala/rise/elevate/algorithmic.scala
@@ -104,7 +104,7 @@ class algorithmic extends test_util.Tests {
                 reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(
                   l(0.0f)))))))))))
 
-    def goldMKN(reduceFun: TDSL[Rise]): Rise = {
+    def goldMKN(reduceFun: ToBeTyped[Rise]): Rise = {
       depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>

--- a/src/test/scala/rise/elevate/algorithmic.scala
+++ b/src/test/scala/rise/elevate/algorithmic.scala
@@ -4,6 +4,7 @@ import elevate.core.Strategy
 import elevate.core.strategies.basic._
 import elevate.core.strategies.traversal._
 import rise.core.TypeLevelDSL._
+import rise.core.primitives._
 import rise.core.TypedDSL._
 import rise.core._
 import rise.core.types._
@@ -76,7 +77,7 @@ class algorithmic extends test_util.Tests {
       depLambda[NatKind](M, depLambda[NatKind](N,
         fun(ArrayType(M, ArrayType(N, f32)))(i =>
           reduce(fun((acc, y) =>
-            map(addTuple) $ zip(acc, y)))(generate(fun(IndexType(M) ->: f32)(_ => l(0.0f)))) $ transpose(i))))
+            map(addTuple) $ zip(acc)(y)))(generate(fun(IndexType(M) ->: f32)(_ => l(0.0f)))) $ transpose(i))))
 
     val rewrite = body(body(body(function(liftReduce))))(DFNF(mapReduce).get).get
 
@@ -97,31 +98,25 @@ class algorithmic extends test_util.Tests {
     val mm = depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
       fun(ArrayType(M, ArrayType(K, f32)))(a =>
         fun(ArrayType(K, ArrayType(N, f32)))(b =>
-          map(fun(ak =>
-            map(fun(bk =>
-              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)), l(0.0f))) $
-                zip(ak, bk))) $ transpose(b) )) $ a)))))
+          a |> map(fun(ak =>
+            transpose(b) |> map(fun(bk =>
+              zip(ak)(bk) |>
+                reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(
+                  l(0.0f)))))))))))
 
     def goldMKN(reduceFun: TDSL[Rise]): Rise = {
       depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>
-            map(fun(ak =>
-              reduceSeq(
-                reduceFun,
-                generate(fun(IndexType(N) ->: f32)(_ => l(0.0f)))
-              ) $
-                zip(ak, b))
-            ) $ a
-          )
-        )
-      )))
+            a |> map(fun(ak =>
+              zip(ak)(b) |> reduceSeq(reduceFun)(
+                generate(fun(IndexType(N) ->: f32)(_ => l(0.0f)))))))))))
     }
 
     val goldMKNVersion1 = goldMKN(
       fun((acc, y) => // y :: (f32, N.f32); acc :: N.f32
         mapSeq(fun(t => fst(t) + snd(t))) $
-          zip(acc,
+          zip(acc)(
             mapSeq(fun(bs => bs * fst(y))) $ snd(y))
       )
     )
@@ -132,8 +127,8 @@ class algorithmic extends test_util.Tests {
        val as = fst(aBN)
        map(fun(t => fst(t) + (fst(snd(t)) * snd(snd(t))))) $
          /* N.(f32, (f32, f32))*/
-         zip(acc,
-           map(fun(bs => pair(bs, as))) $ BN/*:N.f32*/)
+         zip(acc)(
+           map(fun(bs => pair(bs)(as))) $ BN/*:N.f32*/)
      })
     )
 
@@ -160,12 +155,12 @@ class algorithmic extends test_util.Tests {
                 fun((acc, y) => { // akB :: (f32, N.f32); acc :: N.f32
                   map(fun(t => fst(t) + (fst(snd(t)) * snd(snd(t))))) $
                     /* N.(f32, (f32, f32))*/
-                    zip(acc,
-                      map(fun(bs => pair(bs, fst(y)))) $ snd(y)/*:N.f32*/)
-                }),
+                    zip(acc)(
+                      map(fun(bs => pair(bs)(fst(y)))) $ snd(y)/*:N.f32*/)
+                }))(
                 generate(fun(IndexType(N) ->: f32)(_ => l(0.0f)))
               ) $
-                zip(ak, b))
+                zip(ak)(b))
             ) $ a
           )
         )
@@ -198,8 +193,8 @@ class algorithmic extends test_util.Tests {
     val op = fun((acc, y) => { // akB :: (f32, N.f32); acc :: N.f32
       map(fun(t => fst(t) + (fst(snd(t)) * snd(snd(t))))) $
         /* N.(f32, (f32, f32))*/
-        zip(acc,
-          map(fun(bs => pair(bs, fst(y)))) $ snd(y)/*:N.f32*/)
+        zip(acc)(
+          map(fun(bs => pair(bs)(fst(y)))) $ snd(y)/*:N.f32*/)
     })
 
     // this one is constructed more similar to what the rewrite rules will create
@@ -212,12 +207,12 @@ class algorithmic extends test_util.Tests {
                 map(fun(x => // x :: M.((f32, N.f32), N.f32)
                   app(app(op, fst(x)), snd(x)))) $
                   // M.((f32, N.f32), N.f32)
-                  zip(acc, map(fun(t => pair(t,snd(y)))) $ fst(y))),
+                  zip(acc)(map(fun(t => pair(t)(snd(y)))) $ fst(y))))(
               // generate zeros :: M.N.f32
               generate(fun(IndexType(M) ->: ArrayType(N, f32))(_ =>
                 generate(fun(IndexType(N) ->: f32)(_ => l(0.0f) ))))
             ) $
-              zip(transpose(a), b) // :: K.(M.f32, N.f32)
+              zip(transpose(a))(b) // :: K.(M.f32, N.f32)
           ))
       )))
 
@@ -231,12 +226,12 @@ class algorithmic extends test_util.Tests {
                 map(fun(x => // x :: M.((f32, N.f32), N.f32)
                   app(app(op, fst(x)), snd(x)))) $
                   // M.((N.f32, f32), N.f32)
-                  zip(acc, map(fun(t => pair(t,fst(y)))) $ snd(y))),
+                  zip(acc)(map(fun(t => pair(t)(fst(y)))) $ snd(y))))(
               // generate zeros :: M.N.f32
               generate(fun(IndexType(M) ->: ArrayType(N, f32))(_ =>
                 generate(fun(IndexType(N) ->: f32)(_ => l(0.0f) ))))
             ) $
-              zip(b,transpose(a)) // :: K.(N.f32, M.f32)
+              zip(b)(transpose(a)) // :: K.(N.f32, M.f32)
           ))
       )))
 
@@ -286,8 +281,8 @@ class algorithmic extends test_util.Tests {
         fun(ArrayType(K, ArrayType(N, f32)))(b =>
           map(fun(ak =>
             map(fun(bk =>
-              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)), l(0.0f))) $
-                zip(ak, bk))) $ transpose(b) )) $ a)))))).get
+              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(l(0.0f))) $
+                zip(ak)(bk))) $ transpose(b) )) $ a)))))).get
 
     val typedMM = infer(mm)
 
@@ -328,8 +323,8 @@ class algorithmic extends test_util.Tests {
         ((a, b) =>
           map(fun(ak =>
             map(fun(bk =>
-              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)), l(0.0f))) $
-                zip(ak, bk))) $ transpose(b) )) $ a
+              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(l(0.0f))) $
+                zip(ak)(bk))) $ transpose(b) )) $ a
         )
       )
 
@@ -433,7 +428,7 @@ class algorithmic extends test_util.Tests {
 
     val test = nFun(n => nFun(m => fun(ArrayType(n, ArrayType(m, f32)))(i =>
       reduceSeq(fun((y, acc) =>
-        map(addT) $ zip(y)(acc)),
+        map(addT) $ zip(y)(acc)))(
         generate(fun(IndexType(m) ->: f32)(_ => l(0.0f)))) $ i)))
 
     infer(test)

--- a/src/test/scala/rise/elevate/circularBuffering.scala
+++ b/src/test/scala/rise/elevate/circularBuffering.scala
@@ -109,7 +109,7 @@ class circularBuffering extends test_util.Tests {
 
   private def openEquality(typedA: Rise, b: Rise): Boolean = {
     import rise.core.TypedDSL._
-    val typedB: Rise = toTDSL(b) :: typedA.t
+    val typedB: Rise = toBeTyped(b) :: typedA.t
     makeClosed(typedA)._1 == makeClosed(typedB)._1
   }
 

--- a/src/test/scala/rise/elevate/fissionFusion.scala
+++ b/src/test/scala/rise/elevate/fissionFusion.scala
@@ -5,6 +5,7 @@ import elevate.core.strategies.basic._
 import elevate.core.strategies.traversal.{position, topDown}
 import rise.elevate.util._
 import rise.core.TypedDSL._
+import rise.core.primitives._
 import rise.core._
 import rise.elevate.rules.algorithmic.{mapFusion, mapLastFission}
 import rise.elevate.rules.traversal.default._

--- a/src/test/scala/rise/elevate/halide.scala
+++ b/src/test/scala/rise/elevate/halide.scala
@@ -3,7 +3,7 @@ package rise.elevate
 import elevate.core.strategies.traversal._
 import elevate.core.{NotApplicable, Strategy}
 import rise.elevate.util._
-import rise.core.TypedDSL.{reorder => _, _}
+import rise.core.TypedDSL._
 import rise.elevate.rules.traversal._
 import rise.elevate.rules.traversal.default._
 import rise.elevate.strategies.halide._

--- a/src/test/scala/rise/elevate/movement.scala
+++ b/src/test/scala/rise/elevate/movement.scala
@@ -21,7 +21,7 @@ class movement extends test_util.Tests {
   def betaEtaEquals(a: Rise, b: Rise): Boolean = {
     val na = BENF(a).get
     val nb = BENF(b).get
-    val uab: Rise = toTDSL(na) :: nb.t
+    val uab: Rise = toBeTyped(na) :: nb.t
     makeClosed(uab) == makeClosed(nb)
   }
 

--- a/src/test/scala/rise/elevate/movement.scala
+++ b/src/test/scala/rise/elevate/movement.scala
@@ -4,6 +4,7 @@ import elevate.core.strategies.predicate.rewriteResultToBoolean
 import elevate.core.strategies.traversal._
 import rise.elevate.util._
 import rise.core.TypedDSL._
+import rise.core.primitives._
 import rise.core._
 import rise.core.types.f32
 import rise.core.TypeLevelDSL._
@@ -31,7 +32,7 @@ class movement extends test_util.Tests {
       List(
         DFNF(λ(f => *(λ(x => *(f)(x))) >> T)).get,
         toExpr(λ(f => **(f) >> T))
-      ).map((topDown(`**f >> T -> T >> **f`()(RiseTraversable))).apply(_).get), gold
+      ).map(topDown(`**f >> T -> T >> **f`()(RiseTraversable)).apply(_).get), gold
     )
   }
 
@@ -46,10 +47,10 @@ class movement extends test_util.Tests {
           (transpose o map(fun(ac =>
             map(fun(bc =>
               (fun(x => (x * alpha) + beta * bc._2) o
-                reduceSeq(fun((acc, y) => acc + (y._1 * y._2)), l(0.0f))) $
-                zip(ac._1, bc._1))) $
-              zip(transpose(b),ac._2)))) $
-            zip(a, c)
+                reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(l(0.0f))) $
+                zip(ac._1)(bc._1))) $
+              zip(transpose(b))(ac._2)))) $
+            zip(a)(c)
         )
       )
 

--- a/src/test/scala/rise/elevate/tiling.scala
+++ b/src/test/scala/rise/elevate/tiling.scala
@@ -34,7 +34,7 @@ class tiling extends test_util.Tests {
   def betaEtaEquals(a: Rise, b: Rise): Boolean = {
     val na = BENF(a).get
     val nb = BENF(b).get
-    val uab: Rise = toTDSL(na) :: nb.t
+    val uab: Rise = toBeTyped(na) :: nb.t
     makeClosed(uab) == makeClosed(nb)
   }
   // Check that DSL makes sense
@@ -247,9 +247,9 @@ class tiling extends test_util.Tests {
   }
 
   def wrapInLambda[T <: Expr](dim: Int,
-                   f: TDSL[Identifier] => TDSL[T],
-                   genInputType: List[NatIdentifier] => ArrayType,
-                   natIds: List[NatIdentifier] = List()): TDSL[DepLambda[NatKind]] = {
+                              f: ToBeTyped[Identifier] => ToBeTyped[T],
+                              genInputType: List[NatIdentifier] => ArrayType,
+                              natIds: List[NatIdentifier] = List()): ToBeTyped[DepLambda[NatKind]] = {
     dim match {
       case 1 => nFun(n => fun(genInputType( natIds :+ n))(f))
       case d => nFun(n => wrapInLambda(d - 1, f, genInputType, natIds :+ n))

--- a/src/test/scala/rise/elevate/tiling.scala
+++ b/src/test/scala/rise/elevate/tiling.scala
@@ -5,6 +5,7 @@ import elevate.core.strategies.traversal._
 import elevate.core.{RewriteResult, Strategy}
 import rise.core.TypeLevelDSL._
 import rise.core.TypedDSL._
+import rise.core.primitives._
 import rise.core._
 import rise.core.types.{ArrayType, NatKind, f32, infer, _}
 import rise.elevate.rules._

--- a/src/test/scala/rise/elevate/traversals.scala
+++ b/src/test/scala/rise/elevate/traversals.scala
@@ -38,22 +38,22 @@ class traversals extends test_util.Tests {
     println(orig.toString)
 
     val oldTiling = body(body(
-      function(argumentOf(Map()(), body(function(splitJoin(4)) `;` DFNF `;` RNF))) `;`
+      function(argumentOf(map.primitive, body(function(splitJoin(4)) `;` DFNF `;` RNF))) `;`
         function(splitJoin(4)) `;`
         DFNF `;` RNF `;` DFNF `;` RNF `;` DFNF `;`
-        argument(argument(function(argumentOf(Map()(), body(idAfter `;` createTransposePair `;` DFNF `;` argument(mapMapFBeforeTranspose())))) `;` DFNF `;` RNF)) `;`
+        argument(argument(function(argumentOf(map.primitive, body(idAfter `;` createTransposePair `;` DFNF `;` argument(mapMapFBeforeTranspose())))) `;` DFNF `;` RNF)) `;`
         DFNF `;` RNF `;` DFNF `;` RNF `;` RNF
     ))
 
     val simplified = body(body(
-      function(argumentOf(Map()(), body(function(splitJoin(4))))) `;`
+      function(argumentOf(map.primitive, body(function(splitJoin(4))))) `;`
         function(splitJoin(4)) `;`
         RNF `;` DFNF `;`
-        argument(argument(function(argumentOf(Map()(), body(idAfter `;` createTransposePair `;` DFNF `;` argument(mapMapFBeforeTranspose())))) `;` RNF))))
+        argument(argument(function(argumentOf(map.primitive, body(idAfter `;` createTransposePair `;` DFNF `;` argument(mapMapFBeforeTranspose())))) `;` RNF))))
 
     val normalized = FNF(simplified).get
     println(normalized)
-    val normalizedModified = body(body(function(argumentOf(Map()(), body(function(splitJoin(4))))))) `;`
+    val normalizedModified = body(body(function(argumentOf(map.primitive, body(function(splitJoin(4))))))) `;`
     inferType `;`
       body(body(function(splitJoin(4)))) `;`
       inferType `;`
@@ -61,13 +61,13 @@ class traversals extends test_util.Tests {
       inferType `;`
       body(body(DFNF)) `;`
       inferType `;`
-      body(body(argument(argument(function(argumentOf(Map()(), body(idAfter))))))) `;`
+      body(body(argument(argument(function(argumentOf(map.primitive, body(idAfter))))))) `;`
       inferType `;`
-      body(body(argument(argument(function(argumentOf(Map()(), body(createTransposePair))))))) `;`
+      body(body(argument(argument(function(argumentOf(map.primitive, body(createTransposePair))))))) `;`
       inferType `;`
-      body(body(argument(argument(function(argumentOf(Map()(), body(DFNF))))))) `;`
+      body(body(argument(argument(function(argumentOf(map.primitive, body(DFNF))))))) `;`
       inferType `;`
-      body(body(argument(argument(function(argumentOf(Map()(), body(argument(mapMapFBeforeTranspose())))))))) `;`
+      body(body(argument(argument(function(argumentOf(map.primitive, body(argument(mapMapFBeforeTranspose())))))))) `;`
       inferType `;`
       body(body(argument(argument(RNF))))
 

--- a/src/test/scala/rise/elevate/tvmGemm.scala
+++ b/src/test/scala/rise/elevate/tvmGemm.scala
@@ -7,6 +7,7 @@ import elevate.core.strategies.basic._
 import elevate.core.strategies.debug.debug
 import elevate.core.strategies.traversal._
 import rise.core.TypedDSL._
+import rise.core.primitives._
 import rise.core.types._
 import rise.elevate.rules.algorithmic._
 import rise.elevate.rules.lowering._
@@ -37,7 +38,7 @@ class tvmGemm extends test_util.Tests {
       fun(ArrayType(N, ArrayType(N, f32)))(b =>
         a |> map(fun(ak =>
           transpose(b) |> map(fun(bk =>
-            zip(ak, bk) |>
+            zip(ak)(bk) |>
               map(fun(x => fst(x) * snd(x))) |>
               reduce(add)(l(0.0f))
           ))

--- a/src/test/scala/rise/elevate/util/package.scala
+++ b/src/test/scala/rise/elevate/util/package.scala
@@ -50,9 +50,9 @@ package object util {
   }
 
   // notation
-  def T: TDSL[Transpose] = transpose
+  def T: TDSL[Rise] = transpose
   def S: TDSL[DepApp[NatKind]] = split(tileSize) //slide(3)(1)
-  def J: TDSL[Join] = join
+  def J: TDSL[Rise] = join
   def *(x: TDSL[Rise]): TDSL[App] = map(x)
   def **(x: TDSL[Rise]): TDSL[App] = map(map(x))
   def ***(x: TDSL[Rise]): TDSL[App] = map(map(map(x)))

--- a/src/test/scala/rise/elevate/util/package.scala
+++ b/src/test/scala/rise/elevate/util/package.scala
@@ -50,35 +50,35 @@ package object util {
   }
 
   // notation
-  def T: TDSL[Rise] = transpose
-  def S: TDSL[DepApp[NatKind]] = split(tileSize) //slide(3)(1)
-  def J: TDSL[Rise] = join
-  def *(x: TDSL[Rise]): TDSL[App] = map(x)
-  def **(x: TDSL[Rise]): TDSL[App] = map(map(x))
-  def ***(x: TDSL[Rise]): TDSL[App] = map(map(map(x)))
-  def ****(x: TDSL[Rise]): TDSL[App] = map(map(map(map(x))))
-  def *****(x: TDSL[Rise]): TDSL[App] = map(map(map(map(map(x)))))
-  def ******(x: TDSL[Rise]): TDSL[App] = map(map(map(map(map(map(x))))))
+  def T: ToBeTyped[Rise] = transpose
+  def S: ToBeTyped[DepApp[NatKind]] = split(tileSize) //slide(3)(1)
+  def J: ToBeTyped[Rise] = join
+  def *(x: ToBeTyped[Rise]): ToBeTyped[App] = map(x)
+  def **(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(x))
+  def ***(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(map(x)))
+  def ****(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(map(map(x))))
+  def *****(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(map(map(map(x)))))
+  def ******(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(map(map(map(map(x))))))
 
-  def λ(f: TDSL[Identifier] => TDSL[Expr]): TDSL[Lambda] = fun(f)
+  def λ(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Lambda] = fun(f)
 
   // map in LCNF
-  def *!(x: TDSL[Rise]): TDSL[App] = {
+  def *!(x: ToBeTyped[Rise]): ToBeTyped[App] = {
     val i = identifier(freshName("e"))
     map(lambda(i, app(x, i)))
   }
 
-  def **!(x: TDSL[Rise]): TDSL[App] = {
+  def **!(x: ToBeTyped[Rise]): ToBeTyped[App] = {
     val i = identifier(freshName("e"))
     map(lambda(i, app(*!(x), i)))
   }
 
-  def ***!(x: TDSL[Rise]): TDSL[App] = {
+  def ***!(x: ToBeTyped[Rise]): ToBeTyped[App] = {
     val i = identifier(freshName("e"))
     map(lambda(i, app(**!(x), i)))
   }
 
-  def ****!(x: TDSL[Rise]): TDSL[App] = {
+  def ****!(x: ToBeTyped[Rise]): ToBeTyped[App] = {
     val i = identifier(freshName("e"))
     map(lambda(i, app(***!(x), i)))
   }

--- a/src/test/scala/shine/DPIA/Store.scala
+++ b/src/test/scala/shine/DPIA/Store.scala
@@ -1,7 +1,7 @@
 package shine.DPIA
 
-import rise.core._
 import rise.core.TypedDSL._
+import rise.core.primitives._
 import rise.core.types._
 import util.gen
 
@@ -18,7 +18,7 @@ class Store extends test_util.Tests {
     )).code)
     // this is surprising behaviour
     plusNum(2, gen.CProgram(fun(int)(x =>
-      TypedDSL.let(x + l(2))(fun(y => y * y) )
+      let(x + l(2))(fun(y => y * y) )
     )).code)
     // this is what we actually would expect
     plusNum(1, gen.CProgram(fun(int)(x =>


### PR DESCRIPTION
An update to the `@primitive` macro allows the following more concise syntax:

```scala
@primitive object mapSeq extends Primitive with Builder {
    implNat(n => implDT(s => implDT(t =>
      (s ->: t) ->: (n`.`s) ->: (n`.`t))))
}
```
instead of the prior:
```scala
@primitive case class MapSeq()(override val t: Type = TypePlaceholder)
      extends Primitive {
    override def typeScheme: Type = implN(n => implDT(s => implDT(t =>
      (s ->: t) ->: ArrayType(n, s) ->: ArrayType(n, t)
    )))
  }
```

This PR also renames for consistency:
 - `implN` into `implNat`
 - `implT` into `implType`
 - `implA` into `implAddr`
 - `nFunT` into `forallNat`
 - `dtFunT` into `forallDT`
 - `n2nFunT` into `forallN2N`
 - `n2dtFunT` into `forallN2DT`
 - `aFunT` into `forallAddr`
 - `Annotation` into `TypeAnnotation`