### PR TITLE
Translate RISE nats into DPIA nats

### DIFF
--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -60,7 +60,7 @@ object fromRise {
         case n: rt.Nat          => depApp[NatKind](f, nat(n))
         case dt: rt.DataType    => depApp[DataKind](f, dataType(dt))
         case a: rt.AddressSpace => depApp[AddressSpaceKind](f, addressSpace(a))
-        case n2n: rt.NatToNat   => depApp[NatToNatKind](f, nat2nat(n2n))
+        case n2n: rt.NatToNat   => depApp[NatToNatKind](f, ntn(n2n))
       }
 
     case r.Literal(d) => d match {
@@ -941,13 +941,6 @@ object fromRise {
     case rt.AddressSpace.Private => AddressSpace.Private
     case rt.AddressSpace.Constant => AddressSpace.Constant
     case rt.AddressSpaceIdentifier(name, _) => AddressSpaceIdentifier(name)
-  }
-
-  def nat2nat(n2n: rt.NatToNat): NatToNat = n2n match {
-    case rt.NatToNatIdentifier(name, _) =>
-      NatToNatIdentifier(name)
-    case rt.NatToNatLambda(x, body) =>
-      NatToNatLambda(x.range, NatIdentifier(x.name), nat(body))
   }
 
   def dataType(t: rt.DataType): DataType = t match {

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -16,16 +16,14 @@ package object DPIA {
   }
 
   type Nat = ArithExpr
-  type NatIdentifier = NamedVar with Kind.Identifier
-
-  object Nat {
-    def substitute[N <: Nat](ae: Nat, `for`: NatIdentifier, in: N): N =
-      ArithExpr.substitute(in, Map(`for` -> ae)).asInstanceOf[N]
+  case class NatIdentifier(override val name : String, override val range : Range = RangeUnknown) extends NamedVar(name, range) with Kind.Identifier {
+    override def withRange(r : Range) : NatIdentifier = NatIdentifier(name, r)
   }
 
-  object NatIdentifier {
-    def apply(name: String): NatIdentifier = new NamedVar(name) with Kind.Identifier
-    def apply(name: String, range: Range): NatIdentifier = new NamedVar(name, range) with Kind.Identifier
+  object Nat {
+    def substitute[N <: Nat](ae: Nat, `for`: NatIdentifier, in: N): N = {
+      ArithExpr.substitute(in, Map(`for` -> ae)).asInstanceOf[N]
+    }
   }
 
   // note: this is an easy fix to avoid name conflicts between lift and dpia


### PR DESCRIPTION
Currently the types don't help us with this: `Nat`s in both RISE and DPIA are `ArithExpr`, but `NatIdentifier`s in RISE and DPIA are different.