### PR TITLE
Created GAP8 package with Module and ModuleGenerator

### DIFF
--- a/src/main/scala/shine/GAP8/Compilation/ModuleGenerator.scala
+++ b/src/main/scala/shine/GAP8/Compilation/ModuleGenerator.scala
@@ -1,0 +1,93 @@
+package shine.GAP8.Compilation
+
+import arithexpr.arithmetic.Cst
+import shine.C.AST.{IncludeHeader, ParamKind}
+import shine.C.{Compilation, Module}
+import shine.DPIA.Compilation.Passes._
+import shine.DPIA.Compilation.{FunDef, TranslationToImperative}
+import shine.DPIA.DSL._
+import shine.DPIA.Phrases._
+import shine.DPIA.Types._
+import shine.DPIA.primitives.functional
+import shine.{C, DPIA}
+import util.compiler.DSL.run
+import shine.C.Compilation.{ModuleGenerator => CModuleGenerator}
+
+import scala.collection.{immutable, mutable}
+
+object ModuleGenerator extends DPIA.Compilation.ModuleGenerator[FunDef] {
+  override type Module = C.Module
+  override type CodeGenerator = Compilation.CodeGenerator
+
+  override def createOutputParam(outT: ExpType): Identifier[AccType] =
+    CModuleGenerator.createOutputParam(outT)
+
+  def toImperative(gen: CodeGenerator,
+                   funDef: FunDef,
+                   outParam: Identifier[AccType]
+                  ): Phrase[ExpType] => Phrase[CommType] =
+    CModuleGenerator.toImperative(gen, funDef, outParam)
+
+  //Culprit
+  override def imperativeToModule(gen: CodeGenerator,
+                                  funDef: FunDef,
+                                  outParam: Identifier[AccType]
+                                 ): Phrase[CommType] => Module = {
+    imperativePasses andThen
+      generateCode(gen, funDef, outParam) andThen
+      makeGAP8Module(gen, funDef, outParam)
+  }
+
+  def imperativePasses: Phrase[CommType] => Phrase[CommType] =
+    CModuleGenerator.imperativePasses
+
+  def generateCode(gen: CodeGenerator,
+                   funDef: FunDef,
+                   outParam: Identifier[AccType]
+                  ): Phrase[CommType] => (Seq[gen.Decl], gen.Stmt) =
+    CModuleGenerator.generateCode(gen, funDef, outParam)
+
+  def makeGAP8Module(gen: CodeGenerator,
+                  funDef: FunDef,
+                  outParam: Identifier[AccType]
+                 ): ((Seq[gen.Decl], gen.Stmt)) => Module = {
+    case (declarations, code) =>
+      val params = (outParam +: funDef.params).
+        map(C.AST.makeParam(C.AST.makeParamTy(gen)))
+
+      val structDecl = C.AST.StructTypeDecl(
+        "struct cluster_params",
+        params.map(i => C.AST.VarDecl(i.name, i.t))
+      )
+
+      //C.AST.Cast or sth
+      val structCastStmt = C.AST.Code("struct cluster_params* cl_params = (struct cluster_params*) args;")
+      //C.AST.DeclStmt maybe?
+      val unpackingStmt = C.AST.Code(
+        params.map(pdecl => pdecl.t.print + " " + pdecl.name + " = " + "cl_params->" + pdecl.name + ";").mkString("\n")
+      )
+
+
+      Module(
+        includes = immutable.Seq(IncludeHeader("stdint.h")),
+        decls = CModuleGenerator.collectTypeDeclarations(code, params) ++ declarations ++ Seq(structDecl),
+        functions = immutable.Seq(
+          C.AST.Function(
+            code =
+              C.AST.FunDecl(
+                funDef.name,
+                returnType = C.AST.Type.void,
+                Seq(C.AST.ParamDecl("args", C.AST.PointerType(C.AST.Type.void))),
+                C.AST.Block(immutable.Seq(structCastStmt, unpackingStmt, code))),
+            paramKinds =
+            //Construct new ParamKind() of type analogous to void*, assert in Function.scala fails
+              ParamKind(
+                outParam.`type`.dataType, C.AST.ParamKind.Kind.output
+              ) +: funDef.params.map(p =>
+                ParamKind(p.`type`.dataType, C.AST.ParamKind.Kind.input)
+              )
+          )
+        )
+      )
+  }
+}

--- a/src/main/scala/shine/GAP8/Compilation/ModuleGenerator.scala
+++ b/src/main/scala/shine/GAP8/Compilation/ModuleGenerator.scala
@@ -2,16 +2,17 @@ package shine.GAP8.Compilation
 
 import shine.C.AST.{IncludeHeader, ParamKind}
 import shine.C.Compilation.{ModuleGenerator => CModuleGenerator}
-import shine.C.{Compilation, Module}
+import shine.C.Compilation
 import shine.DPIA.Compilation.FunDef
 import shine.DPIA.Phrases._
 import shine.DPIA.Types._
-import shine.{C, DPIA}
+import shine.GAP8.Module
+import shine.{C, DPIA, GAP8}
 
 import scala.collection.immutable
 
 object ModuleGenerator extends DPIA.Compilation.ModuleGenerator[FunDef] {
-  override type Module = C.Module
+  override type Module = GAP8.Module
   override type CodeGenerator = Compilation.CodeGenerator
 
   override def createOutputParam(outT: ExpType): Identifier[AccType] =

--- a/src/main/scala/shine/GAP8/Module.scala
+++ b/src/main/scala/shine/GAP8/Module.scala
@@ -2,8 +2,18 @@ package shine.GAP8
 
 import shine.C
 
-// A C Module consists of a set of functions and their
-// dependencies (i.e. declarations and includes)
+/**
+  * This is a prototype of GAP8 module. Right now it consists of
+  * a set of includes, declarations (structure for passing arguments to cluster), and
+  * accelerator function (forked code)
+  *
+  * To be added:
+  * 1. host (fiber controller) code
+  * 2. code initially executed on core 0 after sending task to cluster
+  *   (executed prior to forking on cluster)
+  * 3. System kickoff code
+  * 4. TBA
+  * */
 case class Module(includes: Seq[C.AST.IncludeDirective],
                   decls: Seq[C.AST.Decl],
                   functions: Seq[C.AST.Function]) {

--- a/src/main/scala/shine/GAP8/Module.scala
+++ b/src/main/scala/shine/GAP8/Module.scala
@@ -1,0 +1,26 @@
+package shine.GAP8
+
+import shine.C
+
+// A C Module consists of a set of functions and their
+// dependencies (i.e. declarations and includes)
+case class Module(includes: Seq[C.AST.IncludeDirective],
+                  decls: Seq[C.AST.Decl],
+                  functions: Seq[C.AST.Function]) {
+  def compose(other: Module): Module =
+    Module(
+      (includes ++ other.includes).distinct,
+      (decls ++ other.decls).distinct,
+      functions ++ other.functions)
+}
+
+object Module {
+  def compose(ms: Seq[Module]): Module = ms.reduce(_ compose _)
+
+  def translateToString(m: Module): String =
+    s"""
+       |${m.includes.map(_.toString).mkString("\n")}
+       |${m.decls.map(C.AST.Printer(_)).mkString("\n")}
+       |${m.functions.map(f => C.AST.Printer(f.code)).mkString("\n")}
+       |""".stripMargin
+}

--- a/src/main/scala/util/gen.scala
+++ b/src/main/scala/util/gen.scala
@@ -103,20 +103,20 @@ object gen {
     }
 
     case class function(name: String = "foo") {
-      def fromExpr: Expr => CModule =
+      def fromExpr: Expr => GAP8.Module =
         functionFromExpr(name, OpenMP.CodeGenerator())
 
       def asStringFromExpr: Expr => String =
         functionAsStringFromExpr(name, OpenMP.CodeGenerator())
 
       private def funDefToFunction(name: String,
-                                   gen: CCodeGenerator): Phrase => CModule =
+                                   gen: CCodeGenerator): Phrase => GAP8.Module =
         (FunDef(name, _)) andThen
           GAP8.Compilation.ModuleGenerator.funDefToModule(gen)
 
       private def functionFromExpr(name: String = "foo",
                                    gen: CCodeGenerator = CCodeGenerator()
-                                  ): Expr => CModule =
+                                  ): Expr => GAP8.Module =
         exprToPhrase andThen
           funDefToFunction(name, gen)
 
@@ -124,7 +124,7 @@ object gen {
                                            gen: CCodeGenerator = CCodeGenerator()
                                           ): Expr => String =
         functionFromExpr(name, gen) andThen
-          C.Module.translateToString andThen
+          GAP8.Module.translateToString andThen
           run(SyntaxChecker(_))
     }
   }

--- a/src/main/scala/util/gen.scala
+++ b/src/main/scala/util/gen.scala
@@ -86,6 +86,49 @@ object gen {
     }
   }
 
+  object gap8 {
+    import shine.OpenMP
+    import shine.GAP8
+
+    object function {
+      def fromExpr: Expr => CModule =
+        gen.openmp.function().fromExpr
+
+      def asStringFromExpr: Expr => String = {
+        gen.openmp.function().asStringFromExpr
+      }
+
+      def asString: CModule => String =
+        gen.functionAsString
+    }
+
+    case class function(name: String = "foo") {
+      def fromExpr: Expr => CModule =
+        functionFromExpr(name, OpenMP.CodeGenerator())
+
+      def asStringFromExpr: Expr => String =
+        functionAsStringFromExpr(name, OpenMP.CodeGenerator())
+
+      private def funDefToFunction(name: String,
+                                   gen: CCodeGenerator): Phrase => CModule =
+        (FunDef(name, _)) andThen
+          GAP8.Compilation.ModuleGenerator.funDefToModule(gen)
+
+      private def functionFromExpr(name: String = "foo",
+                                   gen: CCodeGenerator = CCodeGenerator()
+                                  ): Expr => CModule =
+        exprToPhrase andThen
+          funDefToFunction(name, gen)
+
+      private def functionAsStringFromExpr(name: String = "foo",
+                                           gen: CCodeGenerator = CCodeGenerator()
+                                          ): Expr => String =
+        functionFromExpr(name, gen) andThen
+          C.Module.translateToString andThen
+          run(SyntaxChecker(_))
+    }
+  }
+
   object opencl {
     import shine.OpenCL
 


### PR DESCRIPTION
I have created GAP8 package/module with dedicated ```Module``` and ```ModuleGenerator``` for GAP8 backend. For now ```GAP8.ModuleGenerator``` is reusing most of its functionalities from ```C.ModuleGenerator```. I have also added ```gap8``` object to ```gen.scala```. 

Please check out changes and comments in ```ModuleGenerator``` as I could use a hint or two regarding:
1. Constructing a cast statement in a more meaningful way than using an ordinary string code (line 64)
2. Constructing statements or whatever needed that would translate to something like this:
```
uint8_t* output = cl_params->output;
...
```
As you can see, currently I'm doing it in a pretty naive manner (lines 66-68)

3. Constructing a new ```ParamKind``` of type analogous to ```void*```, as assert in ```Function.scala``` fails (line 84)

Regarding ```gen.scala``` is there any chance of making ```ModuleGenerator``` a parameter of the appropriate functions (i.e. ```asStringFromExpr``` etc.), so one could specify which Module Generator they want to use, as they can for ```CodeGenerator```?

I'm aware of the drawbacks of this copy/paste model of extending code base in general :) This is a draft pull request, so feel free to suggest any other way that would improve code reuse. I was thinking of (maybe) converting C.ModuleGenerator to class which would enable me to extend it for GAP8.ModuleGenerator but that leads to inevitable refactoring of OpenCL and Cuda ```ModuleGenerator``` (which would certainly work but would break coding style used so far)
