### PR TITLE
Allow clang to take unused cli arguments given by NixOS's clang wrapper

### DIFF
--- a/src/main/scala/util/SyntaxChecker.scala
+++ b/src/main/scala/util/SyntaxChecker.scala
@@ -8,7 +8,7 @@ object SyntaxChecker {
   case class Exception(msg: String) extends Throwable
 
   @throws[SyntaxChecker.Exception]("if code doesn't pass the syntax check")
-  def apply(code: String, extension: String = ".c", options: String = "-Werror -Wno-implicit-function-declaration -Wno-parentheses-equality"): Unit = {
+  def apply(code: String, extension: String = ".c", options: String = "-Werror -Wno-implicit-function-declaration -Wno-parentheses-equality -Wno-unused-command-line-argument"): Unit = {
     try {
       s"clang -fsyntax-only $options ${writeToTempFile("code-", extension, code).getAbsolutePath}" !!
     } catch {


### PR DESCRIPTION
Otherwise -Werror makes errors out of these warnings.