### PR TITLE
Clean up type inference constraint collection

### DIFF
--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -12,14 +12,13 @@ object infer {
   private [DSL] def apply(e: Expr,
             printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off,
             explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off): Expr = {
-    val constraints = mutable.ArrayBuffer[Constraint]()
     // Constraints of the form `implicit type var == explicit type var` result in substitutions
     // `implicit type var -> explicit type var`. We (ab)use that fact to create directed constraints out of
     // type assertions and opaque types. To do so, we make the type identifiers on one side of the constraint explicit,
     // and we return a `ftvSubs` map that maps these explicit type identifiers back to implicit type identifiers.
-    val (typed_e, ftvSubs) = constrainTypes(e, constraints, mutable.Map())
+    val (typed_e, constraints, ftvSubs) = constrainTypes(Map())(e)
     // Applies ftvSubs to the constraint solutions
-    val solution = Constraint.solve(constraints.toSeq, Seq())(explDep) ++ ftvSubs
+    val solution = Constraint.solve(constraints, Seq())(explDep) ++ ftvSubs
     val res = traverse(typed_e, Visitor(solution))
     if (printFlag == Flags.PrintTypesAndTypeHoles.On) {
       printTypesAndTypeHoles(res)
@@ -123,96 +122,72 @@ object infer {
     ftvs.distinct.toSeq
   }
 
-  private def constrainTypes(
-                              expr: Expr,
-                              constraints: mutable.ArrayBuffer[Constraint],
-                              env: mutable.Map[String, Type]
-                            ): (Expr, Solution) = {
-    def constrained(e: Expr): (Expr, Solution) =
-      constrainTypes(e, constraints, env)
-    def genType(e: Expr): Type =
-      if (e.t == TypePlaceholder) freshTypeIdentifier else e.t
+  private val genType : Expr => Type = e => if (e.t == TypePlaceholder) freshTypeIdentifier else e.t
 
-    expr match {
-      case i: Identifier =>
-        val t = env.getOrElseUpdate(i.name,
-          if (i.t == TypePlaceholder) {
-            error(s"$i has no type")(Seq())
-          } else {
-            i.t
-          })
-        constraints += TypeConstraint(t, i.t)
-        (i.setType(t), Solution())
+  private val constrainTypes : Map[String, Type] => Expr => (Expr, Seq[Constraint], Solution) = env => {
+    case i: Identifier =>
+      val t = env.getOrElse(i.name,
+        if (i.t == TypePlaceholder) error(s"$i has no type")(Seq()) else i.t )
+      val c = TypeConstraint(t, i.t)
+      (i.setType(t), Nil :+ c, Solution())
 
-      case Lambda(x, e) =>
-        val tx = x.setType(genType(x))
-        env.update(tx.name, tx.t)
-        val (te, ftvSubsE) = constrained(e)
-        env remove tx.name
-        val ft = FunType(tx.t, te.t)
-        val exprT = genType(expr)
-        val constraint = TypeConstraint(exprT, ft)
-        constraints += constraint
-        (Lambda(tx, te)(ft), ftvSubsE)
+    case expr@Lambda(x, e) =>
+      val tx = x.setType(genType(x))
+      val env1 : Map[String, Type] = env + (tx.name -> tx.t)
+      val (te, cs, ftvE) = constrainTypes(env1)(e)
+      val ft = FunType(tx.t, te.t)
+      val exprT = genType(expr)
+      val c = TypeConstraint(exprT, ft)
+      (Lambda(tx, te)(ft), cs :+ c, ftvE)
 
-      case App(f, e) =>
-        val (tf, ftvSubsF) = constrained(f)
-        val (te, ftvSubsE) = constrained(e)
-        val exprT = genType(expr)
-        val constraint = TypeConstraint(tf.t, FunType(te.t, exprT))
-        constraints += constraint
-        (App(tf, te)(exprT), ftvSubsF <> ftvSubsE)
+    case expr@App(f, e) =>
+      val (tf, csF, ftvF) = constrainTypes(env)(f)
+      val (te, csE, ftvE) = constrainTypes(env)(e)
+      val exprT = genType(expr)
+      val c = TypeConstraint(tf.t, FunType(te.t, exprT))
+      (App(tf, te)(exprT), csF :++ csE :+ c, ftvF <> ftvE)
 
-      case DepLambda(x, e) =>
-        val (te, ftvSubsE) = constrained(e)
-        val exprT = genType(expr)
-        val tf = x match {
-          case n: NatIdentifier =>
-            DepLambda[NatKind](n, te)(DepFunType[NatKind, Type](n, te.t))
-          case dt: DataTypeIdentifier =>
-            DepLambda[DataKind](dt, te)(DepFunType[DataKind, Type](dt, te.t))
-          case ad: AddressSpaceIdentifier =>
-            DepLambda[AddressSpaceKind](ad, te)(
-              DepFunType[AddressSpaceKind, Type](ad, te.t)
-            )
-          case n2n: NatToNatIdentifier =>
-            DepLambda[NatToNatKind](n2n, te)(
-              DepFunType[NatToNatKind, Type](n2n, te.t)
-            )
-        }
-        val constraint = TypeConstraint(exprT, tf.t)
-        constraints += constraint
-        (tf, ftvSubsE)
+    case expr@DepLambda(x, e) =>
+      val (te, csE, ftvE) = constrainTypes(env)(e)
+      val exprT = genType(expr)
+      val tf = x match {
+        case n: NatIdentifier =>
+          DepLambda[NatKind](n, te)(DepFunType[NatKind, Type](n, te.t))
+        case dt: DataTypeIdentifier =>
+          DepLambda[DataKind](dt, te)(DepFunType[DataKind, Type](dt, te.t))
+        case ad: AddressSpaceIdentifier =>
+          DepLambda[AddressSpaceKind](ad, te)(DepFunType[AddressSpaceKind, Type](ad, te.t))
+        case n2n: NatToNatIdentifier =>
+          DepLambda[NatToNatKind](n2n, te)(DepFunType[NatToNatKind, Type](n2n, te.t))
+      }
+      val c = TypeConstraint(exprT, tf.t)
+      (tf, csE :+ c, ftvE)
 
-      case DepApp(f, x) =>
-        val (tf, ftvSubsF) = constrained(f)
-        val exprT = genType(expr)
-        val constraint = DepConstraint(tf.t, x, exprT)
-        constraints += constraint
-        (DepApp(tf, x)(exprT), ftvSubsF)
+    case expr@DepApp(f, x) =>
+      val (tf, csF, ftvF) = constrainTypes(env)(f)
+      val exprT = genType(expr)
+      val c = DepConstraint(tf.t, x, exprT)
+      (DepApp(tf, x)(exprT), csF :+ c, ftvF)
 
-      case TypeAnnotation(e, t) =>
-        val (te, ftvSubsE) = constrained(e)
-        val constraint = TypeConstraint(te.t, t)
-        constraints += constraint
-        (te, ftvSubsE)
+    case TypeAnnotation(e, t) =>
+      val (te, csE, ftvE) = constrainTypes(env)(e)
+      val c = TypeConstraint(te.t, t)
+      (te, csE :+ c, ftvE)
 
-      case TypeAssertion(e, t) =>
-        val ftvSubsT = getFTVSubs(t)
-        val (te, ftvSubsE) = constrained(e)
-        val constraint = TypeConstraint(te.t, freeze(ftvSubsT, t))
-        constraints += constraint
-        (te, ftvSubsE <> ftvSubsT)
+    case TypeAssertion(e, t) =>
+      val ftvT = getFTVSubs(t)
+      val (te, csE, ftvE) = constrainTypes(env)(e)
+      val c = TypeConstraint(te.t, freeze(ftvT, t))
+      (te, csE :+ c, ftvE <> ftvT)
 
-      case o: Opaque =>
-        val ftvSubs = getFTVSubs(o.t)
-        val frozenExpr = Opaque(o.e, freeze(ftvSubs, o.t))
-        (frozenExpr, ftvSubs)
+    case o: Opaque =>
+      val ftvO = getFTVSubs(o.t)
+      val frozenExpr = Opaque(o.e, freeze(ftvO, o.t))
+      (frozenExpr, Nil, ftvO)
 
-      case l: Literal => (l, Solution())
+    case l: Literal => (l, Nil, Solution())
 
-      case p: Primitive => (p.setType(p.typeScheme), Solution())
-    }
+    case p: Primitive => (p.setType(p.typeScheme), Nil, Solution())
   }
 
   private case class Visitor(sol: Solution) extends PureTraversal {

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -10,7 +10,7 @@ import rise.core.types.InferenceException.error
 
 import scala.collection.mutable
 
-trait Constraint
+sealed trait Constraint
 case class TypeConstraint(a: Type, b: Type) extends Constraint {
   override def toString: String = s"$a  ~  $b"
 }
@@ -19,10 +19,6 @@ case class NatConstraint(a: Nat, b: Nat) extends Constraint {
 }
 case class BoolConstraint(a: arithexpr.arithmetic.BoolExpr,
                           b: arithexpr.arithmetic.BoolExpr) extends Constraint {
-  override def toString: String = s"$a  ~  $b"
-}
-case class AddressSpaceConstraint(a: AddressSpace, b: AddressSpace)
-  extends Constraint {
   override def toString: String = s"$a  ~  $b"
 }
 case class MatrixLayoutConstraint(a: MatrixLayout, b: MatrixLayout)

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -132,30 +132,27 @@ case class Solution(ts: Map[Type, Type],
 
   def apply(constraints: Seq[Constraint]): Seq[Constraint] = {
     constraints.map {
-      case TypeConstraint(a, b) =>
-        TypeConstraint(apply(a), apply(b))
-      case AddressSpaceConstraint(a, b) =>
-        AddressSpaceConstraint(apply(a), apply(b))
-      case MatrixLayoutConstraint(a, b) =>
-        MatrixLayoutConstraint(apply(a), apply(b))
-      case FragmentTypeConstraint(a, b) =>
-        FragmentTypeConstraint(apply(a), apply(b))
-      case NatConstraint(a, b) =>
-        NatConstraint(apply(a), apply(b))
-      case BoolConstraint(a, b) =>
-        BoolConstraint(apply(a), apply(b))
-      case NatToDataConstraint(a, b) =>
-        NatToDataConstraint(apply(a), apply(b))
-      case DepConstraint(df, arg: Nat, t) =>
-        DepConstraint[NatKind](apply(df), apply(arg), apply(t))
+      case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
+      case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))
+      case BoolConstraint(a, b) => BoolConstraint(apply(a), apply(b))
+      case MatrixLayoutConstraint(a, b) => MatrixLayoutConstraint(apply(a), apply(b))
+      case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
+      case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
+      case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
+      case DepConstraint(df, arg: Nat, t) => DepConstraint[NatKind](apply(df), apply(arg), apply(t))
       case DepConstraint(df, arg: DataType, t) =>
-        DepConstraint[DataKind](
-          apply(df),
-          apply(arg).asInstanceOf[DataType],
-          apply(t)
-        )
+        DepConstraint[DataKind](apply(df), apply(arg).asInstanceOf[DataType], apply(t))
+      case DepConstraint(df, arg: Type, t) =>
+        DepConstraint[TypeKind](apply(df), apply(arg), apply(t))
       case DepConstraint(df, arg: AddressSpace, t) =>
         DepConstraint[AddressSpaceKind](apply(df), apply(arg), apply(t))
+      case DepConstraint(df, arg: NatToData, t) =>
+        DepConstraint[NatToDataKind](apply(df), apply(arg), apply(t))
+      case DepConstraint(df, arg: NatToNat, t) =>
+        DepConstraint[NatToNatKind](apply(df), apply(arg), apply(t))
+      case DepConstraint(df, arg: NatCollection, t) =>
+        DepConstraint[NatCollectionKind](apply(df), apply(arg), apply(t))
+      case DepConstraint(_, _, _) => throw new Exception("Impossible case")
     }
   }
 }


### PR DESCRIPTION
Favors a more straightforward and explicit approach to the collection of type inference constraints where the identifier environment is immutable and only ever passed top-down, while the constraint collection is (also immutable) and passed bottom-up. It also seals the `Constraint` trait and gets rid of the unimplemented and non-generated `AddressSpaceConstraint`. Running `sbt test` on master and on this branch shows no performance impact.