### PR TITLE
Add list of RISE primitives and their types to docs

### DIFF
--- a/docs-website/.gitignore
+++ b/docs-website/.gitignore
@@ -7,7 +7,6 @@
 # Generated files
 .docusaurus
 .cache-loader
-docs/*.md
 docs/**/*.md
 
 # Misc

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -35,4 +35,9 @@ module.exports = {
       ],
     }
   ],
+  docs: {
+    'Getting started': ['greeting', 'setup'],
+    'Tutorials': ['overview'],
+    'Language Reference': ['reference/rise-primitives']
+  },
 };

--- a/docs/reference/rise-primitives.md
+++ b/docs/reference/rise-primitives.md
@@ -1,0 +1,30 @@
+---
+id: rise-primitives
+title: RISE Primitives
+sidebar_label: RISE Primitives
+slug: /reference/rise-primitives
+---
+
+## Type syntax cheatsheet
+
+**Note**: curly braces quantify over implicit parameters.
+
+Type | Syntax
+-----|-------
+Function from `A` to `B` | `(A -> B)`
+Dependent function from `a : A` to `B a` | `(x : A -> B)`
+Dependent function application | `f(n)`
+Vector of `A` of size `n` | `<n>A`
+Array of `A` of size `n` | `n.A`
+Dependent array of `F : Nat -> A` of size `n` | `n..F`
+Index of size `n : Nat` | `idx[n]`
+Pair of `A` and `B` | `(A, B)`
+Dependent pair of `x : A` and `B a` | `(x : A ** B)`
+
+## Primitives
+
+```scala mdoc:passthrough
+    val primTypeScheme = os.pwd / os.RelPath("src/main/scala/rise/core/primitives/primitives.rise")
+    val output = Seq("```", os.read(primTypeScheme), "```").mkString("\n")
+    println(output)
+```


### PR DESCRIPTION
Exposes a list of primitives in `rise.core.primitives`, and uses mdoc to iterate over the list and print the `typeScheme` associated with each primitive. The type pretty printing is rather atrocious, not sure this is the best way to go about it.