### PR TITLE
Preliminary attempt at bidirectional typechecking/inference

### DIFF
--- a/src/main/scala/rise/core/bidirectional.scala
+++ b/src/main/scala/rise/core/bidirectional.scala
@@ -3,6 +3,9 @@ package rise.core
 import scala.collection.mutable.ListBuffer
 import rise.core.semantics._
 import rise.core.types._
+import util.PatternMatching
+
+import scala.annotation.tailrec
 
 /*
 Following "Bidirectional Typing", by Jana Dunfield (http://export.arxiv.org/pdf/1908.05839)
@@ -19,18 +22,46 @@ object bidirectional {
   }
   def error(msg: String)(implicit trace: Trace): Nothing = throw InferenceException(msg, trace)
 
-  type TermCtx = Map[Identifier, Type]
-
   def unify(a : Type, b : Type)(implicit trace : Trace) : Solution =
     Constraint.solve(Seq(TypeConstraint(a, b)), Seq())(Flags.ExplicitDependence.Off)
 
-  def checkKind[K <: Kind](termCtx : TermCtx, expr : K#T, `type` : K#I)(implicit trace : Trace) : Solution = {
-    `type` match {
-      case t : TypeIdentifier => Solution.subs(`type`.asInstanceOf[Type], t)
-      case t : Nat => Solution.subs(`type`.asInstanceOf[NatIdentifier], t)
+  def substitute[K <: Kind](x : K#I, `for` : K#T)(implicit trace : Trace) : Solution = {
+    x match {
+      case x : TypeIdentifier => `for` match {
+        case `for` : Type => Solution.subs(x, `for`)
+        case _ => error(s"$x is a TypeIdentifier but ${`for`} is not a Type")
+      }
+      case x : NatIdentifier => `for` match {
+        case `for` : Nat => Solution.subs(x, `for`)
+        case _ => error(s"$x is a NatIdentifier but ${`for`} is not a Nat")
+      }
+      case x : DataTypeIdentifier => `for` match {
+        case `for` : DataType => Solution.subs(x, `for`)
+        case _ => error(s"$x is a DataTypeIdentifier but ${`for`} is not a DataType")
+      }
+      case x : AddressSpaceIdentifier => `for` match {
+        case `for` : AddressSpace => Solution.subs(x, `for`)
+        case _ => error(s"$x is a AddressSpaceIdentifier but ${`for`} is not an AddressSpace")
+      }
+      case x : NatToNatIdentifier => `for` match {
+        case `for` : NatToNat => Solution.subs(x, `for`)
+        case _ => error(s"$x is a NatToNatIdentifier but ${`for`} is not a NatToNat")
+      }
+      case x : NatToDataIdentifier => `for` match {
+        case `for` : NatToData => Solution.subs(x, `for`)
+        case _ => error(s"$x is a NatToDataIdentifier but ${`for`} is not a NatToData")
+      }
+      case x : NatCollectionIdentifier => `for` match {
+        case `for` : NatCollection => Solution.subs(x, `for`)
+        case _ => error(s"$x is a NatCollectionIdentifier but ${`for`} is not a NatCollection")
+      }
     }
   }
 
+  type TermCtx = Map[Identifier, Type]
+
+  def check(expr : Expr, `type`: Type) : Solution = check(Map(), expr, `type`)(implicitly(new Trace()))
+  @tailrec
   def check(termCtx : TermCtx, expr : Expr, `type` : Type)(implicit trace : Trace) : Solution = {
     trace += s"check $termCtx |- $expr : ${`type`}"
 
@@ -51,6 +82,7 @@ object bidirectional {
     }
   }
 
+  def infer(expr : Expr) : Type = infer(Map(), expr)(implicitly(new Trace()))
   def infer(termCtx : TermCtx, expr : Expr)(implicit trace : Trace) : Type = {
     trace += s"infer $termCtx |- $expr"
 
@@ -60,42 +92,55 @@ object bidirectional {
           case Some(t) => t
           case None => error(s"could not find $x in $termCtx")
         }
+
       case Lambda(x, e) =>
         val xT = TypeIdentifier(freshName("x"))
         val eT = infer(termCtx ++ Map(x -> xT), e)
         FunType(xT, eT)
-      case DepLambda(x, e) => x match {
-        case x : NatIdentifier =>
-          val eT = infer(termCtx, e)
-          DepFunType[NatKind, Type](x, eT)
-      }
+
+      case DepLambda(x, e) =>
+        val eT = infer(termCtx, e)
+        x match {
+          case x : NatIdentifier => DepFunType[NatKind, Type](x, eT)
+          case x : DataTypeIdentifier => DepFunType[DataKind, Type](x, eT)
+          case x : AddressSpaceIdentifier => DepFunType[AddressSpaceKind, Type](x, eT)
+          case x : NatToNatIdentifier => DepFunType[NatToNatKind, Type](x, eT)
+          case x : NatToDataIdentifier => DepFunType[NatToDataKind, Type](x, eT)
+          case x : NatCollectionIdentifier => DepFunType[NatCollectionKind, Type](x, eT)
+        }
+
       case App(f, e) =>
         infer(termCtx, f) match {
           case FunType(a, b) =>
-            val typeCtx1 = check(termCtx, e, a)
-            typeCtx1(b)
+            val subs = check(termCtx, e, a)
+            subs(b)
           case _ => error(s"$termCtx |- $f is not a function type")
         }
+
       case DepApp(f, x) =>
         infer(termCtx, f) match {
           case DepFunType(xT, eT) =>
-            val typeCtx1 = checkKind(termCtx, x, xT)
-            typeCtx1(eT)
+            val subs = substitute(x = xT, `for` = x)
+            subs(eT)
           case _ => error(s"$termCtx |- $f is not a dependent function type")
         }
+
       case TypeAnnotation(e, t) =>
-        val typeCtx1 = check(termCtx, e, t)
-        typeCtx1(t)
+        check(termCtx, e, t)
+        t
+
       case TypeAssertion(e, t) =>
-        val typeCtx1 = check(termCtx, e, t)
-        typeCtx1(t)
+        val subs = check(termCtx, e, t)
+        subs(t)
+
       case Literal(d) => d.dataType
+
       case p : Primitive => p.typeScheme
     }
   }
 
-  implicit val trace : Trace = new Trace()
   val x = Identifier(freshName("x"))(TypePlaceholder)
+  val n2d = NatToDataIdentifier(freshName("x"))
   val n = NatIdentifier(freshName("x"))
   val example0 : Expr = App(TypeAnnotation(Lambda(x, x)(TypePlaceholder), FunType(int, int)), Literal(IntData(1)))(TypePlaceholder)
   val example1 : Expr = Lambda(x, x)(TypePlaceholder)
@@ -103,4 +148,7 @@ object bidirectional {
   val example3 : Expr = DepLambda[NatKind](n, Literal(NatData(n)))(TypePlaceholder)
   val example4 : Expr = DepApp[NatKind](example3, 2)(TypePlaceholder)
   val example5 : Expr = DepApp[TypeKind](example3, bool)(TypePlaceholder)
+  val example6 : Expr = DepLambda[NatToDataKind](n2d, DepApp[NatToDataKind](DepLambda[NatToDataKind](n2d, Literal(IntData(1)))(TypePlaceholder), n2d)(TypePlaceholder))(TypePlaceholder)
+  val mapId : Expr = App(primitives.map.primitive, Lambda(x, x)(TypePlaceholder))(TypePlaceholder)
+  val mapIdArray : Expr = App(mapId, Literal(ArrayData(Seq(BoolData(false)))))(TypePlaceholder)
 }

--- a/src/main/scala/rise/core/bidirectional.scala
+++ b/src/main/scala/rise/core/bidirectional.scala
@@ -1,0 +1,101 @@
+package rise.core
+
+import scala.collection.mutable.ListBuffer
+
+import rise.core.semantics._
+import rise.core.types._
+
+/*
+Following "Bidirectional Typing", by Jana Dunfield (http://export.arxiv.org/pdf/1908.05839)
+The section on polymorphism is especially relevant if we do not want to have type annotations everywhere.
+ */
+
+object bidirectional {
+  type Trace = ListBuffer[String]
+
+  case class InferenceException(msg: String, trace: Trace) extends Exception {
+    override def toString: String =
+      s"inference exception: $msg\n${trace.mkString("---- trace ----\n",
+        "\n", "\n---------------")}"
+  }
+  def error(msg: String)(implicit trace: Trace): Nothing = throw InferenceException(msg, trace)
+
+  type TermCtx = Map[Identifier, Type]
+  type TypeCtx = Solution // FIXME: types should be TypeIdentifier => Type
+
+  def checkKinded[K <: Kind](typeCtx : TypeCtx, termCtx : TermCtx, expr : K#T, `type` : K#I)(implicit trace : Trace) : TypeCtx =
+    expr match {
+      case e : Expr => check(typeCtx, termCtx, e, `type`.asInstanceOf[Type])
+    }
+
+  def unify(a : Type, b : Type)(implicit trace : Trace) : TypeCtx =
+    Constraint.solve(Seq(TypeConstraint(a, b)), Seq())(Flags.ExplicitDependence.Off)
+
+  def check(typeCtx : TypeCtx, termCtx : TermCtx, expr : Expr, `type` : Type)(implicit trace : Trace) : TypeCtx = {
+    trace += s"check $typeCtx ; $termCtx |- $expr : ${`type`}"
+
+    expr match {
+      case Lambda(x, e) =>
+        `type` match {
+          case FunType(a, b) => check(typeCtx, termCtx ++ Map(x -> a), e, b)
+          case _ => error(s"${`type`} is not a function type")
+        }
+      case DepLambda(x, e) =>
+        `type` match {
+          case DepFunType(x, t) => check(typeCtx ++ ???, termCtx, e, t)
+          case _ => error(s"${`type`} is not a dependent function type")
+        }
+      case Literal(d) => unify(d.dataType, `type`)
+      case p: Primitive => unify(p.typeScheme, `type`)
+      case _ =>
+        val t = infer(typeCtx, termCtx, expr)
+        unify(t, `type`)
+    }
+  }
+
+  def infer(typeCtx : TypeCtx, termCtx : TermCtx, expr : Expr)(implicit trace : Trace) : Type = {
+    trace += s"infer $typeCtx ; $termCtx |- $expr"
+
+    expr match {
+      case x: Identifier =>
+        termCtx.get(x) match {
+          case Some(t) => t
+          case None => error(s"could not find $x in $termCtx")
+        }
+      case Lambda(x, e) =>
+        val xT = TypeIdentifier(freshName("x"))
+        val termCtx1 = termCtx ++ Map(x -> xT)
+        val eT = infer(typeCtx, termCtx1, e)
+        FunType(xT, eT)
+      case DepLambda(x, e) => ???
+      case App(f, e) =>
+        infer(typeCtx, termCtx, f) match {
+          case FunType(a, b) =>
+            val typeCtx1 = check(typeCtx, termCtx, e, a)
+            typeCtx1(b)
+          case _ => error(s"$typeCtx ; $termCtx |- $f is not a function type")
+        }
+      case DepApp(f, x) =>
+        infer(typeCtx, termCtx, f) match {
+          case DepFunType(xT, eT) =>
+            val typeCtx1 = checkKinded(typeCtx, termCtx, x, xT)
+            typeCtx1(eT)
+          case _ => error(s"$typeCtx ; $termCtx |- $f is not a dependent function type")
+        }
+      case TypeAnnotation(e, t) =>
+        val typeCtx1 = check(typeCtx, termCtx, e, t)
+        typeCtx1(t)
+      case TypeAssertion(e, t) =>
+        val typeCtx1 = check(typeCtx, termCtx, e, t)
+        typeCtx1(t)
+      case Literal(d) => d.dataType
+      case p : Primitive => p.typeScheme
+    }
+  }
+
+  implicit val trace : Trace = new Trace()
+  val x = Identifier(freshName("x"))(TypePlaceholder)
+  val example : Expr = App(TypeAnnotation(Lambda(x, x)(TypePlaceholder), FunType(int, int)), Literal(IntData(1)))(TypePlaceholder)
+  val example1 : Expr = Lambda(x, x)(TypePlaceholder)
+  val example2 : Expr = App(Lambda(x, x)(TypePlaceholder) , Literal(IntData(1)))(TypePlaceholder)
+}

--- a/src/main/scala/rise/core/bidirectional.scala
+++ b/src/main/scala/rise/core/bidirectional.scala
@@ -1,7 +1,6 @@
 package rise.core
 
 import scala.collection.mutable.ListBuffer
-
 import rise.core.semantics._
 import rise.core.types._
 
@@ -21,40 +20,39 @@ object bidirectional {
   def error(msg: String)(implicit trace: Trace): Nothing = throw InferenceException(msg, trace)
 
   type TermCtx = Map[Identifier, Type]
-  type TypeCtx = Solution // FIXME: types should be TypeIdentifier => Type
 
-  def checkKinded[K <: Kind](typeCtx : TypeCtx, termCtx : TermCtx, expr : K#T, `type` : K#I)(implicit trace : Trace) : TypeCtx =
-    expr match {
-      case e : Expr => check(typeCtx, termCtx, e, `type`.asInstanceOf[Type])
-    }
-
-  def unify(a : Type, b : Type)(implicit trace : Trace) : TypeCtx =
+  def unify(a : Type, b : Type)(implicit trace : Trace) : Solution =
     Constraint.solve(Seq(TypeConstraint(a, b)), Seq())(Flags.ExplicitDependence.Off)
 
-  def check(typeCtx : TypeCtx, termCtx : TermCtx, expr : Expr, `type` : Type)(implicit trace : Trace) : TypeCtx = {
-    trace += s"check $typeCtx ; $termCtx |- $expr : ${`type`}"
+  def checkKind[K <: Kind](termCtx : TermCtx, expr : K#T, `type` : K#I)(implicit trace : Trace) : Solution = {
+    `type` match {
+      case t : TypeIdentifier => Solution.subs(`type`.asInstanceOf[Type], t)
+      case t : Nat => Solution.subs(`type`.asInstanceOf[NatIdentifier], t)
+    }
+  }
+
+  def check(termCtx : TermCtx, expr : Expr, `type` : Type)(implicit trace : Trace) : Solution = {
+    trace += s"check $termCtx |- $expr : ${`type`}"
 
     expr match {
       case Lambda(x, e) =>
         `type` match {
-          case FunType(a, b) => check(typeCtx, termCtx ++ Map(x -> a), e, b)
+          case FunType(a, b) => check(termCtx ++ Map(x -> a), e, b)
           case _ => error(s"${`type`} is not a function type")
         }
       case DepLambda(x, e) =>
         `type` match {
-          case DepFunType(x, t) => check(typeCtx ++ ???, termCtx, e, t)
+          case DepFunType(x, t) => check(termCtx, e, t)
           case _ => error(s"${`type`} is not a dependent function type")
         }
       case Literal(d) => unify(d.dataType, `type`)
       case p: Primitive => unify(p.typeScheme, `type`)
-      case _ =>
-        val t = infer(typeCtx, termCtx, expr)
-        unify(t, `type`)
+      case _ => unify(infer(termCtx, expr), `type`)
     }
   }
 
-  def infer(typeCtx : TypeCtx, termCtx : TermCtx, expr : Expr)(implicit trace : Trace) : Type = {
-    trace += s"infer $typeCtx ; $termCtx |- $expr"
+  def infer(termCtx : TermCtx, expr : Expr)(implicit trace : Trace) : Type = {
+    trace += s"infer $termCtx |- $expr"
 
     expr match {
       case x: Identifier =>
@@ -64,29 +62,32 @@ object bidirectional {
         }
       case Lambda(x, e) =>
         val xT = TypeIdentifier(freshName("x"))
-        val termCtx1 = termCtx ++ Map(x -> xT)
-        val eT = infer(typeCtx, termCtx1, e)
+        val eT = infer(termCtx ++ Map(x -> xT), e)
         FunType(xT, eT)
-      case DepLambda(x, e) => ???
+      case DepLambda(x, e) => x match {
+        case x : NatIdentifier =>
+          val eT = infer(termCtx, e)
+          DepFunType[NatKind, Type](x, eT)
+      }
       case App(f, e) =>
-        infer(typeCtx, termCtx, f) match {
+        infer(termCtx, f) match {
           case FunType(a, b) =>
-            val typeCtx1 = check(typeCtx, termCtx, e, a)
+            val typeCtx1 = check(termCtx, e, a)
             typeCtx1(b)
-          case _ => error(s"$typeCtx ; $termCtx |- $f is not a function type")
+          case _ => error(s"$termCtx |- $f is not a function type")
         }
       case DepApp(f, x) =>
-        infer(typeCtx, termCtx, f) match {
+        infer(termCtx, f) match {
           case DepFunType(xT, eT) =>
-            val typeCtx1 = checkKinded(typeCtx, termCtx, x, xT)
+            val typeCtx1 = checkKind(termCtx, x, xT)
             typeCtx1(eT)
-          case _ => error(s"$typeCtx ; $termCtx |- $f is not a dependent function type")
+          case _ => error(s"$termCtx |- $f is not a dependent function type")
         }
       case TypeAnnotation(e, t) =>
-        val typeCtx1 = check(typeCtx, termCtx, e, t)
+        val typeCtx1 = check(termCtx, e, t)
         typeCtx1(t)
       case TypeAssertion(e, t) =>
-        val typeCtx1 = check(typeCtx, termCtx, e, t)
+        val typeCtx1 = check(termCtx, e, t)
         typeCtx1(t)
       case Literal(d) => d.dataType
       case p : Primitive => p.typeScheme
@@ -95,7 +96,11 @@ object bidirectional {
 
   implicit val trace : Trace = new Trace()
   val x = Identifier(freshName("x"))(TypePlaceholder)
-  val example : Expr = App(TypeAnnotation(Lambda(x, x)(TypePlaceholder), FunType(int, int)), Literal(IntData(1)))(TypePlaceholder)
+  val n = NatIdentifier(freshName("x"))
+  val example0 : Expr = App(TypeAnnotation(Lambda(x, x)(TypePlaceholder), FunType(int, int)), Literal(IntData(1)))(TypePlaceholder)
   val example1 : Expr = Lambda(x, x)(TypePlaceholder)
   val example2 : Expr = App(Lambda(x, x)(TypePlaceholder) , Literal(IntData(1)))(TypePlaceholder)
+  val example3 : Expr = DepLambda[NatKind](n, Literal(NatData(n)))(TypePlaceholder)
+  val example4 : Expr = DepApp[NatKind](example3, 2)(TypePlaceholder)
+  val example5 : Expr = DepApp[TypeKind](example3, bool)(TypePlaceholder)
 }


### PR DESCRIPTION
The main difference wrt what we currently have is that instead of three distinguished phases where we 1) collect constraints 2) solve constraints 3) apply substitutions, we traverse the expression tree alternating between inferring and checking, only ever creating type variables where we need to (i.e. abstractions that do not have typing annotations), and the few created constraints are solved eagerly in place.

The benefits wrt what we currently have are 1) much fewer constraints are generated 2) the errors are a lot more localised (if a constraint doesn't hold we know exactly where in the expression tree this constraint was created).