### PR TITLE
Add a monad on `Monad[(Monoid[F], S)]`

### DIFF
--- a/src/main/scala/rise/core/DSL/ToBeTyped.scala
+++ b/src/main/scala/rise/core/DSL/ToBeTyped.scala
@@ -1,6 +1,6 @@
 package rise.core.DSL
 
-import rise.core.traverse.Pure
+import util.monads.Pure
 import rise.core.types._
 import rise.core._
 

--- a/src/main/scala/rise/core/DSL/TopLevel.scala
+++ b/src/main/scala/rise/core/DSL/TopLevel.scala
@@ -1,9 +1,10 @@
 package rise.core.DSL
 
 import Type.impl
+import util.monads._
 import rise.core.traverse._
 import rise.core.types._
-import rise.core.{DSL, Expr, Primitive, traverse}
+import rise.core.{DSL, Expr, Primitive}
 
 final case class TopLevel(e: Expr, inst: Solution = Solution())(
   override val t: Type = e.t

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -1,5 +1,6 @@
 package rise.core
 
+import util.monads._
 import rise.core.primitives._
 import rise.core.semantics._
 import rise.core.traverse._

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -1,5 +1,6 @@
 package rise.core
 
+import util.monads._
 import arithexpr.arithmetic.NamedVar
 import rise.core.traverse._
 import rise.core.types._

--- a/src/main/scala/rise/core/replace.scala
+++ b/src/main/scala/rise/core/replace.scala
@@ -1,5 +1,6 @@
 package rise.core
 
+import util.monads._
 import rise.core.traverse._
 
 object replace {

--- a/src/main/scala/rise/core/substitute.scala
+++ b/src/main/scala/rise/core/substitute.scala
@@ -1,6 +1,7 @@
 package rise.core
 
-import rise.core.traverse.{Pure, PureExprTraversal, PureTraversal}
+import util.monads._
+import rise.core.traverse._
 import rise.core.types._
 import rise.core.semantics.NatData
 

--- a/src/main/scala/rise/core/traverse.scala
+++ b/src/main/scala/rise/core/traverse.scala
@@ -189,6 +189,7 @@ object traverse {
     type Pair[T] = InMonad[M]#SetFst[F]#Type[T]
     implicit val fstMonoid : Monoid[F]
     implicit val wrapperMonad : Monad[M]
+    def record[T] : F => T => Pair[T] = f => t => wrapperMonad.return_((f, t))
     override def monad : PairMonoidMonad[F,M] = new PairMonoidMonad[F,M] {
       override val monoid = implicitly(fstMonoid)
       override val monad = implicitly(wrapperMonad)
@@ -196,7 +197,9 @@ object traverse {
   }
 
   def traverse(e: Expr, f: PureTraversal): Expr = f.expr(e).unwrap
-  def traverse[M[_]](e: Expr, f: Traversal[M]): M[Expr] = f.expr(e)
   def traverse[T <: Type](t: T, f: PureTraversal): T = f.`type`(t).unwrap
+  def traverse[F](e: Expr, f: PairMonoidTraversal[F,Pure]): (F, Expr) = f.expr(e).unwrap
+  def traverse[F,T <: Type](t: T, f: PairMonoidTraversal[F,Pure]): (F, T) = f.`type`(t).unwrap
+  def traverse[M[_]](e: Expr, f: Traversal[M]): M[Expr] = f.expr(e)
   def traverse[T <: Type, M[_]](e: T, f: Traversal[M]): M[T] = f.`type`(e)
 }

--- a/src/main/scala/rise/core/traverse.scala
+++ b/src/main/scala/rise/core/traverse.scala
@@ -185,21 +185,24 @@ object traverse {
 
   trait PureTraversal extends Traversal[Pure] {override def monad : PureMonad.type = PureMonad }
   trait PureExprTraversal extends PureTraversal with ExprTraversal[Pure]
-  trait PairMonoidTraversal[F,M[_]] extends Traversal[InMonad[M]#SetFst[F]#Type] {
+  trait AccumulatorTraversal[F,M[_]] extends Traversal[InMonad[M]#SetFst[F]#Type] {
     type Pair[T] = InMonad[M]#SetFst[F]#Type[T]
-    implicit val fstMonoid : Monoid[F]
+    implicit val accumulator : Monoid[F]
     implicit val wrapperMonad : Monad[M]
-    def record[T] : F => T => Pair[T] = f => t => wrapperMonad.return_((f, t))
+    def accumulate[T] : F => T => Pair[T] = f => t => wrapperMonad.return_((f, t))
     override def monad : PairMonoidMonad[F,M] = new PairMonoidMonad[F,M] {
-      override val monoid = implicitly(fstMonoid)
+      override val monoid = implicitly(accumulator)
       override val monad = implicitly(wrapperMonad)
     }
+  }
+  trait PureAccumulatorTraversal[F] extends AccumulatorTraversal[F, Pure] {
+    override val wrapperMonad : PureMonad.type = PureMonad
   }
 
   def traverse(e: Expr, f: PureTraversal): Expr = f.expr(e).unwrap
   def traverse[T <: Type](t: T, f: PureTraversal): T = f.`type`(t).unwrap
-  def traverse[F](e: Expr, f: PairMonoidTraversal[F,Pure]): (F, Expr) = f.expr(e).unwrap
-  def traverse[F,T <: Type](t: T, f: PairMonoidTraversal[F,Pure]): (F, T) = f.`type`(t).unwrap
+  def traverse[F](e: Expr, f: PureAccumulatorTraversal[F]): (F, Expr) = f.expr(e).unwrap
+  def traverse[F,T <: Type](t: T, f: PureAccumulatorTraversal[F]): (F, T) = f.`type`(t).unwrap
   def traverse[M[_]](e: Expr, f: Traversal[M]): M[Expr] = f.expr(e)
   def traverse[T <: Type, M[_]](e: T, f: Traversal[M]): M[T] = f.`type`(e)
 }

--- a/src/main/scala/rise/core/traverse.scala
+++ b/src/main/scala/rise/core/traverse.scala
@@ -1,24 +1,11 @@
 package rise.core
 
 import scala.language.implicitConversions
-import arithexpr.arithmetic.NamedVar
+import util.monads._
 import rise.core.semantics._
 import rise.core.types._
 
 object traverse {
-  trait Monad[M[_]] {
-    def return_[T] : T => M[T]
-    def bind[T,S] : M[T] => (T => M[S]) => M[S]
-    def traverse[A] : Seq[M[A]] => M[Seq[A]] =
-      _.foldRight(return_(Nil : Seq[A]))({case (mx, mxs) =>
-        bind(mx)(x => bind(mxs)(xs => return_(x +: xs)))})
-  }
-
-  implicit def monadicSyntax[M[_], A](m: M[A])(implicit tc: Monad[M]) = new {
-    def map[B](f: A => B): M[B] = tc.bind(m)(a => tc.return_(f(a)) )
-    def flatMap[B](f: A => M[B]): M[B] = tc.bind(m)(f)
-  }
-
   sealed trait VarType
   case object Binding extends VarType
   case object Reference extends VarType
@@ -196,23 +183,20 @@ object traverse {
     override def `type`[T <: Type] : T => M[T] = return_
   }
 
-  case class Pure[T](unwrap : T)
-  implicit object PureMonad extends Monad[Pure] {
-    override def return_[T] : T => Pure[T] = t => Pure(t)
-    override def bind[T,S] : Pure[T] => (T => Pure[S]) => Pure[S] =
-      v => f => v match { case Pure(v) => f(v) }
-  }
-
-  implicit object OptionMonad extends Monad[Option] {
-    def return_[T]: T => Option[T] = Some(_)
-    def bind[T, S]: Option[T] => (T => Option[S]) => Option[S] = v => v.flatMap
-  }
-
-  trait PureTraversal extends Traversal[Pure] { override def monad = PureMonad }
+  trait PureTraversal extends Traversal[Pure] {override def monad : PureMonad.type = PureMonad }
   trait PureExprTraversal extends PureTraversal with ExprTraversal[Pure]
+  trait PairMonoidTraversal[F,M[_]] extends Traversal[InMonad[M]#SetFst[F]#Type] {
+    type Pair[T] = InMonad[M]#SetFst[F]#Type[T]
+    implicit val fstMonoid : Monoid[F]
+    implicit val wrapperMonad : Monad[M]
+    override def monad : PairMonoidMonad[F,M] = new PairMonoidMonad[F,M] {
+      override val monoid = implicitly(fstMonoid)
+      override val monad = implicitly(wrapperMonad)
+    }
+  }
 
-  def apply(e : Expr, f : PureTraversal) : Expr = f.expr(e).unwrap
-  def apply[M[_]](e : Expr, f : Traversal[M]) : M[Expr] = f.expr(e)
-  def apply[T <: Type](t : T, f : PureTraversal) : T = f.`type`(t).unwrap
-  def apply[T <: Type, M[_]](e : T, f : Traversal[M]) : M[T] = f.`type`(e)
+  def traverse(e: Expr, f: PureTraversal): Expr = f.expr(e).unwrap
+  def traverse[M[_]](e: Expr, f: Traversal[M]): M[Expr] = f.expr(e)
+  def traverse[T <: Type](t: T, f: PureTraversal): T = f.`type`(t).unwrap
+  def traverse[T <: Type, M[_]](e: T, f: Traversal[M]): M[T] = f.`type`(e)
 }

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -548,7 +548,7 @@ object dependence {
         case n2n@NatToNatApply(_, n) if n == depVar => return_(n2n : Nat)
         case ident: NatIdentifier if ident != depVar && !ident.isExplicit =>
           val sol = Solution.subs(ident, NatToNatApply(NatToNatIdentifier(freshName("nnf")), depVar))
-          Pure((Seq(sol), ident.asImplicit : Nat))
+          record(Seq(sol))(ident.asImplicit : Nat)
         case n => super.nat(n)
       }
 
@@ -557,12 +557,12 @@ object dependence {
         case ident@TypeIdentifier(i) =>
           val application = NatToDataApply(NatToDataIdentifier(freshName("nnf")), depVar)
           val sol = Solution.subs(ident, application)
-          Pure((Seq(sol), ident.asInstanceOf[T]))
+          record(Seq(sol))(ident.asInstanceOf[T])
         case e => super.`type`(e)
       }
 
       def apply(t: Type): (Type, Solution) = {
-        val (sols, rewrittenT) = traverse(t, this).unwrap
+        val (sols, rewrittenT) = traverse(t, this)
         val solution = sols.foldLeft(Solution())(_ ++ _)
         (solution.apply(rewrittenT), solution)
       }

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -1,5 +1,6 @@
 package rise.core.types
 
+import util.monads._
 import arithexpr.arithmetic.BoolExpr
 import rise.core.traverse._
 import rise.core.{Expr, substitute}

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -5,17 +5,14 @@ import rise.core.traverse._
 import rise.core.types._
 
 object uniqueNames {
-  private val collectNames = new PairMonoidTraversal[(Seq[Identifier], Seq[Kind.Identifier]), Pure] {
-    override val fstMonoid: Monoid[(Seq[Identifier], Seq[Kind.Identifier])] = PairMonoid(SeqMonoid, SeqMonoid)
-    override val wrapperMonad = PureMonad
-
+  private val collectNames = new PureAccumulatorTraversal[(Seq[Identifier], Seq[Kind.Identifier])] {
+    override val accumulator: Monoid[(Seq[Identifier], Seq[Kind.Identifier])] = PairMonoid(SeqMonoid, SeqMonoid)
     override def identifier[I <: Identifier]: VarType => I => Pair[I] = {
-      case Binding => i => record((Seq(i), Seq()))(i)
+      case Binding => i => accumulate((Seq(i), Seq()))(i)
       case _ => return_
     }
-
     override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
-      case Binding => i => record((Seq(), Seq(i)))(i)
+      case Binding => i => accumulate((Seq(), Seq(i)))(i)
       case _ => return_
     }
   }

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -5,23 +5,23 @@ import rise.core.traverse._
 import rise.core.types._
 
 object uniqueNames {
-  private val CountingVisitor = new PairMonoidTraversal[(Seq[Identifier], Seq[Kind.Identifier]), Pure] {
+  private val collectNames = new PairMonoidTraversal[(Seq[Identifier], Seq[Kind.Identifier]), Pure] {
     override val fstMonoid: Monoid[(Seq[Identifier], Seq[Kind.Identifier])] = PairMonoid(SeqMonoid, SeqMonoid)
     override val wrapperMonad = PureMonad
 
     override def identifier[I <: Identifier]: VarType => I => Pair[I] = {
-      case Binding => i => Pure((Seq(i), Seq()), i)
+      case Binding => i => record((Seq(i), Seq()))(i)
       case _ => return_
     }
 
     override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
-      case Binding => i => Pure((Seq(), Seq(i)), i)
+      case Binding => i => record((Seq(), Seq(i)))(i)
       case _ => return_
     }
   }
 
   def check(e: Expr): Boolean = {
-    val ((vs, ts), _) = traverse(e, CountingVisitor).unwrap
+    val ((vs, ts), _) = traverse(e, collectNames)
     vs == vs.distinct && ts == ts.distinct
   }
 

--- a/src/main/scala/util/monads.scala
+++ b/src/main/scala/util/monads.scala
@@ -1,0 +1,68 @@
+package util
+
+import scala.language.implicitConversions
+
+object monads {
+  trait Monad[M[_]] {
+    def return_[T] : T => M[T]
+    def bind[T,S] : M[T] => (T => M[S]) => M[S]
+    def traverse[A] : Seq[M[A]] => M[Seq[A]] =
+      _.foldRight(return_(Nil : Seq[A]))({case (mx, mxs) =>
+        bind(mx)(x => bind(mxs)(xs => return_(x +: xs)))})
+  }
+
+  implicit def monadicSyntax[M[_], A](m: M[A])(implicit tc: Monad[M]) = new {
+    def map[B](f: A => B): M[B] = tc.bind(m)(a => tc.return_(f(a)) )
+    def flatMap[B](f: A => M[B]): M[B] = tc.bind(m)(f)
+  }
+
+  case class Pure[T](unwrap : T)
+  implicit object PureMonad extends Monad[Pure] {
+    override def return_[T] : T => Pure[T] = t => Pure(t)
+    override def bind[T,S] : Pure[T] => (T => Pure[S]) => Pure[S] =
+      v => f => v match { case Pure(v) => f(v) }
+  }
+
+  implicit object OptionMonad extends Monad[Option] {
+    override def return_[T]: T => Option[T] = Some(_)
+    override def bind[T, S]: Option[T] => (T => Option[S]) => Option[S] = v => v.flatMap
+  }
+
+  trait Monoid[T] {
+    def empty : T
+    def append : T => T => T
+  }
+
+  implicit val OrMonoid : Monoid[Boolean] = new Monoid[Boolean] {
+    def empty : Boolean = false
+    def append : Boolean => Boolean => Boolean = x => y => x || y
+  }
+
+  implicit def SeqMonoid[T] : Monoid[Seq[T]] = new Monoid[Seq[T]] {
+    def empty : Seq[T] = Seq()
+    def append : Seq[T] => Seq[T] => Seq[T] = x => y => x ++ y
+  }
+
+  implicit def MapMonoid[K,V] : Monoid[Map[K,V]] = new Monoid[Map[K,V]] {
+    def empty : Map[K,V] = Map()
+    def append : Map[K,V] => Map[K,V] => Map[K,V] = x => y => x ++ y
+  }
+
+  implicit def PairMonoid[F,S](fst : Monoid[F], snd : Monoid[S]) : Monoid[Tuple2[F,S]] = new Monoid[Tuple2[F,S]] {
+    override def empty : Tuple2[F,S] = (fst.empty, snd.empty)
+    override def append : Tuple2[F,S] => Tuple2[F,S] => Tuple2[F,S] = {
+      case (f1, s1) => { case (f2, s2) => (fst.append(f1)(f2), snd.append(s1)(s2)) }
+    }
+  }
+
+  trait InMonad[M[_]] { trait SetFst[F] { type Type[S] = M[Tuple2[F, S]] } }
+  trait PairMonoidMonad[F, M[_]] extends Monad[InMonad[M]#SetFst[F]#Type] {
+    type Pair[T] = InMonad[M]#SetFst[F]#Type[T]
+    implicit val monoid : Monoid[F]
+    implicit val monad : Monad[M]
+    override def return_[T]: T => Pair[T] = t => monad.return_((monoid.empty, t))
+    override def bind[T, S]: Pair[T] => (T => Pair[S]) => Pair[S] = t => f =>
+      monad.bind(t) { case (rs1, t) => monad.bind(f(t)) { case (rs2, s) =>
+        monad.return_((monoid.append(rs1)(rs2), s))}}
+  }
+}

--- a/src/test/scala/rise/core/traverseTest.scala
+++ b/src/test/scala/rise/core/traverseTest.scala
@@ -18,14 +18,14 @@ class traverseTest extends test_util.Tests {
     override val fstMonoid = SeqMonoid[Any]
     override val wrapperMonad = PureMonad
     override def identifier[I <: Identifier] : VarType => I => Pair[I] =
-      vt => i => Pure((Seq(i), i))
+      vt => i => record(Seq(i))(i)
   }
 
   class TypeTraceVisitor extends PairMonoidTraversal[Seq[Any], Pure] {
     override val fstMonoid = SeqMonoid[Any]
     override val wrapperMonad = PureMonad
     override def typeIdentifier[I <: Kind.Identifier] : VarType => I => Pair[I] =
-      vt => i => Pure((Seq(i), i))
+      vt => i => record(Seq(i))(i)
   }
 
   def checkEqualities[T] : Seq[T] => Seq[Seq[Int]] => Boolean = xs => gps =>
@@ -33,7 +33,7 @@ class traverseTest extends test_util.Tests {
 
   test("traversing an expression should traverse identifiers in order") {
     val equivs = Seq(Seq(0, 3), Seq(1, 2))
-    val result = traverse(e, new ExprTraceVisitor()).unwrap
+    val result = traverse(e, new ExprTraceVisitor())
 
     // the expression should not have changed
     assert(result._2 == e)
@@ -44,7 +44,7 @@ class traverseTest extends test_util.Tests {
 
   test("traversing a type should traverse identifiers in order") {
     val equivs = Seq(Seq(0, 2, 4), Seq(1, 3, 5))
-    val result = traverse(e.t, new TypeTraceVisitor()).unwrap
+    val result = traverse(e.t, new TypeTraceVisitor())
     // the type should not have changed
     assert(result._2 == e.t)
     // the trace should match expectations

--- a/src/test/scala/rise/core/traverseTest.scala
+++ b/src/test/scala/rise/core/traverseTest.scala
@@ -14,18 +14,16 @@ class traverseTest extends test_util.Tests {
     )
   )
 
-  class ExprTraceVisitor extends PairMonoidTraversal[Seq[Any], Pure] {
-    override val fstMonoid = SeqMonoid[Any]
-    override val wrapperMonad = PureMonad
+  class ExprTraceVisitor extends PureAccumulatorTraversal[Seq[Any]] {
+    override val accumulator = SeqMonoid[Any]
     override def identifier[I <: Identifier] : VarType => I => Pair[I] =
-      vt => i => record(Seq(i))(i)
+      vt => i => accumulate(Seq(i))(i)
   }
 
-  class TypeTraceVisitor extends PairMonoidTraversal[Seq[Any], Pure] {
-    override val fstMonoid = SeqMonoid[Any]
-    override val wrapperMonad = PureMonad
+  class TypeTraceVisitor extends PureAccumulatorTraversal[Seq[Any]] {
+    override val accumulator = SeqMonoid[Any]
     override def typeIdentifier[I <: Kind.Identifier] : VarType => I => Pair[I] =
-      vt => i => record(Seq(i))(i)
+      vt => i => accumulate(Seq(i))(i)
   }
 
   def checkEqualities[T] : Seq[T] => Seq[Seq[Int]] => Boolean = xs => gps =>


### PR DESCRIPTION
A low importance PR, but it adds a monad on pairs where the first element is a monoid, so we don't need to keep surrounding traversals with mutable environments on which we accumulate stuff. Albeit a small benefit, it allow us to merge `getFTVs` and `getFTVsRec` into a single traversal definition. It can also be used on the DPIA side once I finish refactoring the traversals there too.