### PR TITLE
Gather FTVs to preserve, hand them to constraint resolution

### DIFF
--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -29,7 +29,7 @@ object infer {
     // and we return a `ftvSubs` map that maps these explicit type identifiers back to implicit type identifiers.
     val (typed_e, constraints) = constrainTypes(Map())(frozen_e)
     // Applies ftvSubs to the constraint solutions
-    val solution = Constraint.solve(constraints, Seq())(explDep) ++ ftvSubs
+    val solution = Constraint.solve(constraints, Seq(), Seq())(explDep) ++ ftvSubs
     val res = traverse(typed_e, Visitor(solution))
     if (printFlag == Flags.PrintTypesAndTypeHoles.On) {
       printTypesAndTypeHoles(res)

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -44,9 +44,12 @@ case class NatCollectionConstraint(a: NatCollection, b: NatCollection)
 }
 
 object Constraint {
-  def solve(cs: Seq[Constraint], trace: Seq[Constraint])
+  val canBeSubstituted : Seq[Kind.Identifier] => Kind.Identifier with Kind.Explicitness => Boolean =
+    preserve => i => !(preserve.contains(i) || i.isExplicit)
+
+  def solve(cs: Seq[Constraint], preserve: Seq[Kind.Identifier], trace: Seq[Constraint])
      (implicit explDep: Flags.ExplicitDependence): Solution =
-  solveRec(cs, Nil, trace)
+  solveRec(cs, Nil, preserve, trace)
   /* faster but not always enough:
    cs match {
     case Nil => Solution()
@@ -56,26 +59,22 @@ object Constraint {
   }
   */
 
-  def solveRec(cs: Seq[Constraint], rs: Seq[Constraint], trace: Seq[Constraint])
+  def solveRec(cs: Seq[Constraint], rs: Seq[Constraint], preserve: Seq[Kind.Identifier], trace: Seq[Constraint])
               (implicit explDep: Flags.ExplicitDependence): Solution = (cs, rs) match {
     case (Nil, Nil) => Solution()
     case (Nil, _) => error(s"could not solve constraints ${rs}")(trace)
     case (c +: cs, _) =>
-      val s = try {
-        solveOne(c, trace)
-      } catch {
-        case e: InferenceException =>
-          println(e.msg)
-          return solveRec(cs, rs :+ c, trace)
-      }
-      s ++ solve(s.apply(rs ++ cs), trace)
+      val s = try { solveOne(c, preserve, trace) }
+              catch { case e: InferenceException =>
+                println(e.msg)
+                return solveRec(cs, rs :+ c, preserve, trace) }
+      s ++ solve(s.apply(rs ++ cs), preserve, trace)
   }
 
   // scalastyle:off method.length
-  def solveOne(c: Constraint, trace: Seq[Constraint])
-    (implicit explDep: Flags.ExplicitDependence): Solution = {
+  def solveOne(c: Constraint, preserve : Seq[Kind.Identifier], trace: Seq[Constraint]) (implicit explDep: Flags.ExplicitDependence): Solution = {
     implicit val _trace: Seq[Constraint] = trace
-    def decomposed(cs: Seq[Constraint]) = solve(cs, c +: trace)
+    def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, c +: trace)
 
     c match {
       case TypeConstraint(a, b) =>
@@ -85,9 +84,9 @@ object Constraint {
           case (i: TypeIdentifier, _) => unifyTypeIdent(i, b)
           case (_, i: TypeIdentifier) => unifyTypeIdent(i, a)
           case (i: DataTypeIdentifier, dt: DataType) =>
-            unifyDataTypeIdent(i, dt)
+            unifyDataTypeIdent(i, dt, preserve)
           case (dt: DataType, i: DataTypeIdentifier) =>
-            unifyDataTypeIdent(i, dt)
+            unifyDataTypeIdent(i, dt, preserve)
           case (_: ScalarType | _: NatType.type |
                 _: IndexType  | _: VectorType,
           _: ScalarType | _: NatType.type |
@@ -125,11 +124,9 @@ object Constraint {
                   * initial constrain-types phase?
                   */
                 val (nTa, nTaSub) = dependence.explicitlyDependent(
-                  substitute.natInType(n, `for`=na, ta), n
-                )
+                  substitute.natInType(n, `for`=na, ta), n, preserve)
                 val (nTb, nTbSub) = dependence.explicitlyDependent(
-                  substitute.natInType(n, `for`= nb, tb), n
-                )
+                  substitute.natInType(n, `for`= nb, tb), n, preserve)
                 nTaSub ++ nTbSub ++ decomposed(
                     Seq(
                       NatConstraint(n, na.asImplicit),
@@ -227,8 +224,8 @@ object Constraint {
             error(s"expected a dependent function type, but got $df")
         }
 
-      case NatConstraint(a, b) => nat.unify(a, b)
-      case BoolConstraint(a, b) => bool.unify(a, b)
+      case NatConstraint(a, b) => nat.unify(a, b, preserve)
+      case BoolConstraint(a, b) => bool.unify(a, b, preserve)
       case NatToDataConstraint(a, b) =>
         (a, b) match {
           case (i: NatToDataIdentifier, _) => natToData.unifyIdent(i, b)
@@ -247,8 +244,8 @@ object Constraint {
 
       case NatCollectionConstraint(a, b) =>
         (a,b) match {
-          case (i: NatCollectionIdentifier, _) => natCollection.unifyIdent(i, b)
-          case (_, i: NatCollectionIdentifier) => natCollection.unifyIdent(i, b)
+          case (i: NatCollectionIdentifier, _) => natCollection.unifyIdent(i, b, preserve)
+          case (_, i: NatCollectionIdentifier) => natCollection.unifyIdent(i, b, preserve)
           case _ if a == b                    => Solution()
           case (NatCollectionFromArray(e1), NatCollectionFromArray(e2)) =>
             // What to do here???
@@ -279,41 +276,37 @@ object Constraint {
   }
 
   // FIXME: datatypes and types are mixed up
-  def unifyDataTypeIdent(i: DataTypeIdentifier, t: DataType)(
-    implicit trace: Seq[Constraint]
-  ): Solution = {
+  def unifyDataTypeIdent(i: DataTypeIdentifier, t: DataType, preserve : Seq[Kind.Identifier])
+                        (implicit trace: Seq[Constraint]): Solution = {
     t match {
       case j: DataTypeIdentifier =>
-        if (i =~= j) {
+        if (i == j) {
           Solution()
-        } else if (!i.isExplicit) {
+        } else if (canBeSubstituted(preserve)(i)) {
           Solution.subs(i, j)
-        } else if (!j.isExplicit) {
+        } else if (canBeSubstituted(preserve)(j)) {
           Solution.subs(j, i)
         } else {
-          error(s"cannot unify $i and $j, they are both explicit")
+          error(s"cannot unify $i and $j, they are both explicit or in $preserve")
         }
-      case _ if i.isExplicit =>
-        error(s"cannot substitute $i, it is explicit")
       case _ if occurs(i, t) => error(s"circular use: $i occurs in $t")
-      case _ if !i.isExplicit => Solution.subs(i, t)
+      case _ =>
+        if (canBeSubstituted(preserve)(i)) Solution.subs(i, t)
+        else error(s"cannot substitute $i, it is explicit")
     }
   }
 
   private object nat {
     import arithexpr.arithmetic._
 
-    def unify(a: Nat, b: Nat)(
-      implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
-    ): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs, NatConstraint(a, b) +: trace)
+    def unify(a: Nat, b: Nat, preserve : Seq[Kind.Identifier])
+             (implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence): Solution = {
+      def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, NatConstraint(a, b) +: trace)
       (a, b) match {
-        case (i: NatIdentifier, _) => nat.unifyIdent(i, b)
-        case (_, i: NatIdentifier) => nat.unifyIdent(i, a)
-        case (app: NatToNatApply, _) =>
-          nat.unifyApply(app, b)
-        case (_, app: NatToNatApply) =>
-          nat.unifyApply(app, a)
+        case (i: NatIdentifier, _) => nat.unifyIdent(i, b, preserve)
+        case (_, i: NatIdentifier) => nat.unifyIdent(i, a, preserve)
+        case (app: NatToNatApply, _) => nat.unifyApply(app, b, preserve)
+        case (_, app: NatToNatApply) => nat.unifyApply(app, a, preserve)
         case _ if a == b => Solution()
         // case _ if !nat.potentialPivots(a).isEmpty => nat.tryPivots(a, b)
         // case _ if !nat.potentialPivots(b).isEmpty => nat.tryPivots(b, a)
@@ -326,22 +319,22 @@ object Constraint {
           decomposed(Seq(
             NatConstraint(t1, t2), NatConstraint(e1, e2), BoolConstraint(c1, c2)
           ))
-        case (s: arithexpr.arithmetic.Sum, _) => nat.unifySum(s, b)
-        case (_, s: arithexpr.arithmetic.Sum) => nat.unifySum(s, a)
-        case (p: arithexpr.arithmetic.Prod, _) => nat.unifyProd(p, b)
-        case (_, p: arithexpr.arithmetic.Prod) => nat.unifyProd(p, a)
-        case (p: arithexpr.arithmetic.Pow, _) => nat.unifyProd(p, b)
-        case (_, p: arithexpr.arithmetic.Pow) => nat.unifyProd(p, a)
-        case (p: arithexpr.arithmetic.IntDiv, _) => nat.unifyProd(p, b)
-        case (_, p: arithexpr.arithmetic.IntDiv) => nat.unifyProd(p, a)
+        case (s: arithexpr.arithmetic.Sum, _) => nat.unifySum(s, b, preserve)
+        case (_, s: arithexpr.arithmetic.Sum) => nat.unifySum(s, a, preserve)
+        case (p: arithexpr.arithmetic.Prod, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.Prod) => nat.unifyProd(p, a, preserve)
+        case (p: arithexpr.arithmetic.Pow, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.Pow) => nat.unifyProd(p, a, preserve)
+        case (p: arithexpr.arithmetic.IntDiv, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.IntDiv) => nat.unifyProd(p, a, preserve)
         case (arithexpr.arithmetic.Mod(x1, m1),
           arithexpr.arithmetic.Mod(x2: NatIdentifier, m2))
-          if m1 == m2 && !x2.isExplicit =>
+          if m1 == m2 && canBeSubstituted(preserve)(x2) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
           Solution.subs(x2, k*m1 + x1%m1)
         case (arithexpr.arithmetic.Mod(x2: NatIdentifier, m2),
           arithexpr.arithmetic.Mod(x1, m1))
-          if m1 == m2 && !x2.isExplicit =>
+          if m1 == m2 && canBeSubstituted(preserve)(x2) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
           Solution.subs(x2, k*m1 + x1%m1)
         case _ => error(s"cannot unify $a and $b")
@@ -406,9 +399,7 @@ object Constraint {
       }
     }
 
-    def tryPivots(n: Nat, value: Nat)(
-      implicit trace: Seq[Constraint]
-    ): Solution = {
+    def tryPivots(n: Nat, value: Nat)(implicit trace: Seq[Constraint]): Solution = {
       potentialPivots(n).foreach(pivotSolution(_, n, value) match {
         case Some(s) => return s
         case None    =>
@@ -416,44 +407,44 @@ object Constraint {
       error(s"could not pivot $n = $value")
     }
 
-    def unifyProd(p: Nat, n: Nat)(implicit trace: Seq[Constraint]): Solution = {
+    def unifyProd(p: Nat, n: Nat, preserve : Seq[Kind.Identifier])(implicit trace: Seq[Constraint]): Solution = {
       // n = p --> 1 = p * (1/n)
       tryPivots(p /^ n, 1)
     }
 
-    def unifySum(s: Sum, n: Nat)(implicit trace: Seq[Constraint]): Solution = {
+    def unifySum(s: Sum, n: Nat, preserve : Seq[Kind.Identifier])(implicit trace: Seq[Constraint]): Solution = {
       // n = s --> 0 = s + (-n)
       tryPivots(s - n, 0)
     }
 
-    def unifyIdent(i: NatIdentifier, n: Nat)(
+    def unifyIdent(i: NatIdentifier, n: Nat, preserve : Seq[Kind.Identifier])(
       implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
     ): Solution = n match {
       case j: NatIdentifier =>
         if (i == j) {
           Solution()
-        } else if (!i.isExplicit) {
+        } else if (canBeSubstituted(preserve)(i)) {
           Solution.subs(i, j)
-        } else if (!j.isExplicit) {
+        } else if (canBeSubstituted(preserve)(j)) {
           Solution.subs(j, i)
         } else {
           error(s"cannot unify $i and $j")
         }
-      case fx: NatToNatApply => unifyApply(fx, i)
-      case _ if !ArithExpr.contains(n, i) && (!i.isExplicit) =>
+      case fx: NatToNatApply => unifyApply(fx, i, preserve)
+      case _ if !ArithExpr.contains(n, i) && (canBeSubstituted(preserve)(i)) =>
         Solution.subs(i, n)
-      case p: Prod => unifyProd(p, i)
-      case s: Sum  => unifySum(s, i)
+      case p: Prod => unifyProd(p, i, preserve)
+      case s: Sum  => unifySum(s, i, preserve)
       case _       => error(s"cannot unify $i and $n")
     }
 
-    def unifyApply(apply: NatToNatApply, nat: Nat)(
+    def unifyApply(apply: NatToNatApply, nat: Nat, preserve: Seq[Kind.Identifier])(
       implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
     ): Solution = {
       val NatToNatApply(f1, n1) = apply
       nat match {
         case NatToNatApply(f2, n2) =>
-          natToNat.unify(f1, f2) ++ unify(n1, n2)
+          natToNat.unify(f1, f2, preserve) ++ unify(n1, n2, preserve)
         case _ => (f1, n1) match {
           case (f1: NatToNatIdentifier, n1: NatIdentifier) =>
             val freshVar = NatIdentifier(freshName("n"), isExplicit = true)
@@ -468,10 +459,10 @@ object Constraint {
   private object bool {
     import arithexpr.arithmetic._
 
-    def unify(a: BoolExpr, b: BoolExpr)(
+    def unify(a: BoolExpr, b: BoolExpr, preserve : Seq[Kind.Identifier])(
       implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
     ): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs, BoolConstraint(a, b) +: trace)
+      def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, BoolConstraint(a, b) +: trace)
       (a, b) match {
         case _ if a == b => Solution()
         case (ArithPredicate(lhs1, rhs1, op1), ArithPredicate(lhs2, rhs2, op2)) if op1 == op2 =>
@@ -482,9 +473,7 @@ object Constraint {
   }
 
   object natToData {
-    def unifyIdent(i: NatToDataIdentifier, n: NatToData)(
-      implicit trace: Seq[Constraint]
-    ): Solution = n match {
+    def unifyIdent(i: NatToDataIdentifier, n: NatToData)(implicit trace: Seq[Constraint]): Solution = n match {
       case j: NatToDataIdentifier =>
         if (i == j) {
           Solution()
@@ -496,7 +485,7 @@ object Constraint {
   }
 
   object natToNat {
-    def unify(f1: NatToNat, f2: NatToNat)(
+    def unify(f1: NatToNat, f2: NatToNat, preserve: Seq[Kind.Identifier])(
       implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
     ): Solution = f1 match {
       case id1: NatToNatIdentifier => Solution.subs(id1, f2)
@@ -506,14 +495,14 @@ object Constraint {
           val n = NatIdentifier(freshName("n"), isExplicit = true)
           nat.unify(
             substitute.natInNat(n, `for` = x1, body1),
-            substitute.natInNat(n, `for`=x2, body2)
-          )
+            substitute.natInNat(n, `for`=x2, body2),
+            preserve)
       }
     }
   }
 
   object natCollection {
-    def unifyIdent(i: NatCollectionIdentifier, n: NatCollection)(
+    def unifyIdent(i: NatCollectionIdentifier, n: NatCollection, preserve : Seq[Kind.Identifier])(
         implicit trace: Seq[Constraint]
       ): Solution = n match {
       case j: NatCollectionIdentifier =>
@@ -539,13 +528,13 @@ object dependence {
    * explicitly represent the dependence by replacing identifiers in t
    * with applied nat-to-X functions.
    */
-  def explicitlyDependent(t: Type, depVar: NatIdentifier): (Type, Solution) = {
+  def explicitlyDependent(t: Type, depVar: NatIdentifier, preserve : Seq[Kind.Identifier]): (Type, Solution) = {
     val visitor = new PureAccumulatorTraversal[Seq[Solution]] {
       override val accumulator = SeqMonoid
 
       override def nat: Nat => Pair[Nat] = {
         case n2n@NatToNatApply(_, n) if n == depVar => return_(n2n : Nat)
-        case ident: NatIdentifier if ident != depVar && !ident.isExplicit =>
+        case ident: NatIdentifier if ident != depVar && Constraint.canBeSubstituted(preserve)(ident) =>
           val sol = Solution.subs(ident, NatToNatApply(NatToNatIdentifier(freshName("nnf")), depVar))
           accumulate(Seq(sol))(ident.asImplicit : Nat)
         case n => super.nat(n)

--- a/src/main/scala/util/monads.scala
+++ b/src/main/scala/util/monads.scala
@@ -1,5 +1,6 @@
 package util
 
+import scala.collection.immutable.HashSet
 import scala.language.implicitConversions
 
 object monads {
@@ -41,6 +42,11 @@ object monads {
   implicit def SeqMonoid[T] : Monoid[Seq[T]] = new Monoid[Seq[T]] {
     def empty : Seq[T] = Seq()
     def append : Seq[T] => Seq[T] => Seq[T] = x => y => x ++ y
+  }
+
+  implicit def SetMonoid[T] : Monoid[Set[T]] = new Monoid[Set[T]] {
+    def empty : Set[T] = HashSet()
+    def append : Set[T] => Set[T] => Set[T] = x => y => x ++ y
   }
 
   implicit def MapMonoid[K,V] : Monoid[Map[K,V]] = new Monoid[Map[K,V]] {


### PR DESCRIPTION
Closes #128 

- Introduce a pre-inference pass `collectPreserve` that collects the type variables to preserve from type assertions and opaques. While doing so, it transforms all type assertions into type annotations. This makes it easier to eventually drop type assertions altogether (#142).
- Remove freeze/unfreeze, instead pass to constraint solving a list of type identifiers to preserve. The code style could maybe be improved here by making `preserve` global to all the functions called within `solveOne`.