### PR TITLE
Refactored reorder primitive to use NatToNat lambdas rather than idx[n] -> idx[n] functions

### DIFF
--- a/src/main/scala/rise/core/DSL/HighLevelConstructs.scala
+++ b/src/main/scala/rise/core/DSL/HighLevelConstructs.scala
@@ -74,16 +74,10 @@ object HighLevelConstructs {
 
   val reorderWithStride: ToBeTyped[Expr] = {
     depFun((s: Nat) => {
-      val f =
-        impl { n: Nat =>
-          fun(IndexType(n))(i =>
-            natAsIndex(n)(
-              (indexAsNat(i) / (n /^ s)) +
-                (l(s) * (indexAsNat(i) % (n /^ s)))
-            )
-          )
-        }
-      reorder(f)(f)
+      impl { n: Nat =>
+        def f = n2nFun(n)(i => (i / (n /^ s)) + (s * (i % (n /^ s))))
+        reorder(n)(f)(f)
+      }
     })
   }
 

--- a/src/main/scala/rise/core/DSL/Type.scala
+++ b/src/main/scala/rise/core/DSL/Type.scala
@@ -212,6 +212,15 @@ object Type {
     }
   }
 
+  object `(NatToNat)->:` {
+    def unapply[K <: Kind, T <: Type](funType: DepFunType[K, T]): Option[(NatToNatIdentifier, T)] = {
+      funType.x match {
+        case n: NatToNatIdentifier => Some((n, funType.t))
+        case _ => throw new Exception("Expected NatToNat DepFunType")
+      }
+    }
+  }
+
   implicit final class TupleTypeConstructors(private val a: DataType)
     extends AnyVal {
     @inline def x(b: DataType): PairType = PairType(a, b)

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -40,6 +40,13 @@ object IsClosedForm {
       case t => super.natToData(t)
     }
 
+    override def natToNat: NatToNat => Option[NatToNat] = {
+      case d@NatToNatLambda(x, n) =>
+        for { _ <- this.copy(boundT = boundT + x).nat(n) }
+          yield d
+      case n => super.natToNat(n)
+    }
+
     override def `type`[T <: Type]: T => Option[T] = {
       case d@DepFunType(x, t) =>
         for { _ <- this.copy(boundT = boundT + x).`type`(t) }

--- a/src/main/scala/rise/core/primitives/primitives.rise
+++ b/src/main/scala/rise/core/primitives/primitives.rise
@@ -53,7 +53,7 @@ def transpose: {n: nat} -> {m: nat} -> {t: data} -> n.m.t -> m.n.t
 
 def gather : {n: nat} -> {m: nat} -> {t: data} -> m.idx[n] -> n.t -> m.t
 def scatter: {n: nat} -> {m: nat} -> {t: data} -> n.idx[m] -> n.t -> m.t
-def reorder: {n: nat} -> {t: data} -> (idx[n] -> idx[n]) -> (idx[n] -> idx[n]) -> n.t -> n.t
+def reorder: {t: data} -> (n: nat) -> (idxF: nat2nat) -> (idxFinv: nat2nat) -> n.t -> n.t
 
 def padCst:   {n: nat} -> (l: nat) -> (r: nat) -> {t: data} -> t -> n.t -> (l+n+r).t
 def padClamp: {n: nat} -> (l: nat) -> (r: nat) -> {t: data} -> n.t -> (l+n+r).t

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -1,7 +1,7 @@
 package rise.core.types
 
 import util.monads._
-import arithexpr.arithmetic.BoolExpr
+import arithexpr.arithmetic.{BoolExpr, NamedVar}
 import rise.core.traverse._
 import rise.core.{Expr, substitute}
 
@@ -104,6 +104,7 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToNatLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
+          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range, isExplicit = true)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToNatLambda(xSub, apply(body))

--- a/src/main/scala/rise/elevate/rules/traversal.scala
+++ b/src/main/scala/rise/elevate/rules/traversal.scala
@@ -183,6 +183,10 @@ object traversal {
               Some(s(f).mapSuccess(DepApp[DataKind](_, dt)(da.t)))
             case addr: AddressSpace =>
               Some(s(f).mapSuccess(DepApp[AddressSpaceKind](_, addr)(da.t)))
+            case n2n: NatToNat =>
+              Some(s(f).mapSuccess(DepApp[NatToNatKind](_, n2n)(da.t)))
+            case n2d: NatToData =>
+              Some(s(f).mapSuccess(DepApp[NatToDataKind](_, n2d)(da.t)))
           }
           case Literal(_) => None
           case _: ForeignFunction => None

--- a/src/main/scala/shine/C/Compilation/CodeGenerator.scala
+++ b/src/main/scala/shine/C/Compilation/CodeGenerator.scala
@@ -242,7 +242,7 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
 
     case ReorderAcc(n, _, idxF, a) => path match {
       case (i: CIntExpr) :: ps =>
-        a |> acc(env, CIntExpr(OperationalSemantics.evalIndexExp(idxF(NatAsIndex(n, Natural(i))))) :: ps, cont)
+        a |> acc(env, CIntExpr(idxF(i)) :: ps, cont)
       case _ => error(s"Expected a C-Integer-Expression on the path.")
     }
 
@@ -421,7 +421,7 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
 
     case Reorder(n, _, _, idxF, _, a) => path match {
       case (i: CIntExpr) :: ps =>
-        a |> exp(env, CIntExpr(OperationalSemantics.evalIndexExp(idxF(functional.NatAsIndex(n, Natural(i))))) :: ps, cont)
+        a |> exp(env, CIntExpr(idxF(i)) :: ps, cont)
       case _ => error(s"Expected a C-Integer-Expression on the path.")
     }
 

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -2,7 +2,7 @@ package shine.DPIA
 
 import rise.{core => r}
 import rise.core.{types => rt}
-import rise.core.DSL.Type.{->:, `(Addr)->:`, `(Nat)->:`, x, TupleTypeConstructors, `.`, ArrayTypeConstructors}
+import rise.core.DSL.Type.{->:, `(Addr)->:`, `(Nat)->:`, `(NatToNat)->:`, x, TupleTypeConstructors, `.`, ArrayTypeConstructors}
 import rise.core.{primitives => rp}
 import rise.openMP.{primitives => rompp}
 import rise.openCL.{primitives => roclp}
@@ -523,13 +523,10 @@ private class InferAccessAnnotation {
       }
 
       case rp.reorder() => p.t match {
-        case (rt.IndexType(n) ->: rt.IndexType(_)) ->:
-          (rt.IndexType(_) ->: rt.IndexType(_)) ->: (_`.`t) ->: (_`.`_) =>
+        case (n `(Nat)->:` (idxF `(NatToNat)->:` (idxFinv `(NatToNat)->:` ((_`.`t) ->: (_`.`_) )))) =>
 
           val ai = accessTypeIdentifier()
-          (expT(rt.IndexType(n), read) ->: expT(rt.IndexType(n), read)) ->:
-            (expT(rt.IndexType(n), read) ->: expT(rt.IndexType(n), read)) ->:
-            expT(n`.`t, ai) ->: expT(n`.`t, ai)
+          nFunT(n, n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
         case _ => error()
       }
 

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -12,10 +12,10 @@ object VisitAndRebuild {
 
     def data[T <: DataType](dt: T): T = dt
 
-    def natToNat[N <: NatToNat](ft: N): N = (ft match {
+    def natToNat(ft: NatToNat): NatToNat= ft match {
       case NatToNatLambda(n, body) => NatToNatLambda(nat(n), nat(body))
       case i: NatToNatIdentifier => i
-    }).asInstanceOf[N]
+    }
 
     def natToData[N <: NatToData](ft: N): N = (ft match {
       case NatToDataLambda(n, body) => NatToDataLambda(nat(n), data(body))

--- a/src/main/scala/shine/DPIA/Types/NatToNat.scala
+++ b/src/main/scala/shine/DPIA/Types/NatToNat.scala
@@ -34,12 +34,12 @@ object NatToNatLambda {
   }
 
   def apply(upperBound:Nat, id: NatIdentifier, body:Nat):NatToNatLambda = {
-    val x = NamedVar(freshName("n"), RangeAdd(0, upperBound, 1))
+    val x = NatIdentifier(freshName("n"), RangeAdd(0, upperBound, 1))
     NatToNatLambda(x, x => ArithExpr.substitute(body, Map((id, x))))
   }
 
   def apply(range: Range, id: NatIdentifier, body: Nat): NatToNatLambda = {
-    val x = NamedVar(freshName("n"), range)
+    val x = NatIdentifier(freshName("n"), range)
     NatToNatLambda(x, x => ArithExpr.substitute(body, Map((id, x))))
   }
 }

--- a/src/main/scala/shine/DPIA/Types/NatToNat.scala
+++ b/src/main/scala/shine/DPIA/Types/NatToNat.scala
@@ -37,6 +37,11 @@ object NatToNatLambda {
     val x = NamedVar(freshName("n"), RangeAdd(0, upperBound, 1))
     NatToNatLambda(x, x => ArithExpr.substitute(body, Map((id, x))))
   }
+
+  def apply(range: Range, id: NatIdentifier, body: Nat): NatToNatLambda = {
+    val x = NamedVar(freshName("n"), range)
+    NatToNatLambda(x, x => ArithExpr.substitute(body, Map((id, x))))
+  }
 }
 
 final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier {

--- a/src/main/scala/shine/DPIA/Types/PhraseType.scala
+++ b/src/main/scala/shine/DPIA/Types/PhraseType.scala
@@ -54,7 +54,7 @@ object PhraseType {
     case (n: Nat, forN: NatIdentifier)                    => substitute(n, forN, in)
     case (a: AddressSpace, forA: AddressSpaceIdentifier)  => substitute(a, forA, in)
     case (a: AccessType, forA: AccessTypeIdentifier)      => substitute(a, forA, in)
-    case (n2n: NatToNat, fotN2N: NatToNatIdentifier)      => ??? //substitute(n2n, forN2N, in)
+    case (n2n: NatToNat, forN2N: NatToNatIdentifier)      => substitute(n2n, forN2N, in)
     case (n2d: NatToData, fotN2D: NatToDataIdentifier)    => ??? //substitute(n2d, forN2D, in)
     case _ => throw new Exception(s"could not substitute $x for ${`for`} in $in")
   }
@@ -64,8 +64,8 @@ object PhraseType {
     case (n: Nat, forN: NatIdentifier)                    => substitute(n, forN, in)
     case (a: AddressSpace, forA: AddressSpaceIdentifier)  => substitute(a, forA, in)
     case (a: AccessType, forA: AccessTypeIdentifier)      => ??? //substitute(a, forA, in)
-    case (n2n: NatToNat, fotN2N: NatToNatIdentifier)      => ??? //substitute(n2n, forN2N, in)
-    case (n2d: NatToData, fotN2D: NatToDataIdentifier)    => ??? //substitute(n2d, forN2D, in)
+    case (n2n: NatToNat, forN2N: NatToNatIdentifier)      => substitute(n2n, forN2N, in)
+    case (n2d: NatToData, forN2D: NatToDataIdentifier)    => ??? //substitute(n2d, forN2D, in)
     case _ => throw new Exception(s"could not substitute $x for ${`for`} in $in")
   }
 
@@ -135,21 +135,21 @@ object PhraseType {
   }
 
 
-  def substitute(ae: Nat, `for`: Nat, in: PhraseType): PhraseType = {
+  def substitute(n: Nat, `for`: Nat, in: PhraseType): PhraseType = {
     in match {
       case b: BasePhraseType => b match {
-        case e: ExpType => ExpType(DataType.substitute(ae, `for`, e.dataType), e.accessType)
-        case a: AccType => AccType(DataType.substitute(ae, `for`, a.dataType))
+        case e: ExpType => ExpType(DataType.substitute(n, `for`, e.dataType), e.accessType)
+        case a: AccType => AccType(DataType.substitute(n, `for`, a.dataType))
       }
       case c: CommType => c
       case p: PhrasePairType[_, _] =>
-        PhrasePairType(substitute(ae, `for`, p.t1), substitute(ae, `for`, p.t2))
+        PhrasePairType(substitute(n, `for`, p.t1), substitute(n, `for`, p.t2))
       case f: FunType[_, _] =>
-        FunType(substitute(ae, `for`, f.inT), substitute(ae, `for`, f.outT))
+        FunType(substitute(n, `for`, f.inT), substitute(n, `for`, f.outT))
       case pf: PassiveFunType[_, _] =>
-        PassiveFunType(substitute(ae, `for`, pf.inT), substitute(ae, `for`, pf.outT))
+        PassiveFunType(substitute(n, `for`, pf.inT), substitute(n, `for`, pf.outT))
       case df: DepFunType[_, _] =>
-        DepFunType(df.x, substitute(ae, `for`, df.t))(df.kn)
+        DepFunType(df.x, substitute(n, `for`, df.t))(df.kn)
     }
   }
 
@@ -166,6 +166,26 @@ object PhraseType {
   def substitute(addr: AddressSpace,
                  `for`: AddressSpaceIdentifier,
                  in: PhraseType): PhraseType = {
+    // address spaces do not appear syntactically in phrase types
+    in
+  }
+
+  def substitute[T <: PhraseType](n2n: NatToNat,
+                                  `for`: NatToNatIdentifier,
+                                  in: Phrase[T]): Phrase[T] = {
+    object Visitor extends Phrases.VisitAndRebuild.Visitor {
+      override def natToNat(ft: NatToNat): NatToNat = ft match {
+        case i: NatToNatIdentifier if i == `for` => n2n
+        case _ => ft
+      }
+    }
+    Phrases.VisitAndRebuild(in, Visitor)
+  }
+
+  def substitute(n2n: NatToNat,
+                 `for`: NatToNatIdentifier,
+                 in: PhraseType): PhraseType = {
+    // NatToNat does not appear syntactically in phrase types
     in
   }
 

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -161,4 +161,22 @@ package object DPIA {
       }
     }
   }
+
+  object n2nFunT {
+    def apply(n: rt.NatToNatIdentifier, t: PhraseType): PhraseType = {
+      DepFunType[NatToNatKind, PhraseType](fromRise.natToNatIdentifier(n), t)
+    }
+
+    def apply(n: NatToNatIdentifier, t: PhraseType): PhraseType = {
+      DepFunType[NatToNatKind, PhraseType](n, t)
+    }
+
+    def unapply[K <: Kind, T <: PhraseType](funType: DepFunType[K, T]
+                                           ): Option[(NatToNatIdentifier, T)] = {
+      funType.x match {
+        case n: NatToNatIdentifier => Some((n, funType.t))
+        case _ => throw new Exception("Expected Nat DepFunType")
+      }
+    }
+  }
 }

--- a/src/main/scala/shine/DPIA/primitives/imperative/ReorderAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ReorderAcc.scala
@@ -9,10 +9,9 @@ import shine.macros.Primitive.accPrimitive
 @accPrimitive
 final case class ReorderAcc(n: Nat,
                             dt: DataType,
-                            idxF: Phrase[ExpType ->: ExpType],
+                            idxF: NatToNat,
                             array: Phrase[AccType]
                            ) extends AccPrimitive {
-  idxF :: expT(idx(n), read) ->: expT(idx(n), read)
   array :: accT(n`.`dt)
   override val t: AccType = accT(n`.`dt)
 }


### PR DESCRIPTION
Changes the type of the `reorder` primitive from:
```scala
def reorder: {n: nat} -> {t: data} -> (idx[n] -> idx[n]) -> (idx[n] -> idx[n]) -> n.t -> n.t
```
to
```scala
def reorder: {t: data} -> (n: nat) -> (idxF: nat2nat) -> (idxFinv: nat2nat) -> n.t -> n.t
```

This is how we should have implemented `reorder` from the start. But I believe initially we didn't had the `NatToNat` lambdas.

Before we wrote the reindexing functions like this:
```scala
val f = impl { n: Nat =>
	fun(IndexType(n))(i =>
		natAsIndex(n)(
		  (indexAsNat(i) / (n /^ s)) +
		    (l(s) * (indexAsNat(i) % (n /^ s)))
		)
	)
}
reorder(f)(f)
```

We had to convert awkwardly between `nat`s and `idx[n]`.
During code generation, we then used `evalIndexExp` to eventually turn the phrase with type `expr[idx[n], read]` into a `nat`.

This PR avoids these conventions.
Now we write the reindexing function like this:
```scala
impl { n: Nat =>
	def f = n2nFun(n)(i => (i / (n /^ s)) + (s * (i % (n /^ s))))
	reorder(n)(f)(f)
}
```

The new type of `reorder` does not express that the nat that is reindexed is smaller than `n`. I hope that we will be able to re-establish this in the type once we have a `Nat` language with the range information in the type.

This PR helps also to remove the partially implemented `eval` function (as the old `reorder` primitive requires the `evalIndexExp` functionality).