### PR TITLE
Remove explicitness information

### DIFF
--- a/src/main/scala/apps/cameraPipelineRewrite.scala
+++ b/src/main/scala/apps/cameraPipelineRewrite.scala
@@ -157,7 +157,7 @@ object cameraPipelineRewrite {
   // idx i >> f -> map f >> idx i
   def idxAfterF: Strategy[Rise] = {
     case expr @ App(f, App(App(p.idx(), i), in)) =>
-      Success(p.idx(i)(p.map(f)(in)) !: expr.t)
+      Success(p.idx(i)(p.map(f)(in)) !: expr)
     case _ => Failure(idxAfterF)
   }
 
@@ -383,18 +383,18 @@ object cameraPipelineRewrite {
 
   def letHoist: Strategy[Rise] = {
     case expr @ App(f, App(App(p.let(), v), Lambda(x, b))) =>
-      Success(letf(lambda(eraseType(x), preserveType(f)(b)))(v) !: expr.t)
+      Success(letf(lambda(eraseType(x), preserveType(f)(b)))(v) !: expr)
     // TODO: normal form / non-map specific?
     case expr @ App(App(p.map(), Lambda(y,
       App(App(p.let(), v), Lambda(x, b))
     )), in) if !contains[Rise](y).apply(v) =>
-      Success(letf(lambda(eraseType(x), p.map(lambda(eraseType(y), b))(in)))(v) !: expr.t)
+      Success(letf(lambda(eraseType(x), p.map(lambda(eraseType(y), b))(in)))(v) !: expr)
     case expr @ App(p.map(), Lambda(y,
       App(App(p.let(), v), Lambda(x, b))
     )) if !contains[Rise](y).apply(v) =>
       Success(fun(in =>
         letf(lambda(eraseType(x), p.map(lambda(eraseType(y), b))(in)))(v)
-      ) !: expr.t)
+      ) !: expr)
     case _ => Failure(letHoist)
   }
 
@@ -404,7 +404,7 @@ object cameraPipelineRewrite {
       argument(argument({
         case expr @ App(Lambda(x, color_correct), matrix) =>
           Success(letf(lambda(toBeTyped(x), color_correct))(
-            p.mapSeq(p.mapSeq(fun(x => x)))(matrix)) !: expr.t)
+            p.mapSeq(p.mapSeq(fun(x => x)))(matrix)) !: expr)
         case _ => Failure(precomputeColorCorrectionMatrix)
       })) `;`
       normalize.apply(gentleBetaReduction() <+ letHoist)
@@ -422,7 +422,7 @@ object cameraPipelineRewrite {
           argument(function(isEqualTo(p.generate.primitive))) `;`
           argument({ curve =>
             Success(letf(fun(x => x))(
-              p.mapSeq(fun(x => x))(curve)) !: curve.t)
+              p.mapSeq(fun(x => x))(curve)) !: curve)
           })
         )
       ))) `;`

--- a/src/main/scala/rise/core/DSL/ToBeTyped.scala
+++ b/src/main/scala/rise/core/DSL/ToBeTyped.scala
@@ -12,7 +12,6 @@ final case class ToBeTyped[+T <: Expr](private val e: T) {
       case Opaque(x, t) => expr(x)
       case tl@TopLevel(x, t) => expr(x)
       case TypeAnnotation(e, t) => expr(e)
-      case TypeAssertion(e, t) => expr(e)
       case p => super.`expr`(p.setType(TypePlaceholder))
     }
   }.expr(e).unwrap

--- a/src/main/scala/rise/core/DSL/Type.scala
+++ b/src/main/scala/rise/core/DSL/Type.scala
@@ -12,34 +12,28 @@ object Type {
   // type level lambdas
   object n2dtFun {
     def apply(f: NatIdentifier => DataType): NatToDataLambda = {
-      val x = NatIdentifier(freshName("n"), isExplicit = true)
+      val x = NatIdentifier(freshName("n"))
       NatToDataLambda(x, f(x))
     }
 
-    def apply(
-               r: arithexpr.arithmetic.Range
-             )(f: NatIdentifier => DataType): NatToDataLambda = {
-      val x = NatIdentifier(freshName("n"), r, isExplicit = true)
+    def apply(r: arithexpr.arithmetic.Range)(f: NatIdentifier => DataType): NatToDataLambda = {
+      val x = NatIdentifier(freshName("n"), r)
       NatToDataLambda(x, f(x))
     }
 
-    def apply(
-               upperBound: Nat
-             )(f: NatIdentifier => DataType): NatToDataLambda = {
+    def apply(upperBound: Nat)(f: NatIdentifier => DataType): NatToDataLambda = {
       apply(RangeAdd(0, upperBound, 1))(f)
     }
   }
 
   object n2nFun {
     def apply(f: NatIdentifier => Nat): NatToNatLambda = {
-      val x = NatIdentifier(freshName("n2n"), isExplicit = true)
+      val x = NatIdentifier(freshName("n2n"))
       NatToNatLambda(x, f(x))
     }
 
-    def apply(
-               r: arithexpr.arithmetic.Range
-             )(f: NatIdentifier => Nat): NatToNatLambda = {
-      val x = NatIdentifier(freshName("n2n"), r, isExplicit = true)
+    def apply(r: arithexpr.arithmetic.Range)(f: NatIdentifier => Nat): NatToNatLambda = {
+      val x = NatIdentifier(freshName("n2n"), r)
       NatToNatLambda(x, f(x))
     }
 
@@ -93,27 +87,27 @@ object Type {
 
   object expl {
     def apply(w: NatFunctionWrapper[Type]): Type = {
-      val x = NatIdentifier(freshName("n"), isExplicit = true)
+      val x = NatIdentifier(freshName("n"))
       DepFunType[NatKind, Type](x, w.f(x))
     }
 
     def apply(w: DataTypeFunctionWrapper[Type]): Type = {
-      val x = DataTypeIdentifier(freshName("dt"), isExplicit = true)
+      val x = DataTypeIdentifier(freshName("dt"))
       DepFunType[DataKind, Type](x, w.f(x))
     }
 
     def apply(w: NatToDataFunctionWrapper[Type]): Type = {
-      val x = NatToDataIdentifier(freshName("n2d"), isExplicit = true)
+      val x = NatToDataIdentifier(freshName("n2d"))
       DepFunType[NatToDataKind, Type](x, w.f(x))
     }
 
     def apply(w: NatToNatFunctionWrapper[Type]): Type = {
-      val x = NatToNatIdentifier(freshName("n2n"), isExplicit = true)
+      val x = NatToNatIdentifier(freshName("n2n"))
       DepFunType[NatToNatKind, Type](x, w.f(x))
     }
 
     def apply(w: AddressSpaceFunctionWrapper[Type]): Type = {
-      val x = AddressSpaceIdentifier(freshName("a"), isExplicit = true)
+      val x = AddressSpaceIdentifier(freshName("a"))
       DepFunType[AddressSpaceKind, Type](x, w.f(x))
     }
   }
@@ -159,14 +153,14 @@ object Type {
   // dependent pairs
   object Nat {
     def `**`(f: Nat => DataType): Type = {
-      val x = NatIdentifier(freshName("n"), isExplicit = true)
+      val x = NatIdentifier(freshName("n"))
       DepPairType[NatKind](x, f(x))
     }
   }
 
   object NatCollection {
     def `**`(f: NatCollection => DataType): Type = {
-      val x = NatCollectionIdentifier(freshName("ns"), isExplicit = true)
+      val x = NatCollectionIdentifier(freshName("ns"))
       DepPairType[NatCollectionKind](x, f(x))
     }
   }

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -42,7 +42,7 @@ object infer {
     infer.preserving(e_wo_assertions, Map(), preserve, printFlag, explDep)
   }
 
-  def preserving(wo_assertions: Expr, env: Map[String, Type], preserve : Set[Kind.Identifier],
+  def preserving(wo_assertions: Expr, env: Map[String, Type], preserve : Set[String],
                                printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off,
                                explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off): Expr = {
     // Collect constraints
@@ -99,16 +99,16 @@ object infer {
     traverse(e, FTVGathering)._1.distinct
   }
 
-  private val collectPreserve = new PureAccumulatorTraversal[Set[Kind.Identifier]] {
+  private val collectPreserve = new PureAccumulatorTraversal[Set[String]] {
     override val accumulator = SetMonoid
     override def expr: Expr => Pair[Expr] = {
       // Transform assertions into annotations, collect FTVs
       case TypeAssertion(e, t) =>
         val (s, e1) = expr(e).unwrap
-        accumulate(s ++ getFTVs(t))(TypeAnnotation(e1, t) : Expr)
+        accumulate(s ++ getFTVs(t).map(_.name))(TypeAnnotation(e1, t) : Expr)
       // Collect FTVs
       case Opaque(e, t) =>
-        accumulate(getFTVs(t).toSet)(Opaque(e, t) : Expr)
+        accumulate(getFTVs(t).map(_.name).toSet)(Opaque(e, t) : Expr)
       case e => super.expr(e)
     }
   }

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -83,7 +83,7 @@ package object DSL {
     def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = {
       val ftvT = infer.getFTVs(t).map(_.name).toSet
       val fvE = infer.collectFreeEnv(e)
-      e >>= (e => infer(TypeAnnotation(e, t), env=fvE, preserve=ftvT))
+      e >>= (e => infer(TypeAnnotation(e, t), extraEnv=fvE, extraPreserve=ftvT))
     }
   }
 

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -80,8 +80,11 @@ package object DSL {
   }
 
   implicit class TypeAssertionHelper(t: Type) {
-    def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] =
-      e >>= (e => toBeTyped(TypeAssertion(e, t)))
+    def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = {
+      val ftvT = infer.getFTVs(t).map(_.name).toSet
+      val fvE = infer.collectFreeEnv(e)
+      e >>= (e => infer(TypeAnnotation(e, t), env=fvE, preserve=ftvT))
+    }
   }
 
   implicit class TypeAnnotationHelper(t: Type) {

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -19,10 +19,7 @@ package object DSL {
     x >>= (x => e >>= (e => toBeTyped(Lambda(x, e)(TypePlaceholder))))
   def app(f: ToBeTyped[Expr], e: ToBeTyped[Expr]): ToBeTyped[App] =
     f >>= (f => e >>= (e => toBeTyped(App(f, e)(TypePlaceholder))))
-  def depLambda[K <: Kind: KindName](
-                                      x: K#I with Kind.Explicitness,
-                                      e: ToBeTyped[Expr]
-                                    ): ToBeTyped[DepLambda[K]] =
+  def depLambda[K <: Kind: KindName](x: K#I, e: ToBeTyped[Expr]): ToBeTyped[DepLambda[K]] =
     e >>= (e => toBeTyped(DepLambda[K](x, e)(TypePlaceholder)))
   def depApp[K <: Kind](f: ToBeTyped[Expr], x: K#T): ToBeTyped[DepApp[K]] =
     f >>= (f => toBeTyped(DepApp[K](f, x)(TypePlaceholder)))
@@ -408,71 +405,60 @@ package object DSL {
   }
 
   object depFun {
-    def apply(r: arithexpr.arithmetic.Range,
-              w: NatFunction1Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
-      val n = NatIdentifier(freshName("n"), r, isExplicit = true)
+    def apply(r: arithexpr.arithmetic.Range, w: NatFunction1Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
+      val n = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n, w.f(n))
     }
 
-    def apply(w: NatFunction1Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
+    def apply(w: NatFunction1Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
-      val n = NatIdentifier(freshName("n"), r, isExplicit = true)
+      val n = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n, w.f(n))
     }
 
-    def apply(w: NatFunction2Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
+    def apply(w: NatFunction2Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
-      val n1 = NatIdentifier(freshName("n"), r, isExplicit = true)
+      val n1 = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n1, depFun((n2: Nat) => w.f(n1, n2)))
     }
 
-    def apply(w: NatFunction3Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
+    def apply(w: NatFunction3Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
-      val n1 = NatIdentifier(freshName("n"), r, isExplicit = true)
+      val n1 = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n1, depFun((n2: Nat, n3: Nat) => w.f(n1, n2, n3)))
     }
 
-    def apply(w: NatFunction4Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
+    def apply(w: NatFunction4Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
-      val n1 = NatIdentifier(freshName("n"), r, isExplicit = true)
+      val n1 = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n1, depFun((n2: Nat, n3: Nat, n4: Nat) =>
         w.f(n1, n2, n3, n4)))
     }
 
-    def apply(w: NatFunction5Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatKind]] = {
+    def apply(w: NatFunction5Wrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatKind]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
-      val n1 = NatIdentifier(freshName("n"), r, isExplicit = true)
+      val n1 = NatIdentifier(freshName("n"), r)
       depLambda[NatKind](n1, depFun((n2: Nat, n3: Nat, n4: Nat, n5: Nat) =>
         w.f(n1, n2, n3, n4, n5)))
     }
 
-    def apply(w: DataTypeFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[DataKind]] = {
-      val x = DataTypeIdentifier(freshName("dt"), isExplicit = true)
+    def apply(w: DataTypeFunctionWrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[DataKind]] = {
+      val x = DataTypeIdentifier(freshName("dt"))
       depLambda[DataKind](x, w.f(x))
     }
 
-    def apply(w: NatToDataFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatToDataKind]] = {
-      val x = NatToDataIdentifier(freshName("n2d"), isExplicit = true)
+    def apply(w: NatToDataFunctionWrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatToDataKind]] = {
+      val x = NatToDataIdentifier(freshName("n2d"))
       depLambda[NatToDataKind](x, w.f(x))
     }
 
-    def apply(w: NatToNatFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatToNatKind]] = {
-      val x = NatToNatIdentifier(freshName("n2n"), isExplicit = true)
+    def apply(w: NatToNatFunctionWrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[NatToNatKind]] = {
+      val x = NatToNatIdentifier(freshName("n2n"))
       depLambda[NatToNatKind](x, w.f(x))
     }
 
-    def apply(w: AddressSpaceFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[AddressSpaceKind]] = {
-      val x = AddressSpaceIdentifier(freshName("a"), isExplicit = true)
+    def apply(w: AddressSpaceFunctionWrapper[ToBeTyped[Expr]]): ToBeTyped[DepLambda[AddressSpaceKind]] = {
+      val x = AddressSpaceIdentifier(freshName("a"))
       depLambda[AddressSpaceKind](x, w.f(x))
     }
   }

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -5,6 +5,7 @@ import rise.core.primitives._
 import rise.core.semantics._
 import rise.core.traverse._
 import rise.core.types._
+import rise.elevate.rewrite
 
 import scala.language.implicitConversions
 
@@ -76,14 +77,8 @@ package object DSL {
     def `@`(i: ToBeTyped[Expr]): ToBeTyped[App] = idx(i)(e)
   }
 
-  implicit class TypeAssertionHelper(t: Type) {
-    def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = {
-      val preserve = infer.getFTVs(t).map(_.name)
-      e >>= (e => {
-        val env = infer.collectFreeEnv(e)
-        infer(TypeAnnotation(e, t), env, preserve)
-      })
-    }
+  implicit class TypeAssertionHelper(lhs: Expr) {
+    def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = rewrite(lhs)(e)
   }
 
   implicit class TypeAnnotationHelper(t: Type) {

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -81,9 +81,11 @@ package object DSL {
 
   implicit class TypeAssertionHelper(t: Type) {
     def !:[T <: Expr](e: ToBeTyped[T]): ToBeTyped[Expr] = {
-      val ftvT = infer.getFTVs(t).map(_.name).toSet
-      val fvE = infer.collectFreeEnv(e)
-      e >>= (e => infer(TypeAnnotation(e, t), extraEnv=fvE, extraPreserve=ftvT))
+      val preserve = infer.getFTVs(t).map(_.name)
+      e >>= (e => {
+        val env = infer.collectFreeEnv(e)
+        infer(TypeAnnotation(e, t), env, preserve)
+      })
     }
   }
 

--- a/src/main/scala/rise/core/Expr.scala
+++ b/src/main/scala/rise/core/Expr.scala
@@ -70,12 +70,7 @@ case class TypeAnnotation(e: Expr, annotation: Type) extends Expr {
       this
     }
 }
-case class TypeAssertion(e: Expr, assertion: Type) extends Expr {
-  override val t : Type = TypePlaceholder
-  override def toString: String = s"$e !: $assertion"
-  override def setType(t: Type): TypeAnnotation =
-    throw TypeException(s"cannot set the type of ${getClass}")
-}
+
 
 abstract class Primitive extends Expr {
   override val t: Type = TypePlaceholder

--- a/src/main/scala/rise/core/Expr.scala
+++ b/src/main/scala/rise/core/Expr.scala
@@ -30,18 +30,12 @@ final case class App(f: Expr, e: Expr)(override val t: Type)
   override def setType(t: Type): App = this.copy(f, e)(t)
 }
 
-final case class DepLambda[K <: Kind: KindName](
-    x: K#I with Kind.Explicitness,
-    e: Expr
-)(override val t: Type)
-    extends Expr {
+final case class DepLambda[K <: Kind: KindName](x: K#I, e: Expr)(override val t: Type) extends Expr {
   val kindName: String = implicitly[KindName[K]].get
   override def setType(t: Type): DepLambda[K] = this.copy(x, e)(t)
 }
 
-final case class DepApp[K <: Kind](f: Expr, x: K#T)(
-    override val t: Type
-) extends Expr {
+final case class DepApp[K <: Kind](f: Expr, x: K#T)(override val t: Type) extends Expr {
   override def setType(t: Type): DepApp[K] = this.copy(f, x)(t)
 }
 

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -11,6 +11,9 @@ object IsClosedForm {
   {
     override val accumulator = PairMonoid(SetMonoid, SetMonoid)
 
+    val extractNatIdentifiers : Nat => Set[Kind.Identifier] =
+      _.varList.map(v => NatIdentifier(v.name, v.range)).toSet
+
     override def identifier[I <: Identifier]: VarType => I => Pair[I] = vt => i => {
       for { t2 <- `type`(i.t);
             i2 <- if (vt == Reference && !boundV(i)) {
@@ -28,11 +31,7 @@ object IsClosedForm {
     }
 
     override def nat: Nat => Pair[Nat] = n => {
-      val free = n.varList.foldLeft(Set[Kind.Identifier]()) {
-        case (free, v: NamedVar) if !boundT(NatIdentifier(v)) => free + NatIdentifier(v)
-        case (free, _) => free
-      }
-      accumulate((Set(), free))(n)
+      accumulate((Set(), extractNatIdentifiers(n).diff(boundT)))(n)
     }
 
     override def expr: Expr => Pair[Expr] = {

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -69,6 +69,9 @@ object IsClosedForm {
   def freeVars(expr: Expr): (Set[Identifier], Set[Kind.Identifier]) =
     traverse(expr, Visitor(Set(), Set()))._1
 
+  def freeVars(t: Type): (Set[Identifier], Set[Kind.Identifier]) =
+    traverse(t, Visitor(Set(), Set()))._1
+
   def apply(expr: Expr): Boolean = {
     val (freeV, freeT) = freeVars(expr)
     freeV.isEmpty && freeT.isEmpty

--- a/src/main/scala/rise/core/equality.scala
+++ b/src/main/scala/rise/core/equality.scala
@@ -121,7 +121,7 @@ object equality {
     val hashType: Type => Int = {
       case TypePlaceholder => 5
       case TypeIdentifier(_) => 7
-      case DataTypeIdentifier(_, _) => 11
+      case DataTypeIdentifier(_) => 11
       case FunType(inT, outT) => 13 * hashType(inT) + 17 * hashType(outT)
       case DepFunType(_, t) => 19 * hashType(t)
       case st: ScalarType => 29 * st.hashCode()

--- a/src/main/scala/rise/core/equality.scala
+++ b/src/main/scala/rise/core/equality.scala
@@ -168,8 +168,6 @@ object equality {
           equiv(typeEnv)(exprEnv)(e1)(e2) && typeEq.equiv[TypeKind](typeEnv)(t1)(t2) }
         case TypeAnnotation(e1, t1) => and { case TypeAnnotation(e2, t2) =>
           equiv(typeEnv)(exprEnv)(e1)(e2) && typeEq.equiv[TypeKind](typeEnv)(t1)(t2) }
-        case TypeAssertion(e1, t1) => and { case TypeAssertion(e2, t2) =>
-          equiv(typeEnv)(exprEnv)(e1)(e2) && typeEq.equiv[TypeKind](typeEnv)(t1)(t2) }
         // TODO: TopLevel
         case a: Primitive => and { case b: Primitive => a.primEq(b) }
       })
@@ -208,7 +206,6 @@ object equality {
       case Literal(_: PairData) => 97
       case Opaque(e, t) => 101*hash(e) + 103*typeEq.hash[TypeKind](t)
       case TypeAnnotation(e, t) => 107*hash(e) + 109*typeEq.hash[TypeKind](t)
-      case TypeAssertion(e, t) => 113*hash(e) + 127*typeEq.hash[TypeKind](t)
       case p: Primitive => 131*p.name.hashCode() + 137*typeEq.hash[TypeKind](p.t)
     }
   }

--- a/src/main/scala/rise/core/makeClosed.scala
+++ b/src/main/scala/rise/core/makeClosed.scala
@@ -6,36 +6,22 @@ import rise.core.types._
 object makeClosed {
   def apply(e: Expr): Expr = withCount(e)._1
   def withCount(e: Expr): (Expr, Int) = {
-    val emptySubs: (Map[Type, Type],
-      Map[NatIdentifier, Nat],
-      Map[AddressSpaceIdentifier, AddressSpace],
-      Map[NatToDataIdentifier, NatToData]) = (Map(), Map(), Map(), Map())
-
-    val (expr, (ts, ns, as, n2ds)) = DSL.infer.getFTVsRec(e).foldLeft((e, emptySubs))((acc, ftv) => acc match {
-      case (expr, (ts, ns, as, n2ds)) => ftv match {
+    val (expr, ts) = DSL.infer.getFTVsRec(e).foldLeft((e, Map[Type, Type]()))((acc, ftv) => acc match {
+      case (expr, ts) => ftv match {
         case i: TypeIdentifier =>
-          val dt = DataTypeIdentifier(freshName("dt"), isExplicit = true)
-          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)),
-            (ts ++ Map(i -> dt), ns, as , n2ds))
-        case i: DataTypeIdentifier =>
-          val dt = i.asExplicit
-          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)),
-            (ts ++ Map(i -> dt), ns, as , n2ds))
-        case i: NatIdentifier =>
-          val n = i.asExplicit
-          (DepLambda[NatKind](n, expr)(DepFunType[NatKind, Type](n, expr.t)),
-            (ts, ns ++ Map(i -> n), as, n2ds))
-        case i: AddressSpaceIdentifier =>
-          val a = i.asExplicit
-          (DepLambda[AddressSpaceKind](a, expr)(DepFunType[AddressSpaceKind, Type](a, expr.t)),
-            (ts, ns, as ++ Map(i -> a), n2ds))
-        case i: NatToDataIdentifier =>
-          val n2d = i.asExplicit
-          (DepLambda[NatToDataKind](n2d, expr)(DepFunType[NatToDataKind, Type](n2d, expr.t)),
-            (ts, ns, as, n2ds ++ Map(i -> n2d)))
+          val dt = DataTypeIdentifier(freshName("dt"))
+          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)), ts ++ Map(i -> dt))
+        case dt: DataTypeIdentifier =>
+          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)), ts)
+        case n: NatIdentifier =>
+          (DepLambda[NatKind](n, expr)(DepFunType[NatKind, Type](n, expr.t)), ts)
+        case a: AddressSpaceIdentifier =>
+          (DepLambda[AddressSpaceKind](a, expr)(DepFunType[AddressSpaceKind, Type](a, expr.t)), ts)
+        case n2d: NatToDataIdentifier =>
+          (DepLambda[NatToDataKind](n2d, expr)(DepFunType[NatToDataKind, Type](n2d, expr.t)), ts)
         case i => throw TypeException(s"${i.getClass} is not supported yet")
       }
     })
-    (new Solution(ts, ns, as, Map.empty, Map.empty, n2ds, Map.empty, Map.empty)(expr), ts.size + ns.size + as.size + n2ds.size)
+    (new Solution(ts, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty)(expr), ts.size)
   }
 }

--- a/src/main/scala/rise/core/package.scala
+++ b/src/main/scala/rise/core/package.scala
@@ -40,7 +40,6 @@ package object core {
       case Literal(d)           => s"Literal($d)"
       case ff: ForeignFunction  => ff.toString
       case TypeAnnotation(e, t) => s"TypeAnnotation(${toEvaluableString(e)}, $t)"
-      case TypeAssertion(e, t)  => s"TypeAssertion(${toEvaluableString(e)}, $t)"
       case Opaque(e, t)         => s"Opaque(${toEvaluableString(e)}, $t)"
       case p: Primitive         => p.toString
     }

--- a/src/main/scala/rise/core/showRise.scala
+++ b/src/main/scala/rise/core/showRise.scala
@@ -275,7 +275,6 @@ class ShowRiseCompact {
     case Literal(d) => (true, dataSize(d), line(d.toString))
 
     case TypeAnnotation(e, _) => drawAST(e, wrapped)
-    case TypeAssertion(e, _) => drawAST(e, wrapped)
     case Opaque(e, _) => drawAST(e, wrapped)
 
     case p: Primitive => (true, 1, line(p.name))

--- a/src/main/scala/rise/core/showScala.scala
+++ b/src/main/scala/rise/core/showScala.scala
@@ -69,7 +69,6 @@ object showScala {
       case Identifier(name) => s"""Identifier("$name")(${`type`(e.t)})"""
       case p: Primitive => s"${p.name}.primitive"
       case TypeAnnotation(e, t) => s"TypeAnnotation(${expr(e)}, ${`type`(t)})"
-      case TypeAssertion(e, t) => s"TypeAssertion(${expr(e)}, ${`type`(t)})"
       case Opaque(e, t) => s"Opaque(${expr(e)}, ${`type`(t)})"
       case Literal(d) => s"Literal(${data(d)})"
       case App(f, a) => s"App(${expr(f)}, ${expr(a)})(${`type`(e.t)})"

--- a/src/main/scala/rise/core/showScala.scala
+++ b/src/main/scala/rise/core/showScala.scala
@@ -6,9 +6,9 @@ object showScala {
   private def kindIdent[K <: Kind](x: K#I): String = {
     x match {
       case n: NatIdentifier =>
-        s"""NatIdentifier("${n.name}", ${n.range}, ${n.isExplicit})"""
-      case DataTypeIdentifier(n, isE) =>
-        s"""DataTypeIdentifier("$n", $isE)"""
+        s"""NatIdentifier("${n.name}", ${n.range})"""
+      case DataTypeIdentifier(n) =>
+        s"""DataTypeIdentifier("$n")"""
       case _ => throw new Exception(s"missing rule for $x")
     }
   }
@@ -17,7 +17,7 @@ object showScala {
     import arithexpr.arithmetic._
     n match {
       case n: NatIdentifier =>
-        s"""NatIdentifier("${n.name}", ${n.range}, ${n.isExplicit})"""
+        s"""NatIdentifier("${n.name}", ${n.range})"""
       case n: NamedVar =>
         s"""NamedVar("${n.name}", ${n.range})"""
       case Prod(factors) => factors.map(nat).mkString("(", " * ", ")")
@@ -50,7 +50,7 @@ object showScala {
         s"FunType(${`type`(inT)}, ${`type`(outT)})"
       case DepFunType(x, t) =>
         s"DepFunType(${kindIdent(x)}, ${`type`(t)})"
-      case DataTypeIdentifier(n, isE) => s"""DataTypeIdentifier("$n", $isE)"""
+      case DataTypeIdentifier(n) => s"""DataTypeIdentifier("$n")"""
       case ArrayType(n, e) =>
         s"ArrayType(${nat(n)}, ${`type`(e)})"
       case PairType(p1, p2) =>

--- a/src/main/scala/rise/core/substitute.scala
+++ b/src/main/scala/rise/core/substitute.scala
@@ -57,7 +57,6 @@ object substitute {
     case DepApp(f, _) => FV(f)
     case Literal(_) => Set()
     case TypeAnnotation(e, _) => FV(e)
-    case TypeAssertion(e, _) => FV(e)
     case Opaque(e, _) => FV(e)
     case _: Primitive => Set()
   }

--- a/src/main/scala/rise/core/traverse.scala
+++ b/src/main/scala/rise/core/traverse.scala
@@ -179,9 +179,6 @@ object traverse {
       case TypeAnnotation(e, t) =>
         for { e1 <- expr(e); t1 <- `type`(t)}
           yield TypeAnnotation(e1, t1)
-      case TypeAssertion(e, t) =>
-        for { e1 <- expr(e); t1 <- `type`(t)}
-          yield TypeAssertion(e1, t1)
       case Opaque(e, t) =>
         for { e1 <- expr(e); t1 <- `type`(t)}
           yield Opaque(e1, t1)

--- a/src/main/scala/rise/core/types/AddressSpace.scala
+++ b/src/main/scala/rise/core/types/AddressSpace.scala
@@ -3,7 +3,9 @@ package rise.core.types
 // TODO: should not be in the core
 sealed trait AddressSpace
 
-final case class AddressSpaceIdentifier(name: String) extends AddressSpace with Kind.Identifier
+final case class AddressSpaceIdentifier(name: String) extends AddressSpace with Kind.Identifier {
+  override def toString : String = name
+}
 
 // scalastyle:off public.methods.have.type
 object AddressSpace {

--- a/src/main/scala/rise/core/types/AddressSpace.scala
+++ b/src/main/scala/rise/core/types/AddressSpace.scala
@@ -3,17 +3,7 @@ package rise.core.types
 // TODO: should not be in the core
 sealed trait AddressSpace
 
-final case class AddressSpaceIdentifier(
-    name: String,
-    override val isExplicit: Boolean = false
-) extends AddressSpace
-    with Kind.Identifier
-    with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: AddressSpaceIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: AddressSpaceIdentifier =
-    this.copy(isExplicit = false)
-}
+final case class AddressSpaceIdentifier(name: String) extends AddressSpace with Kind.Identifier
 
 // scalastyle:off public.methods.have.type
 object AddressSpace {

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -44,9 +44,7 @@ case class NatCollectionConstraint(a: NatCollection, b: NatCollection)
 }
 
 object Constraint {
-  def canBeSubstituted(preserve: Set[String], i: Kind.Identifier with Kind.Explicitness): Boolean =
-    !(preserve.contains(i.name) || i.isExplicit)
-  def canBeSubstituted(preserve: Set[String], i: TypeIdentifier): Boolean =
+  def canBeSubstituted(preserve: Set[String], i: Kind.Identifier): Boolean =
     !preserve.contains(i.name)
 
   def solve(cs: Seq[Constraint], preserve: Set[String], trace: Seq[Constraint])
@@ -117,7 +115,7 @@ object Constraint {
             ) =>
             explDep match {
               case ExplicitDependence.On =>
-                val n = NatIdentifier(freshName("n"), isExplicit = true)
+                val n = NatIdentifier(freshName("n"))
                 /** Note(federico):
                   * This step recurses in both functions and makes dependence between type
                   * variables and n explicit (by replacing type variables with NatToData/NatToNat).
@@ -131,16 +129,16 @@ object Constraint {
                   substitute.natInType(n, `for`= nb, tb), n, preserve)
                 nTaSub ++ nTbSub ++ decomposed(
                     Seq(
-                      NatConstraint(n, na.asImplicit),
-                      NatConstraint(n, nb.asImplicit),
+                      NatConstraint(n, na),
+                      NatConstraint(n, nb),
                       TypeConstraint(nTa, nTb)
                     ))
               case ExplicitDependence.Off =>
-                val n = NatIdentifier(freshName("n"), isExplicit = true)
+                val n = NatIdentifier(freshName("n"))
                 decomposed(
                   Seq(
-                    NatConstraint(n, na.asImplicit),
-                    NatConstraint(n, nb.asImplicit),
+                    NatConstraint(n, na),
+                    NatConstraint(n, nb),
                     TypeConstraint(ta, tb)
                   )
                 )
@@ -149,11 +147,11 @@ object Constraint {
             DepFunType(dta: DataTypeIdentifier, ta),
             DepFunType(dtb: DataTypeIdentifier, tb)
             ) =>
-            val dt = DataTypeIdentifier(freshName("t"), isExplicit = true)
+            val dt = DataTypeIdentifier(freshName("t"))
             decomposed(
               Seq(
-                TypeConstraint(dt, dta.asImplicit),
-                TypeConstraint(dt, dtb.asImplicit),
+                TypeConstraint(dt, dta),
+                TypeConstraint(dt, dtb),
                 TypeConstraint(ta, tb)
               )
             )
@@ -167,11 +165,11 @@ object Constraint {
             DepPairType(x1: NatIdentifier, t1),
             DepPairType(x2: NatIdentifier, t2)
             ) =>
-            val n = NatIdentifier(freshName("n"), isExplicit = true)
+            val n = NatIdentifier(freshName("n"))
 
             decomposed(Seq(
-              NatConstraint(n, x1.asImplicit),
-              NatConstraint(n, x2.asImplicit),
+              NatConstraint(n, x1),
+              NatConstraint(n, x2),
               TypeConstraint(t1, t2)
             ))
 
@@ -179,11 +177,11 @@ object Constraint {
             DepPairType(x1: NatCollectionIdentifier, t1),
             DepPairType(x2: NatCollectionIdentifier, t2)
             ) =>
-            val n = NatCollectionIdentifier(freshName("n"), isExplicit = true)
+            val n = NatCollectionIdentifier(freshName("n"))
 
             decomposed(Seq(
-              NatCollectionConstraint(n, x1.asImplicit),
-              NatCollectionConstraint(n, x2.asImplicit),
+              NatCollectionConstraint(n, x1),
+              NatCollectionConstraint(n, x2),
               TypeConstraint(t1, t2)
             ))
 
@@ -234,10 +232,10 @@ object Constraint {
           case (_, i: NatToDataIdentifier) => natToData.unifyIdent(i, a)
           case _ if a == b                 => Solution()
           case (NatToDataLambda(x1, dt1), NatToDataLambda(x2, dt2)) =>
-            val n = NatIdentifier(freshName("n"), isExplicit = true)
+            val n = NatIdentifier(freshName("n"))
             decomposed(Seq(
-              NatConstraint(n, x1.asImplicit),
-              NatConstraint(n, x2.asImplicit),
+              NatConstraint(n, x1),
+              NatConstraint(n, x2),
               TypeConstraint(dt1, dt2)
             ))
 
@@ -464,7 +462,7 @@ object Constraint {
           natToNat.unify(f1, f2, preserve) ++ unify(n1, n2, preserve)
         case _ => (f1, n1) match {
           case (f1: NatToNatIdentifier, n1: NatIdentifier) =>
-            val freshVar = NatIdentifier(freshName("n"), isExplicit = true)
+            val freshVar = NatIdentifier(freshName("n"))
             val lambda = NatToNatLambda(freshVar, substitute.natInNat(freshVar, n1, nat))
             Solution.subs(f1, lambda)
           case _ => ???
@@ -509,7 +507,7 @@ object Constraint {
       case NatToNatLambda(x1, body1) => f2 match {
         case id2: NatToNatIdentifier => Solution.subs(id2, f1)
         case NatToNatLambda(x2, body2) =>
-          val n = NatIdentifier(freshName("n"), isExplicit = true)
+          val n = NatIdentifier(freshName("n"))
           nat.unify(
             substitute.natInNat(n, `for` = x1, body1),
             substitute.natInNat(n, `for`=x2, body2),
@@ -554,7 +552,7 @@ object dependence {
         case ident: NatIdentifier
           if ident != depVar && Constraint.canBeSubstituted(preserve, ident) =>
           val sol = Solution.subs(ident, NatToNatApply(NatToNatIdentifier(freshName("nnf")), depVar))
-          accumulate(Seq(sol))(ident.asImplicit : Nat)
+          accumulate(Seq(sol))(ident: Nat)
         case n => super.nat(n)
       }
 

--- a/src/main/scala/rise/core/types/Kinds.scala
+++ b/src/main/scala/rise/core/types/Kinds.scala
@@ -9,11 +9,6 @@ object Kind {
   trait Identifier {
     def name: String
   }
-  trait Explicitness {
-    val isExplicit: Boolean
-    def asExplicit: Explicitness
-    def asImplicit: Explicitness
-  }
 }
 
 sealed trait TypeKind extends Kind {

--- a/src/main/scala/rise/core/types/Nat.scala
+++ b/src/main/scala/rise/core/types/Nat.scala
@@ -6,44 +6,24 @@ import rise.core.types
 class NatIdentifier(
     override val name: String,
     override val range: Range = RangeUnknown,
-    override val isExplicit: Boolean = false
 ) extends NamedVar(name, range)
-    with types.Kind.Identifier
-    with types.Kind.Explicitness {
-
-  override lazy val toString: String = if (isExplicit) name else "_" + name
+    with types.Kind.Identifier {
 
   override def copy(r: Range): NatIdentifier =
-    new NatIdentifier(name, r, isExplicit)
-
-  override def asExplicit: NatIdentifier = new NatIdentifier(name, range, true)
-
-  override def asImplicit: NatIdentifier = new NatIdentifier(name, range, false)
+    new NatIdentifier(name, r)
 
   override def visitAndRebuild(f: ArithExpr => ArithExpr): ArithExpr = {
-    f(new NatIdentifier(name, range.visitAndRebuild(f), isExplicit))
+    f(new NatIdentifier(name, range.visitAndRebuild(f)))
   }
 
   override def cloneSimplified(): NatIdentifier with SimplifiedExpr =
-    new NatIdentifier(name, range, isExplicit) with SimplifiedExpr
+    new NatIdentifier(name, range) with SimplifiedExpr
 }
 
 object NatIdentifier {
-  def apply(name: String, isExplicit: Boolean): NatIdentifier =
-    new NatIdentifier(name, isExplicit = isExplicit)
-
-  def apply(name: String): NatIdentifier = apply(name, isExplicit = false)
-
-  def apply(name: String, range: Range, isExplicit: Boolean): NatIdentifier =
-    new NatIdentifier(name, range, isExplicit = isExplicit)
-
-  def apply(name: String, range: Range): NatIdentifier =
-    apply(name, range, isExplicit = false)
-
-  def apply(nv: NamedVar, isExplicit: Boolean): NatIdentifier =
-    new NatIdentifier(nv.name, nv.range, isExplicit = isExplicit)
-
-  def apply(nv: NamedVar): NatIdentifier = apply(nv, isExplicit = false)
+  def apply(name: String): NatIdentifier = new NatIdentifier(name)
+  def apply(name: String, range: Range): NatIdentifier = new NatIdentifier(name, range)
+  def apply(nv: NamedVar): NatIdentifier = new NatIdentifier(nv.name, nv.range)
 }
 
 final class NatToNatApply(val f: NatToNat, val n: Nat)

--- a/src/main/scala/rise/core/types/NatCollection.scala
+++ b/src/main/scala/rise/core/types/NatCollection.scala
@@ -26,7 +26,9 @@ sealed abstract class NatCollection {
   def apply(idxs: Nat*): Nat = new NatCollectionIndexing(this, idxs)
 }
 
-final case class NatCollectionIdentifier(name: String) extends NatCollection with Kind.Identifier
+final case class NatCollectionIdentifier(name: String) extends NatCollection with Kind.Identifier {
+  override def toString : String = name
+}
 
 /**
   * Represents an n-dimensional array of natural number, which is indexable at the

--- a/src/main/scala/rise/core/types/NatCollection.scala
+++ b/src/main/scala/rise/core/types/NatCollection.scala
@@ -26,18 +26,7 @@ sealed abstract class NatCollection {
   def apply(idxs: Nat*): Nat = new NatCollectionIndexing(this, idxs)
 }
 
-final case class NatCollectionIdentifier(
-    name: String,
-   override val isExplicit: Boolean = false
- ) extends NatCollection
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatCollectionIdentifier =
-      this.copy(isExplicit = true)
-  override def asImplicit: NatCollectionIdentifier =
-    this.copy(isExplicit = false)
-}
+final case class NatCollectionIdentifier(name: String) extends NatCollection with Kind.Identifier
 
 /**
   * Represents an n-dimensional array of natural number, which is indexable at the

--- a/src/main/scala/rise/core/types/NatToData.scala
+++ b/src/main/scala/rise/core/types/NatToData.scala
@@ -11,7 +11,9 @@ sealed trait NatToData {
   def apply(n: Nat): DataType = NatToDataApply(this, n)
 }
 
-final case class NatToDataIdentifier(name: String) extends NatToData with Kind.Identifier
+final case class NatToDataIdentifier(name: String) extends NatToData with Kind.Identifier {
+  override def toString : String = name
+}
 
 case class NatToDataLambda private (x: NatIdentifier, body: DataType)
     extends NatToData {

--- a/src/main/scala/rise/core/types/NatToData.scala
+++ b/src/main/scala/rise/core/types/NatToData.scala
@@ -11,15 +11,7 @@ sealed trait NatToData {
   def apply(n: Nat): DataType = NatToDataApply(this, n)
 }
 
-final case class NatToDataIdentifier(name: String,
-                                     override val isExplicit: Boolean = false
-                                    ) extends NatToData
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatToDataIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: NatToDataIdentifier = this.copy(isExplicit = false)
-}
+final case class NatToDataIdentifier(name: String) extends NatToData with Kind.Identifier
 
 case class NatToDataLambda private (x: NatIdentifier, body: DataType)
     extends NatToData {

--- a/src/main/scala/rise/core/types/NatToNat.scala
+++ b/src/main/scala/rise/core/types/NatToNat.scala
@@ -6,15 +6,7 @@ sealed trait NatToNat {
   def apply(n: Nat): Nat = NatToNatApply(this, n)
 }
 
-final case class NatToNatIdentifier(name: String,
-                                    override val isExplicit: Boolean = false
-                                   ) extends NatToNat
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatToNatIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: NatToNatIdentifier = this.copy(isExplicit = false)
-}
+final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier
 
 final case class NatToNatLambda private (x: NatIdentifier, body: Nat)
     extends NatToNat {

--- a/src/main/scala/rise/core/types/NatToNat.scala
+++ b/src/main/scala/rise/core/types/NatToNat.scala
@@ -6,7 +6,9 @@ sealed trait NatToNat {
   def apply(n: Nat): Nat = NatToNatApply(this, n)
 }
 
-final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier
+final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier {
+  override def toString : String = name
+}
 
 final case class NatToNatLambda private (x: NatIdentifier, body: Nat)
     extends NatToNat {

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -91,7 +91,7 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToDataLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range, isExplicit = true)
+          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToDataLambda(xSub, apply(body).asInstanceOf[DataType])
@@ -104,7 +104,7 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToNatLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range, isExplicit = true)
+          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToNatLambda(xSub, apply(body))

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -24,10 +24,7 @@ final case class FunType[T <: Type, U <: Type](inT: T, outT: U)
   override def toString: String = s"($inT -> $outT)"
 }
 
-final case class DepFunType[K <: Kind: KindName, T <: Type](
-    x: K#I with Kind.Explicitness,
-    t: T
-) extends Type {
+final case class DepFunType[K <: Kind: KindName, T <: Type](x: K#I, t: T) extends Type {
   override def toString: String =
     s"(${x.name}: ${implicitly[KindName[K]].get} -> $t)"
 }
@@ -36,15 +33,7 @@ final case class DepFunType[K <: Kind: KindName, T <: Type](
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(name: String,
-                                    override val isExplicit: Boolean = false
-                                   ) extends DataType
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: DataTypeIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: DataTypeIdentifier = this.copy(isExplicit = false)
-}
+final case class DataTypeIdentifier(name: String) extends DataType with Kind.Identifier
 
 sealed trait ScalarType extends DataType
 
@@ -98,16 +87,7 @@ object MatrixLayout {
   object None extends MatrixLayout
 }
 
-final case class MatrixLayoutIdentifier(name: String,
-                                        override val isExplicit: Boolean = false
-                                       ) extends MatrixLayout
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: MatrixLayoutIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: MatrixLayoutIdentifier =
-    this.copy(isExplicit = false)
-}
+final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout with Kind.Identifier
 
 sealed trait FragmentKind
 
@@ -117,16 +97,7 @@ object FragmentKind {
   object Accumulator extends FragmentKind { override def toString = "Accumulator"}
 }
 
-final case class FragmentKindIdentifier(name: String,
-                                        override val isExplicit: Boolean = false
-                                       ) extends FragmentKind
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: FragmentKindIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: FragmentKindIdentifier =
-    this.copy(isExplicit = false)
-}
+final case class FragmentKindIdentifier(name: String) extends FragmentKind with Kind.Identifier
 
 object FragmentType {
   def apply(rows: Nat, columns:Nat, d3: Nat, dataType: DataType): FragmentType = {
@@ -153,10 +124,7 @@ final case class ManagedBufferType(dt: DataType) extends DataType {
 
 }
 
-final case class DepPairType[K <: Kind: KindName](
-                            x: K#I,
-                            t: DataType
-                           ) extends DataType {
+final case class DepPairType[K <: Kind: KindName](x: K#I, t: DataType) extends DataType {
   type Kind = K
 
   // Note(federico): for pattern-matching purposes, if we ever need to
@@ -192,7 +160,7 @@ final case class DepArrayType(size: Nat, fdt: NatToData) extends DataType {
 
 object DepArrayType {
   def apply(size: Nat, f: Nat => DataType): DepArrayType = {
-    val n = NatIdentifier(freshName("n"), RangeAdd(0, size, 1), isExplicit = true)
+    val n = NatIdentifier(freshName("n"), RangeAdd(0, size, 1))
     DepArrayType(size, NatToDataLambda(n, f(n)))
   }
 }

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -33,7 +33,9 @@ final case class DepFunType[K <: Kind: KindName, T <: Type](x: K#I, t: T) extend
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(name: String) extends DataType with Kind.Identifier
+final case class DataTypeIdentifier(name: String) extends DataType with Kind.Identifier {
+  override def toString : String = name
+}
 
 sealed trait ScalarType extends DataType
 
@@ -87,7 +89,9 @@ object MatrixLayout {
   object None extends MatrixLayout
 }
 
-final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout with Kind.Identifier
+final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout with Kind.Identifier {
+  override def toString : String = name
+}
 
 sealed trait FragmentKind
 
@@ -97,7 +101,9 @@ object FragmentKind {
   object Accumulator extends FragmentKind { override def toString = "Accumulator"}
 }
 
-final case class FragmentKindIdentifier(name: String) extends FragmentKind with Kind.Identifier
+final case class FragmentKindIdentifier(name: String) extends FragmentKind with Kind.Identifier {
+  override def toString : String = name
+}
 
 object FragmentType {
   def apply(rows: Nat, columns:Nat, d3: Nat, dataType: DataType): FragmentType = {

--- a/src/main/scala/rise/core/types/check.scala
+++ b/src/main/scala/rise/core/types/check.scala
@@ -81,8 +81,6 @@ object check {
       t1 match {
         case TypePlaceholder =>
           throw TypeException(s"TypePlaceholder found")
-        case i: Kind.Explicitness if !i.isExplicit =>
-          throw TypeException(s"Implicit type variable found")
         case _ => t1
       }
     }

--- a/src/main/scala/rise/core/types/check.scala
+++ b/src/main/scala/rise/core/types/check.scala
@@ -67,7 +67,6 @@ object check {
 
     // Annotations and assertions should be gone after type inference
     case TypeAnnotation(e, t) => e `:` t
-    case TypeAssertion(e, t) => e `:` t
     case Opaque(e, t) => e `:` t
 
     case p: Primitive =>

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -80,21 +80,21 @@ object uniqueNames {
         } yield Lambda(x2, b2)(t2)
 
         case d@DepLambda(x: NatIdentifier, b) =>
-          val x2 = NatIdentifier(s"n$nextNatN", x.range, x.isExplicit)
+          val x2 = NatIdentifier(s"n$nextNatN", x.range)
           for {
             b2 <- renameInExpr(b)(values, types + (x -> x2))
             t2 <- renameInTypes(d.t)(types + (x -> x2))
           } yield DepLambda[NatKind](x2, b2)(t2)
 
         case d@DepLambda(x: DataTypeIdentifier, b) =>
-          val x2 = DataTypeIdentifier(s"dt$nextDtN", x.isExplicit)
+          val x2 = DataTypeIdentifier(s"dt$nextDtN")
           for {
             b2 <- renameInExpr(b)(values, types + (x -> x2))
             t2 <- renameInTypes(d.t)(types)
           } yield DepLambda[DataKind](x2, b2)(t2)
 
         case d@DepLambda(x: AddressSpaceIdentifier, b) =>
-          val x2 = AddressSpaceIdentifier(s"a$nextAN", x.isExplicit)
+          val x2 = AddressSpaceIdentifier(s"a$nextAN")
           for {
             b2 <- renameInExpr(b)(values, types + (x -> x2))
             t2 <- renameInTypes(d.t)(types)
@@ -108,21 +108,19 @@ object uniqueNames {
           return_(types.getOrElse(i, i).asInstanceOf[T])
 
         case DepFunType(x: NatIdentifier, b) =>
-          val x2 = types.getOrElse(x,
-            NatIdentifier(s"n$nextNatN", x.range, x.isExplicit))
-            .asInstanceOf[NatIdentifier with Kind.Explicitness]
+          val x2 = types.getOrElse(x, NatIdentifier(s"n$nextNatN", x.range)).asInstanceOf[NatIdentifier]
           for { b2 <- renameInTypes(b)(types + (x -> x2)) }
             yield DepFunType[NatKind, Type](x2, b2).asInstanceOf[T]
 
         case DepFunType(x: DataTypeIdentifier, b) =>
           val x2 = types.getOrElse(x,
-            DataTypeIdentifier(s"dt$nextDtN", x.isExplicit)).asInstanceOf[DataTypeIdentifier]
+            DataTypeIdentifier(s"dt$nextDtN")).asInstanceOf[DataTypeIdentifier]
           for { b2 <- renameInTypes(b)(types + (x -> x2)) }
             yield DepFunType[DataKind, Type](x2, b2).asInstanceOf[T]
 
         case DepFunType(x: AddressSpaceIdentifier, b) =>
           val x2 = types.getOrElse(x,
-            AddressSpaceIdentifier(s"dt$nextAN", x.isExplicit)).asInstanceOf[AddressSpaceIdentifier]
+            AddressSpaceIdentifier(s"dt$nextAN")).asInstanceOf[AddressSpaceIdentifier]
           for { b2 <- renameInTypes(b)(types + (x -> x2)) }
             yield DepFunType[AddressSpaceKind, Type](x2, b2).asInstanceOf[T]
 

--- a/src/main/scala/rise/elevate/package.scala
+++ b/src/main/scala/rise/elevate/package.scala
@@ -3,8 +3,9 @@ package rise
 import _root_.rise.core._
 import _root_.rise.core.primitives._
 import _root_.rise.core.types.Type
+import _root_.rise.core.DSL.{TypeAnnotationHelper, infer}
 import rise.elevate.strategies.normalForm.DFNF
-import _root_.elevate.core.Strategy
+import _root_.elevate.core._
 import _root_.elevate.core.strategies.Traversable
 
 package object elevate {
@@ -14,6 +15,12 @@ package object elevate {
   object ::: {
     def unapply(e: Expr): Option[(Expr, Type)] = Some((e, e.t))
   }
+
+  def rewrite : Rise => Rise => Rise = lhs => rhs =>
+    infer(rhs :: lhs.t, infer.collectFreeEnv(lhs), infer.getFTVsRec(lhs).map(_.name))
+
+  def rewriteS : Strategy[Strategy[Rise]] =
+    f => Success(lhs => f(lhs).flatMapSuccess(rhs => Success(rewrite(lhs)(rhs))))
 
   object ReduceX {
     def unapply(e: Expr): Boolean = e match {

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -33,49 +33,49 @@ object lowering {
 
   def `map -> mapSeq`: Strategy[Rise] = mapSeq
   @rule def mapSeq: Strategy[Rise] = {
-    case m@map() => Success(p.mapSeq !: m.t)
+    case m@map() => Success(p.mapSeq !: m)
   }
 
   def `map -> mapPar`: Strategy[Rise] = mapPar
   @rule def mapPar: Strategy[Rise] = {
-    case m@map() => Success(omp.mapPar !: m.t)
+    case m@map() => Success(omp.mapPar !: m)
   }
 
   def `map -> mapStream`: Strategy[Rise] = mapStream
   @rule def mapStream: Strategy[Rise] = {
-    case m@map() => Success(p.mapStream !: m.t)
+    case m@map() => Success(p.mapStream !: m)
   }
 
   def `map -> iterateStream`: Strategy[Rise] = iterateStream
   @rule def iterateStream: Strategy[Rise] = {
-    case m@map() => Success(p.iterateStream !: m.t)
+    case m@map() => Success(p.iterateStream !: m)
   }
 
   def `map -> mapSeqUnroll`: Strategy[Rise] = mapSeqUnroll
   @rule def mapSeqUnroll: Strategy[Rise] = {
-    case m@map() => Success(p.mapSeqUnroll !: m.t)
+    case m@map() => Success(p.mapSeqUnroll !: m)
   }
 
   def `map -> mapGlobal`(dim: Int = 0): Strategy[Rise] = mapGlobal(dim)
   @rule def mapGlobal(dim: Int = 0): Strategy[Rise] = {
-    case m@map() => Success(rise.openCL.DSL.mapGlobal(dim) !: m.t)
+    case m@map() => Success(rise.openCL.DSL.mapGlobal(dim) !: m)
   }
 
   def `reduce -> reduceSeq`: Strategy[Rise] = reduceSeq
   @rule def reduceSeq: Strategy[Rise] = {
-    case e@reduce() => Success(p.reduceSeq !: e.t)
+    case e@reduce() => Success(p.reduceSeq !: e)
   }
 
   def `reduce -> reduceSeqUnroll`: Strategy[Rise] = reduceSeqUnroll
   @rule def reduceSeqUnroll: Strategy[Rise] = {
-    case e@reduce() => Success(p.reduceSeqUnroll !: e.t)
+    case e@reduce() => Success(p.reduceSeqUnroll !: e)
   }
 
   // Specialized Lowering
 
   @rule def mapSeqCompute()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
     case e@App(map(), f) if containsComputation()(ev)(f) && predicate.not(isMappingZip)(f) =>
-      Success(p.mapSeq(f) !: e.t)
+      Success(p.mapSeq(f) !: e)
   }
 
   @rule def isMappingZip: Strategy[Rise] = {
@@ -86,12 +86,12 @@ object lowering {
   // TODO: load identity instead, then change with other rules?
   @rule def circularBuffer(load: Expr): Strategy[Rise] = {
     case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
-      p.circularBuffer(sz)(sz)(eraseType(load)) !: e.t)
+      p.circularBuffer(sz)(sz)(eraseType(load)) !: e)
   }
 
   @rule def rotateValues(write: Expr): Strategy[Rise] = {
     case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
-      p.rotateValues(sz)(eraseType(write)) !: e.t)
+      p.rotateValues(sz)(eraseType(write)) !: e)
   }
 
   @rule def containsComputation()(implicit ev: Traversable[Rise]): Strategy[Rise] =
@@ -140,14 +140,14 @@ object lowering {
   // TODO: think about more complex cases
   @rule def mapSeqUnrollWrite: Strategy[Rise] = e => e.t match {
     case ArrayType(_, t) if typeHasTrivialCopy(t) =>
-      Success(app(p.mapSeqUnroll(fun(x => x)), preserveType(e)) !: e.t)
+      Success(app(p.mapSeqUnroll(fun(x => x)), preserveType(e)) !: e)
     case _ =>
       Failure(mapSeqUnrollWrite)
   }
 
   @rule def toMemAfterMapSeq: Strategy[Rise] = {
     case a@App(App(p.mapSeq(), _), _) =>
-      Success((preserveType(a) |> p.toMem) !: a.t)
+      Success((preserveType(a) |> p.toMem) !: a)
   }
 
   // Lowerings used in PLDI submission
@@ -213,7 +213,7 @@ object lowering {
 
     e match {
       case reduceResult@App(App(App(ReduceX(), _), _), _) =>
-        Success((preserveType(e) |> constructCopy(reduceResult.t) ) !: e.t)
+        Success((preserveType(e) |> constructCopy(reduceResult.t) ) !: e)
       case _ => Failure(copyAfterReduce)
     }
   }
@@ -228,7 +228,7 @@ object lowering {
 
     e match {
       case App(a@App(ReduceX(), _), init) =>
-        Success((preserveType(init) |> constructCopy(init.t) |> a) !: e.t)
+        Success((preserveType(init) |> constructCopy(init.t) |> a) !: e)
       case _ => Failure(copyAfterReduceInit)
     }
   }
@@ -243,20 +243,20 @@ object lowering {
 
     e match {
       case a@App(generate(), _) =>
-        Success((preserveType(a) |> constructCopy(a.t)) !: e.t)
+        Success((preserveType(a) |> constructCopy(a.t)) !: e)
       case _ => Failure(copyAfterGenerate)
     }
   }
 
   @rule def toMemAfterAsScalar: Strategy[Rise] = {
-    case a@App(asScalar(), _) => Success((preserveType(a) |> p.toMem) !: a.t)
+    case a@App(asScalar(), _) => Success((preserveType(a) |> p.toMem) !: a)
   }
 
   @rule def toMemAfter: Strategy[Rise] =
-    e => Success((preserveType(e) |> p.toMem) !: e.t)
+    e => Success((preserveType(e) |> p.toMem) !: e)
 
   @rule def toMemBefore: Strategy[Rise] = {
-    case a@App(f, e) => Success((p.toMem(e) |> preserveType(f)) !: a.t)
+    case a@App(f, e) => Success((p.toMem(e) |> preserveType(f)) !: a)
   }
 
   @strategy
@@ -301,11 +301,11 @@ object lowering {
 
   def parallel()(implicit ev: Traversable[Rise]): Strategy[Rise] = mapParCompute()
   @rule def mapParCompute()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case e@App(map(), f) if containsComputation()(ev)(f) => Success(omp.mapPar(f) !: e.t)
+    case e@App(map(), f) if containsComputation()(ev)(f) => Success(omp.mapPar(f) !: e)
   }
 
   @rule def unroll: Strategy[Rise] = {
-    case e@p.reduceSeq() => Success(p.reduceSeqUnroll !: e.t)
+    case e@p.reduceSeq() => Success(p.reduceSeqUnroll !: e)
   }
 
   object ocl {
@@ -314,15 +314,15 @@ object lowering {
 
     // TODO shall we allow lowering from an already lowered reduceSeq?
     @rule def reduceSeqUnroll(a: AddressSpace): Strategy[Rise] = {
-      case e@reduce() => Success(oclReduceSeqUnroll(a) !: e.t)
-      case e@p.reduceSeq() => Success(oclReduceSeqUnroll(a) !: e.t)
+      case e@reduce() => Success(oclReduceSeqUnroll(a) !: e)
+      case e@p.reduceSeq() => Success(oclReduceSeqUnroll(a) !: e)
     }
 
     @rule def circularBuffer(a: AddressSpace): Strategy[Rise] = {
       case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
         Success(
           oclCircularBuffer(a)(n)(n)(fun(x => x))
-            !: e.t)
+            !: e)
     }
 
     @rule def circularBufferLoadFusion: Strategy[Rise] = {
@@ -330,14 +330,14 @@ object lowering {
         cb @ DepApp(DepApp(DepApp(oclCircularBuffer(), _), _), _),
         load), App(App(map(), f), in)
       ) =>
-        Success(eraseType(cb)(preserveType(f) >> load, in) !: e.t)
+        Success(eraseType(cb)(preserveType(f) >> load, in) !: e)
     }
 
     @rule def rotateValues(a: AddressSpace, write: Expr): Strategy[Rise] = {
       case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
         Success(
           oclRotateValues(a)(n)(eraseType(write))
-            !: e.t)
+            !: e)
     }
   }
 }

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -35,7 +35,7 @@ object movement {
     case e@App(
       transpose(),
       App(App(map(), App(map(), f)), y)) =>
-        Success((preserveType(y) |> transpose |> map(map(f))) !: e.t)
+        Success((preserveType(y) |> transpose |> map(map(f))) !: e)
     // LCNF
     case e@App(transpose(),
     App(
@@ -44,13 +44,13 @@ object movement {
       arg)
     ) if etaReduction()(ev)(lamA) && etaReduction()(ev)(lamB) =>
       // Success((typed(arg) |> transpose |> map(map(f))) :: e.t)
-      Success((preserveType(arg) |> transpose |> map(fun(a => map(fun(b => preserveType(f)(b)))(a)))) !: e.t)
+      Success((preserveType(arg) |> transpose |> map(fun(a => map(fun(b => preserveType(f)(b)))(a)))) !: e)
   }
 
   def transposeBeforeMapMapF: Strategy[Rise] = `T >> **f -> **f >> T`
   @rule def `T >> **f -> **f >> T`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(transpose(), y)) =>
-      Success((preserveType(y) |> map(map(f)) |> transpose) !: e.t)
+      Success((preserveType(y) |> map(map(f)) |> transpose) !: e)
   }
 
 
@@ -65,19 +65,19 @@ object movement {
   def slideBeforeMapMapF: Strategy[Rise] = `S >> **f -> *f >> S`
   @rule def `S >> **f -> *f >> S`: Strategy[Rise] = {
     case e@App(App(map(), App(map(), f)), App(s, y)) if isSplitOrSlide(s) =>
-      Success((preserveType(y) |> map(f) |> eraseType(s)) !: e.t)
+      Success((preserveType(y) |> map(f) |> eraseType(s)) !: e)
   }
 
   def slideBeforeMap: Strategy[Rise] = `*f >> S -> S >> **f`
   @rule def `*f >> S -> S >> **f`: Strategy[Rise] = {
     case e@App(s @ DepApp(DepApp(slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
-      Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e)
   }
 
   // *f >> S -> S >> **f
   @rule def splitBeforeMap: Strategy[Rise] = {
     case e@App(s @ DepApp(split(), _: Nat), App(App(map(), f), y)) =>
-      Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e)
   }
 
   // join
@@ -85,13 +85,13 @@ object movement {
   def joinBeforeMapF: Strategy[Rise] = `J >> *f -> **f >> J`
   @rule def `J >> *f -> **f >> J`: Strategy[Rise] = {
     case e@App(App(map(), f),App(join(), y)) =>
-      Success((preserveType(y) |> map(map(f)) >> join) !: e.t)
+      Success((preserveType(y) |> map(map(f)) >> join) !: e)
   }
 
   def mapMapFBeforeJoin: Strategy[Rise] = `**f >> J -> J >> *f`
   @rule def `**f >> J -> J >> *f`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), App(map(), f)), y)) =>
-      Success((preserveType(y) |> join |> map(f)) !: e.t)
+      Success((preserveType(y) |> join |> map(f)) !: e)
   }
 
   // drop and take
@@ -99,25 +99,25 @@ object movement {
   def dropBeforeMap: Strategy[Rise] = `*f >> drop n -> drop n >> *f`
   @rule def `*f >> drop n -> drop n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(drop(n), preserveType(in))) !: expr.t)
+      Success(app(map(f), app(drop(n), preserveType(in))) !: expr)
   }
 
   def takeBeforeMap: Strategy[Rise] = `*f >> take n -> take n >> *f`
   @rule def `*f >> take n -> take n >> *f`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(App(map(), f), in)) =>
-      Success(app(map(f), app(take(n), preserveType(in))) !: expr.t)
+      Success(app(map(f), app(take(n), preserveType(in))) !: expr)
   }
 
   // take n >> *f -> *f >> take n
   @rule def takeAfterMap: Strategy[Rise] = {
     case e @ App(App(map(), f), App(DepApp(take(), n: Nat), in)) =>
-      Success(take(n)(map(f)(in)) !: e.t)
+      Success(take(n)(map(f)(in)) !: e)
   }
 
   def takeInZip: Strategy[Rise] = `take n (zip a b) -> zip (take n a) (take n b)`
   @rule def `take n (zip a b) -> zip (take n a) (take n b)`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n), App(App(zip(), a), b)) =>
-      Success(zip(depApp(take, n)(a))(depApp(take, n)(b)) !: expr.t)
+      Success(zip(depApp(take, n)(a))(depApp(take, n)(b)) !: expr)
   }
 
   // zip (take n a) (take n b) -> take n (zip a b)
@@ -125,7 +125,7 @@ object movement {
     case e @ App(App(zip(),
       App(DepApp(take(), n1: Nat), a)), App(DepApp(take(), n2: Nat), b)
     ) if n1 == n2 =>
-      Success(take(n1)(zip(a)(b)) !: e.t)
+      Success(take(n1)(zip(a)(b)) !: e)
   }
 
   // pair (take n a) (take m b) -> pair a b >> mapFst take n >> mapSnd take m
@@ -134,49 +134,49 @@ object movement {
     case e @ App(App(makePair(),
       App(DepApp(take(), n: Nat), a)), App(DepApp(take(), m: Nat), b)
     ) =>
-      Success((makePair(a)(b) |> mapFst(take(n)) |> mapSnd(take(m))) !: e.t)
+      Success((makePair(a)(b) |> mapFst(take(n)) |> mapSnd(take(m))) !: e)
   }
 
   def dropInZip: Strategy[Rise] = `drop n (zip a b) -> zip (drop n a) (drop n b)`
   @rule def `drop n (zip a b) -> zip (drop n a) (drop n b)`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), n), App(App(zip(), a), b)) =>
-      Success(zip(depApp(drop, n)(a))(depApp(drop, n)(b)) !: expr.t)
+      Success(zip(depApp(drop, n)(a))(depApp(drop, n)(b)) !: expr)
   }
 
   def takeInSelect: Strategy[Rise] = `take n (select t a b) -> select t (take n a) (take n b)`
   @rule def `take n (select t a b) -> select t (take n a) (take n b)`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n), App(App(App(select(), t), a), b)) =>
-      Success(select(t)(depApp(take, n)(a), depApp(take, n)(b)) !: expr.t)
+      Success(select(t)(depApp(take, n)(a), depApp(take, n)(b)) !: expr)
   }
 
   def dropInSelect: Strategy[Rise] = `drop n (select t a b) -> select t (drop n a) (drop n b)`
   @rule def `drop n (select t a b) -> select t (drop n a) (drop n b)`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), n), App(App(App(select(), t), a), b)) =>
-      Success(select(t)(depApp(drop, n)(a), depApp(drop, n)(b)) !: expr.t)
+      Success(select(t)(depApp(drop, n)(a), depApp(drop, n)(b)) !: expr)
   }
 
   def dropBeforeTake: Strategy[Rise] = `take (n+m) >> drop m -> drop m >> take n`
   @rule def `take (n+m) >> drop m -> drop m >> take n`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), m: Nat), App(DepApp(take(), nm: Nat), in)) =>
-      Success(app(take(nm - m), app(drop(m), preserveType(in))) !: expr.t)
+      Success(app(take(nm - m), app(drop(m), preserveType(in))) !: expr)
   }
 
   def takeBeforeDrop: Strategy[Rise] = `drop m >> take n -> take (n+m) >> drop m`
   @rule def `drop m >> take n -> take (n+m) >> drop m`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), n: Nat), App(DepApp(drop(), m: Nat), in)) =>
-      Success(app(drop(m), app(take(n+m), preserveType(in))) !: expr.t)
+      Success(app(drop(m), app(take(n+m), preserveType(in))) !: expr)
   }
 
   def takeBeforeSlide: Strategy[Rise] = `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`
   @rule def `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`: Strategy[Rise] = {
     case expr @ App(DepApp(take(), t: Nat), App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)) =>
-      Success(app(slide(n)(m), take(m * (t - 1) + n)(in)) !: expr.t)
+      Success(app(slide(n)(m), take(m * (t - 1) + n)(in)) !: expr)
   }
 
   def dropBeforeSlide: Strategy[Rise] = `slide n m >> drop d -> drop (d * m) >> slide n m`
   @rule def `slide n m >> drop d -> drop (d * m) >> slide n m`: Strategy[Rise] = {
     case expr @ App(DepApp(drop(), d: Nat), App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)) =>
-      Success(app(slide(n)(m), drop(d * m)(in)) !: expr.t)
+      Success(app(slide(n)(m), drop(d * m)(in)) !: expr)
   }
 
   // slide n m >> padEmpty p -> padEmpty (p * m) >> slide n m
@@ -184,25 +184,25 @@ object movement {
     case e @ App(DepApp(padEmpty(), p: Nat),
       App(DepApp(DepApp(slide(), n: Nat), m: Nat), in)
     ) =>
-      Success(slide(n)(m)(padEmpty(p * m)(in)) !: e.t)
+      Success(slide(n)(m)(padEmpty(p * m)(in)) !: e)
   }
 
   // map f >> padEmpty n -> padEmpty n >> map f
   @rule def padEmptyBeforeMap: Strategy[Rise] = {
     case e @ App(DepApp(padEmpty(), n: Nat), App(App(map(), f), in)) =>
-      Success(map(f)(padEmpty(n)(in)) !: e.t)
+      Success(map(f)(padEmpty(n)(in)) !: e)
   }
 
   // transpose >> padEmpty n -> map (padEmpty n) >> transpose
   @rule def padEmptyBeforeTranspose: Strategy[Rise] = {
     case e @ App(DepApp(padEmpty(), n: Nat), App(transpose(), in)) =>
-      Success(transpose(map(padEmpty(n))(in)) !: e.t)
+      Success(transpose(map(padEmpty(n))(in)) !: e)
   }
 
   // padEmpty n (zip a b) -> zip (padEmpty n a) (padEmpty n b)
   @rule def padEmptyInsideZip: Strategy[Rise] = {
     case e @ App(DepApp(padEmpty(), n: Nat), App(App(zip(), a), b)) =>
-      Success(zip(padEmpty(n)(a))(padEmpty(n)(b)) !: e.t)
+      Success(zip(padEmpty(n)(a))(padEmpty(n)(b)) !: e)
   }
 
   // FIXME: this is very specific
@@ -214,7 +214,7 @@ object movement {
     if e1 =~= e2 =>
       Success((preserveType(e1) |>
         mapFst(padEmpty(n)) |> mapSnd(padEmpty(n)) |>
-        fun(p => zip(fst(p))(snd(p)))) !: e.t)
+        fun(p => zip(fst(p))(snd(p)))) !: e)
   }
 
   // special-cases
@@ -223,19 +223,19 @@ object movement {
   def transposeBeforeSlide: Strategy[Rise] = `T >> S -> *S >> T >> *T`
   @rule def `T >> S -> *S >> T >> *T`: Strategy[Rise] = {
     case e@App(s, App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((preserveType(y) |> map(eraseType(s)) |> transpose.apply |> map(transpose)) !: e.t)
+      Success((preserveType(y) |> map(eraseType(s)) |> transpose.apply |> map(transpose)) !: e)
   }
 
   def transposeBeforeMapSlide: Strategy[Rise] = `T >> *S -> S >> *T >> T`
   @rule def `T >> *S -> S >> *T >> T`: Strategy[Rise] = {
     case e@App(App(map(), s), App(transpose(), y)) if isSplitOrSlide(s) =>
-      Success((preserveType(y) |> eraseType(s) |> map(transpose) |> transpose) !: e.t)
+      Success((preserveType(y) |> eraseType(s) |> map(transpose) |> transpose) !: e)
   }
 
   def mapSlideBeforeTranspose: Strategy[Rise] = `*S >> T -> T >> S >> *T`
   @rule def `*S >> T -> T >> S >> *T`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), s), y)) if isSplitOrSlide(s) =>
-      Success((preserveType(y) |> transpose.apply |> eraseType(s) |> map(transpose)) !: e.t)
+      Success((preserveType(y) |> transpose.apply |> eraseType(s) |> map(transpose)) !: e)
   }
 
   // transpose + join
@@ -243,25 +243,25 @@ object movement {
   def joinBeforeTranspose: Strategy[Rise] = `J >> T -> *T >> T >> *J`
   @rule def `J >> T -> *T >> T >> *J`: Strategy[Rise] = {
     case e@App(transpose(), App(join(), y)) =>
-      Success((preserveType(y) |> map(transpose) |> transpose |> map(join)) !: e.t)
+      Success((preserveType(y) |> map(transpose) |> transpose |> map(join)) !: e)
   }
 
   def transposeBeforeMapJoin: Strategy[Rise] = `T >> *J -> *T >> J >> T`
   @rule def `T >> *J -> *T >> J >> T`: Strategy[Rise] = {
     case e@App(App(map(), join()), App(transpose(), y)) =>
-      Success((preserveType(y) |> map(transpose) |> join |> transpose) !: e.t)
+      Success((preserveType(y) |> map(transpose) |> join |> transpose) !: e)
   }
 
   def mapTransposeBeforeJoin: Strategy[Rise] = `*T >> J -> T >> *J >> T`
   @rule def `*T >> J -> T >> *J >> T`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), transpose()), y)) =>
-      Success((preserveType(y) |> transpose |> map(join) |> transpose) !: e.t)
+      Success((preserveType(y) |> transpose |> map(join) |> transpose) !: e)
   }
 
   def mapJoinBeforeTranspose: Strategy[Rise] = `*J >> T -> T >> *T >> J`
   @rule def `*J >> T -> T >> *T >> J`: Strategy[Rise] = {
     case e@App(transpose(), App(App(map(), join()), y)) =>
-      Success((preserveType(y) |> transpose |> map(transpose) |> join) !: e.t)
+      Success((preserveType(y) |> transpose |> map(transpose) |> join) !: e)
   }
 
   // join + join
@@ -269,13 +269,13 @@ object movement {
   def joinBeforeJoin: Strategy[Rise] = `J >> J -> *J >> J`
   @rule def `J >> J -> *J >> J`: Strategy[Rise] = {
     case e@App(join(), App(join(), y)) =>
-      Success((preserveType(y) |> map(join) >> join) !: e.t)
+      Success((preserveType(y) |> map(join) >> join) !: e)
   }
 
   def mapJoinBeforeJoin: Strategy[Rise] = `*J >> J -> J >> J`
   @rule def `*J >> J -> J >> J`: Strategy[Rise] = {
     case e@App(join(), App(App(map(), join()), y)) =>
-      Success((preserveType(y) |> join |> join) !: e.t)
+      Success((preserveType(y) |> join |> join) !: e)
   }
 
   // split + slide
@@ -283,7 +283,7 @@ object movement {
   def slideBeforeSplit: Strategy[Rise] = `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`
   @rule def `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`: Strategy[Rise] = {
     case e@App(DepApp(split(), k: Nat), App(DepApp(DepApp(slide(), n: Nat), s: Nat), y)) =>
-      Success((preserveType(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) !: e.t)
+      Success((preserveType(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) !: e)
   }
 
   // TODO: what if s != 1?
@@ -292,7 +292,7 @@ object movement {
     case e@App(DepApp(DepApp(slide(), m: Nat), k: Nat),
             App(DepApp(DepApp(slide(), n: Nat), s: Nat), in)
          ) if s == (1: Nat) =>
-      Success((preserveType(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) !: e.t)
+      Success((preserveType(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) !: e)
   }
 
   // nested map + reduce
@@ -311,11 +311,11 @@ object movement {
       val result: ToBeTyped[Rise] = (fun(x =>
         (reduceSeq(fun((acc, y) =>
           map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
-        ))(x._1 !: resultT) o // x._1 :: 2D array
+        ))(x._1 :: resultT) o // x._1 :: 2D array
           // transpose2D
           transpose o map(transpose) $ x._2)) o
         // unzip2D
-        unzip o map(unzip)) !: e.t
+        unzip o map(unzip)) !: e
 
       Success(result)
 
@@ -342,8 +342,8 @@ object movement {
             fun((acc, y) => // acc::32.float, y::32.(float,float)
               map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
             )
-          )(x._1 !: resultT) o
-            transpose $ x._2) o unzip) !: e.t
+          )(x._1 :: resultT) o
+            transpose $ x._2) o unzip) !: e
 
       Success(result)
 
@@ -360,7 +360,7 @@ object movement {
           eraseType(rx)(fun((acc, y) =>
             map(fun(x => app(app(op, fst(x)), snd(x)))) $ zippedMapArg(acc, y)
           ))(generate(fun(IndexType(size) ->: dt)(_ => init))) o reduceArgFun
-        ) !: e.t)
+        ) !: e)
       }
 
       reduceArg match {
@@ -404,6 +404,6 @@ object movement {
   // mapSnd f >> mapFst g -> mapFst g >> mapSnd f
   @rule def mapFstBeforeMapSnd: Strategy[Rise] = {
     case e @ App(App(mapFst(), g), App(App(mapSnd(), f), in)) =>
-      Success(mapSnd(f)(mapFst(g)(in)) !: e.t)
+      Success(mapSnd(f)(mapFst(g)(in)) !: e)
   }
 }

--- a/src/main/scala/rise/elevate/rules/package.scala
+++ b/src/main/scala/rise/elevate/rules/package.scala
@@ -40,14 +40,14 @@ package object rules {
 
   //TODO @rule
   def etaReduction()(implicit ev: Traversable[Rise]): Strategy[Rise] = {
-    case e@Lambda(x1, App(f, x2)) if x1 == x2 && !contains[Rise](x1).apply(f) => Success(f !: e.t)
+    case e@Lambda(x1, App(f, x2)) if x1 == x2 && !contains[Rise](x1).apply(f) => Success(f !: e)
     case _ => Failure(etaReduction())
   }
 
   @rule def etaAbstraction: Strategy[Rise] = f => f.t match {
     case FunType(_, _) =>
       val x = identifier(freshName("η"))
-      Success(lambda(x, app(f, x)) !: f.t)
+      Success(lambda(x, app(f, x)) !: f)
     case _ => Failure(etaAbstraction)
   }
 

--- a/src/main/scala/rise/elevate/rules/traversal.scala
+++ b/src/main/scala/rise/elevate/rules/traversal.scala
@@ -190,7 +190,6 @@ object traversal {
           }
           case Literal(_) => None
           case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
-          case _: TypeAssertion => throw new Exception("Type assertions should be gone.")
           case _: Opaque => throw new Exception("Opaque expressions should be gone.")
           case _: ForeignFunction => None
           case _: Primitive => None

--- a/src/main/scala/rise/elevate/rules/vectorize.scala
+++ b/src/main/scala/rise/elevate/rules/vectorize.scala
@@ -16,14 +16,14 @@ object vectorize {
   @rule def after(n: Nat): Strategy[Rise] = e => e.t match {
     // FIXME: m + n hack
     case ArrayType(m, _: ScalarType) if (m + n) % n == (0: Nat) =>
-      Success(asScalar(asVector(n)(e)) !: e.t)
+      Success(asScalar(asVector(n)(e)) !: e)
   }
 
   // _ -> padEmpty >> asVector >> asScalar >> take
   @rule def roundUpAfter(n: Nat): Strategy[Rise] = e => e.t match {
     case ArrayType(m, _: ScalarType) =>
       val roundUp = padEmpty(n - ((m + n) % n)) // FIXME: m + n hack
-      Success(take(m)(asScalar(asVector(n)(roundUp(e)))) !: e.t)
+      Success(take(m)(asScalar(asVector(n)(roundUp(e)))) !: e)
     case _ => Failure(after(n))
   }
 
@@ -31,7 +31,7 @@ object vectorize {
   @rule def alignedAfter(n: Nat): Strategy[Rise] = e => e.t match {
     // FIXME: m + n hack
     case ArrayType(m, _: ScalarType) if (m + n) % n == (0: Nat) =>
-      Success(asScalar(asVectorAligned(n)(e)) !: e.t)
+      Success(asScalar(asVectorAligned(n)(e)) !: e)
     case _ => Failure(alignedAfter(n))
   }
 
@@ -48,7 +48,7 @@ object vectorize {
       // TODO: generalize?
       val inV = preserveType(in) |> transpose |> map(eraseType(v)) |> transpose
       val fV = vectorizeScalarFun(f, Set())
-      Success(map(reduce(fV)(vectorFromScalar(init)))(inV) !: e.t)
+      Success(map(reduce(fV)(vectorFromScalar(init)))(inV) !: e)
   }
 
   // TODO: express as a combination of beforeMapReduce, beforeMap, and others.
@@ -61,7 +61,7 @@ object vectorize {
       val aV = preserveType(a) |> transpose |> map(eraseType(v)) |> transpose
       val bV = map(vectorFromScalar)(b)
       val rV = vectorizeScalarFun(r, Set())
-      Success(map(zip(bV) >> rV(vectorFromScalar(init)))(aV) !: e.t)
+      Success(map(zip(bV) >> rV(vectorFromScalar(init)))(aV) !: e)
   }
 
   // map f >> asVector -> asVector >> map f
@@ -70,7 +70,7 @@ object vectorize {
     if isAsVector(v) && isScalarFun(f.t) =>
       val inV = makeAsVector(v)(in.t)(in)
       val fV = vectorizeScalarFun(f, Set())
-      Success(map(fV)(inV) !: e.t)
+      Success(map(fV)(inV) !: e)
   }
 
   // pair (asScalar a) (asScalar b)
@@ -78,14 +78,14 @@ object vectorize {
   // TODO: can get any function out, see takeOutsidePair
   @rule def asScalarOutsidePair: Strategy[Rise] = {
     case e @ App(App(makePair(), App(asScalar(), a)), App(asScalar(), b)) =>
-      Success((makePair(a)(b) |> mapFst(asScalar) |> mapSnd(asScalar)) !: e.t)
+      Success((makePair(a)(b) |> mapFst(asScalar) |> mapSnd(asScalar)) !: e)
   }
 
   // zip (asScalar a) (asScalar b)
   // -> pair a b >> mapFst asScalar >> mapSnd asScalar
   @rule def asScalarOutsideZip: Strategy[Rise] = {
     case e @ App(App(makePair(), App(asScalar(), a)), App(asScalar(), b)) =>
-      Success((makePair(a)(b) |> mapFst(asScalar) |> mapSnd(asScalar)) !: e.t)
+      Success((makePair(a)(b) |> mapFst(asScalar) |> mapSnd(asScalar)) !: e)
   }
 
   // padEmpty (p*v) (asScalar in) -> asScalar (padEmpty p in)
@@ -102,7 +102,7 @@ object vectorize {
   @rule def padEmptyBeforeAsVector: Strategy[Rise] = {
     case e @ App(DepApp(padEmpty(), p: Nat), App(asV @ DepApp(_, v: Nat), in))
     if isAsVector(asV) =>
-      Success(eraseType(asV)(padEmpty(p*v)(in)) !: e.t)
+      Success(eraseType(asV)(padEmpty(p*v)(in)) !: e)
   }
 
   // TODO: express as a combination of smaller rules
@@ -132,7 +132,7 @@ object vectorize {
           map(asScalar >> take(v+2) >> slide(v)(1) >> join >> asVector(v)) >>
           join
         )
-      Success(r !: e.t)
+      Success(r !: e)
 
     case e @ App(transpose(),
       App(App(map(), DepApp(asVector(), Cst(v))),
@@ -150,7 +150,7 @@ object vectorize {
       val r = preserveType(in) |>
         padEmpty(pV) >> asVectorAligned(v) >> slide(2)(1) >>
         map(asScalar >> take(v+2) >> slide(v)(1) >> join >> asVector(v))
-      Success(r !: e.t)
+      Success(r !: e)
   }
 
   // TODO: express as a combination of smaller rules
@@ -167,7 +167,7 @@ object vectorize {
         asScalar >> take(t) >>
         slide(v)(1) >> join >> asVector(v)
       )(in.t)
-      Success((preserveType(in) |> shuffle |> map(f)) !: e.t)
+      Success((preserveType(in) |> shuffle |> map(f)) !: e)
   }
 
   // FIXME: this is very specific
@@ -182,7 +182,7 @@ object vectorize {
         preserveType(in) |> mapFst(padEmpty(p*v)) |> mapSnd(padEmpty(p*v)) |>
         // FIXME: aligning although we have no alignment information
         fun(p => zip(asVectorAligned(v)(fst(p)))(asVectorAligned(v)(snd(p))))
-      ) !: e.t)
+      ) !: e)
   }
 
   def isAsVector: Rise => Boolean = {

--- a/src/main/scala/rise/elevate/strategies/algorithmic.scala
+++ b/src/main/scala/rise/elevate/strategies/algorithmic.scala
@@ -31,7 +31,7 @@ object algorithmic {
       gx match {
         case App(f2, gx2) =>
           if (gx2 =~= x) {
-            Success(map(f2) >> map(f) !: e.t)
+            Success(map(f2) >> map(f) !: e)
           } else {
             mapFirstFissionRec(x, fun(e => f(preserveType(f2)(e))), gx2)
           }
@@ -63,7 +63,7 @@ object algorithmic {
 
     e match {
       case App(primitives.map(), Lambda(x, gx)) => mapFullFissionRec(x, gx) match {
-        case Some(p) => Success(p !: e.t)
+        case Some(p) => Success(p !: e)
         case None => Failure(mapFullFission)
       }
       case _ => Failure(mapFullFission)

--- a/src/main/scala/rise/elevate/strategies/lowering.scala
+++ b/src/main/scala/rise/elevate/strategies/lowering.scala
@@ -41,7 +41,6 @@ object lowering {
       case _: Literal         => Failure(extract(what))
       case _: ForeignFunction => Failure(extract(what))
       case _: TypeAnnotation  => throw new Exception("Type annotations should be gone.")
-      case _: TypeAssertion   => throw new Exception("Type assertions should be gone.")
       case _: Opaque          => throw new Exception("Opaque expressions should be gone.")
       case _: Primitive       => Failure(extract(what))
     })

--- a/src/main/scala/rise/elevate/strategies/lowering.scala
+++ b/src/main/scala/rise/elevate/strategies/lowering.scala
@@ -18,7 +18,7 @@ object lowering {
 
         replaceAll(what, idx)(ev)(p) match {
           case Success(replaced) =>
-            Success(let(toMem(storedSubExpr))(lambda(ToBeTyped(idx), replaced)) !: p.t)
+            Success(let(toMem(storedSubExpr))(lambda(ToBeTyped(idx), replaced)) !: p)
           case Failure(_) => Failure(storeInMemory(what, how))
         }
       })

--- a/src/main/scala/rise/eqsat/Expr.scala
+++ b/src/main/scala/rise/eqsat/Expr.scala
@@ -156,12 +156,12 @@ object Expr {
       case NatApp(f, x) =>
         core.DepApp[rct.NatKind](toNamed(f, bound), Nat.toNamed(x, bound)) _
       case NatLambda(e) =>
-        val i = rct.NatIdentifier(s"n${bound.nat.size}", isExplicit = true)
+        val i = rct.NatIdentifier(s"n${bound.nat.size}")
         core.DepLambda[rct.NatKind](i, toNamed(e, bound + i)) _
       case DataApp(f, x) =>
         core.DepApp[rct.DataKind](toNamed(f, bound), DataType.toNamed(x, bound)) _
       case DataLambda(e) =>
-        val i = rct.DataTypeIdentifier(s"dt${bound.data.size}", isExplicit = true)
+        val i = rct.DataTypeIdentifier(s"dt${bound.data.size}")
         core.DepLambda[rct.DataKind](i, toNamed(e, bound + i)) _
       case Literal(d) => core.Literal(d).setType _
       case Primitive(p) => p.setType _

--- a/src/main/scala/rise/eqsat/Expr.scala
+++ b/src/main/scala/rise/eqsat/Expr.scala
@@ -141,8 +141,7 @@ object Expr {
       // note: we set the primitive type to a place holder here,
       // because we do not want type information at the node level
       case p: core.Primitive => Primitive(p.setType(core.types.TypePlaceholder))
-      case _: core.Opaque | _: core.TypeAnnotation | _: core.TypeAssertion =>
-        throw new Exception("this should not happen")
+      case _: core.Opaque | _: core.TypeAnnotation => throw new Exception("this should not happen")
     }, Type.fromNamed(expr.t, bound))
   }
 

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -9,7 +9,7 @@ object NamedRewrite {
   def init(name: String,
            rule: (NamedRewriteDSL.Pattern, NamedRewriteDSL.Pattern)
           ): Rewrite[DefaultAnalysisData] = {
-    import rise.core.DSL.infer.{preservingWithEnv, collectFreeEnv}
+    import rise.core.DSL.infer.{preserving, collectFreeEnv}
     import arithexpr.{arithmetic => ae}
 
     val (lhs, rhs) = rule
@@ -17,10 +17,10 @@ object NamedRewrite {
       assert(t == rct.TypePlaceholder)
       name -> rct.TypeIdentifier("t" + name)
     }
-    val typedLhs = preservingWithEnv(lhs, untypedFreeV, Set())
+    val typedLhs = preserving(lhs, untypedFreeV, Set())
     val freeV = collectFreeEnv(typedLhs)
     val (_, freeT) = rise.core.IsClosedForm.freeVars(typedLhs)
-    val typedRhs = preservingWithEnv(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
+    val typedRhs = preserving(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
 
     trait PatVarStatus
     case object Unknown extends PatVarStatus

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -20,7 +20,7 @@ object NamedRewrite {
     val typedLhs = preserving(lhs, untypedFreeV, Set())
     val freeV = collectFreeEnv(typedLhs)
     val (_, freeT) = rise.core.IsClosedForm.freeVars(typedLhs)
-    val typedRhs = preserving(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
+    val typedRhs = preserving(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT.map(_.name))
 
     trait PatVarStatus
     case object Unknown extends PatVarStatus

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -427,7 +427,7 @@ object NamedRewriteDSL {
   def nApp(f: Pattern, x: NatPattern): Pattern =
     rc.DepApp[rct.NatKind](f, x)(TypePlaceholder)
   def nLam(name: String, e: Pattern): Pattern = {
-    val n = rct.NatIdentifier(name, isExplicit = true)
+    val n = rct.NatIdentifier(name)
     rc.DepLambda[rct.NatKind](n, e)(TypePlaceholder)
   }
   def l(d: rc.semantics.Data): Pattern = rc.Literal(d)
@@ -447,14 +447,14 @@ object NamedRewriteDSL {
   def take: Pattern = rcp.take.primitive
 
   implicit def placeholderAsNatPattern(p: `_`.type): NatPattern =
-    rct.NatIdentifier(rc.freshName("n"), isExplicit = false)
+    rct.NatIdentifier(rc.freshName("n"))
   implicit def stringAsNatPattern(name: String): NatPattern =
-    rct.NatIdentifier(name, isExplicit = false)
+    rct.NatIdentifier(name)
 
   implicit def placeholderAsDataTypePattern(p: `_`.type): DataTypePattern =
-    rct.DataTypeIdentifier(rc.freshName("dt"), isExplicit = false)
+    rct.DataTypeIdentifier(rc.freshName("dt"))
   implicit def stringAsDataTypePattern(name: String): DataTypePattern =
-    rct.DataTypeIdentifier(name, isExplicit = false)
+    rct.DataTypeIdentifier(name)
 
   val int: DataTypePattern = rct.int
   val f32: DataTypePattern = rct.f32

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -9,18 +9,18 @@ object NamedRewrite {
   def init(name: String,
            rule: (NamedRewriteDSL.Pattern, NamedRewriteDSL.Pattern)
           ): Rewrite[DefaultAnalysisData] = {
-    import rise.core.DSL.infer.{preserving, collectFreeEnv}
+    import rise.core.DSL.infer
     import arithexpr.{arithmetic => ae}
 
     val (lhs, rhs) = rule
-    val untypedFreeV = collectFreeEnv(lhs).map { case (name, t) =>
+    val untypedFreeV = infer.collectFreeEnv(lhs).map { case (name, t) =>
       assert(t == rct.TypePlaceholder)
       name -> rct.TypeIdentifier("t" + name)
     }
-    val typedLhs = preserving(lhs, untypedFreeV, Set())
-    val freeV = collectFreeEnv(typedLhs)
+    val typedLhs = infer(lhs, untypedFreeV, Set())
+    val freeV = infer.collectFreeEnv(typedLhs)
     val (_, freeT) = rise.core.IsClosedForm.freeVars(typedLhs)
-    val typedRhs = preserving(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT.map(_.name))
+    val typedRhs = infer(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT.map(_.name))
 
     trait PatVarStatus
     case object Unknown extends PatVarStatus

--- a/src/main/scala/rise/eqsat/TypeNode.scala
+++ b/src/main/scala/rise/eqsat/TypeNode.scala
@@ -128,10 +128,10 @@ object Type {
       case dt: DataTypeNode[Nat, DataType] => DataType.toNamed(DataType(dt), bound)
       case FunType(a, b) => rct.FunType(toNamed(a, bound), toNamed(b, bound))
       case NatFunType(t) =>
-        val i = rct.NatIdentifier(s"n${bound.nat.size}", isExplicit = true)
+        val i = rct.NatIdentifier(s"n${bound.nat.size}")
         rct.DepFunType[rct.NatKind, rct.Type](i, toNamed(t, bound + i))
       case DataFunType(t) =>
-        val i = rct.DataTypeIdentifier(s"n${bound.data.size}", isExplicit = true)
+        val i = rct.DataTypeIdentifier(s"n${bound.data.size}")
         rct.DepFunType[rct.DataKind, rct.Type](i, toNamed(t, bound + i))
     }
   }

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -1,7 +1,7 @@
 package shine.DPIA
 
 import rise.{core => r}
-import rise.core.{Opaque, TypeAnnotation, TypeAssertion, primitives => rp, types => rt}
+import rise.core.{Opaque, TypeAnnotation, primitives => rp, types => rt}
 import rise.core.DSL.Type.{->:, ArrayTypeConstructors, TupleTypeConstructors, `(Addr)->:`, `(Nat)->:`, `(NatToNat)->:`, `.`, x}
 import rise.openMP.{primitives => rompp}
 import rise.openCL.{primitives => roclp}
@@ -133,7 +133,6 @@ private class InferAccessAnnotation {
       case depA: r.DepApp[_] =>
         inferDepApp(depA, ctx, addsKernelParam(e, isKernelParamFun))
       case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
-      case _: TypeAssertion => throw new Exception("Type assertions should be gone.")
       case _: Opaque => throw new Exception("Opaque expressions should be gone.")
       case p: r.Primitive => inferPrimitive(p)
     }

--- a/src/main/scala/shine/DPIA/Types/Kind.scala
+++ b/src/main/scala/shine/DPIA/Types/Kind.scala
@@ -10,8 +10,7 @@ sealed trait Kind {
 
 object Kind {
   // Reexport rise's kind identifiers
-  import rise.core.types.Kind.{Identifier => rIdentifier}
-  type Identifier = rIdentifier
+  type Identifier = rise.core.types.Kind.Identifier
 
   trait IdentifierMaker[K <: Kind] {
     def makeIdentifier(): K#I

--- a/src/main/scala/shine/DPIA/Types/Kind.scala
+++ b/src/main/scala/shine/DPIA/Types/Kind.scala
@@ -9,9 +9,9 @@ sealed trait Kind {
 }
 
 object Kind {
-  trait Identifier {
-    def name: String
-  }
+  // Reexport rise's kind identifiers
+  import rise.core.types.Kind.{Identifier => rIdentifier}
+  type Identifier = rIdentifier
 
   trait IdentifierMaker[K <: Kind] {
     def makeIdentifier(): K#I

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -4,7 +4,7 @@ import elevate.core.strategies.Traversable
 import elevate.core.strategies.basic.normalize
 import rise.elevate.Rise
 import rise.elevate.rules._
-import rise.core.{Opaque, TypeAnnotation, TypeAssertion, semantics => rs, types => rt}
+import rise.core.{Opaque, TypeAnnotation, semantics => rs, types => rt}
 import rise.{core => r}
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
@@ -69,7 +69,6 @@ object fromRise {
     }
 
     case e@TypeAnnotation(_, _) => throw new Exception(s"Missing rule for ${e.getClass}")
-    case e@TypeAssertion(_, _) => throw new Exception(s"Missing rule for ${e.getClass}")
     case e@Opaque(_, _) => throw new Exception(s"Missing rule for ${e.getClass}")
     case p: r.Primitive => primitive(p, ptMap.get(p))
   }

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -939,14 +939,12 @@ object fromRise {
     case rt.AddressSpace.Local => AddressSpace.Local
     case rt.AddressSpace.Private => AddressSpace.Private
     case rt.AddressSpace.Constant => AddressSpace.Constant
-    case rt.AddressSpaceIdentifier(name, _) => AddressSpaceIdentifier(name)
+    case rt.AddressSpaceIdentifier(name) => AddressSpaceIdentifier(name)
   }
 
   def nat2nat(n2n: rt.NatToNat): NatToNat = n2n match {
-    case rt.NatToNatIdentifier(name, _) =>
-      NatToNatIdentifier(name)
-    case rt.NatToNatLambda(x, body) =>
-      NatToNatLambda(x.range, NatIdentifier(x.name), body)
+    case rt.NatToNatIdentifier(name) => NatToNatIdentifier(name)
+    case rt.NatToNatLambda(x, body) => NatToNatLambda(x.range, NatIdentifier(x.name), body)
   }
 
   def dataType(t: rt.DataType): DataType = t match {
@@ -987,7 +985,7 @@ object fromRise {
     case rt.MatrixLayout.Row_Major => MatrixLayout.Row_Major
     case rt.MatrixLayout.Col_Major => MatrixLayout.Col_Major
     case rt.MatrixLayout.None => MatrixLayout.None
-    case rt.MatrixLayoutIdentifier(name, _) => layouts.getOrElseUpdate(name, MatrixLayoutIdentifier(name))
+    case rt.MatrixLayoutIdentifier(name) => layouts.getOrElseUpdate(name, MatrixLayoutIdentifier(name))
     case _ => throw new Exception("this should not happen")
   }
 
@@ -1010,12 +1008,12 @@ object fromRise {
   def ntd(ntd: rt.NatToData): NatToData= ntd match {
     case rt.NatToDataLambda(n, body) =>
       NatToDataLambda(natIdentifier(n), dataType(body))
-    case rt.NatToDataIdentifier(x, _) => NatToDataIdentifier(x)
+    case rt.NatToDataIdentifier(x) => NatToDataIdentifier(x)
   }
 
   def ntn(ntn: rt.NatToNat): NatToNat= ntn match {
     case rt.NatToNatLambda(n, body) => NatToNatLambda(natIdentifier(n), body)
-    case rt.NatToNatIdentifier(x, _) => NatToNatIdentifier(x)
+    case rt.NatToNatIdentifier(x) => NatToNatIdentifier(x)
   }
 
   def dataTypeIdentifier(dt: rt.DataTypeIdentifier): DataTypeIdentifier =

--- a/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
+++ b/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
@@ -79,8 +79,8 @@ class separableConvolution2DNaiveEqsat extends test_util.Tests {
                                 expandStrats: immutable.Seq[ExpandStrategy],
                                 filterStrat: Strategy[Rise] = BENF): Unit = {
     // FIXME: ad-hoc closing mechanism
-    val closedStart = makeClosed(BENF(start).get !: start.t)
-    val closedGoal = makeClosed(eraseType(BENF(goal).get) !: start.t)
+    val closedStart = makeClosed(BENF(start).get !: start)
+    val closedGoal = makeClosed(eraseType(BENF(goal).get) !: start)
 
     val visited = mutable.Set[ExprWrapper]()
     val unvisited = mutable.Set[ExprWrapper](ExprWrapper(closedStart))

--- a/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
+++ b/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
@@ -64,7 +64,6 @@ class separableConvolution2DNaiveEqsat extends test_util.Tests {
       case Literal(_) => Nil
       case _: ForeignFunction => Nil
       case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
-      case _: TypeAssertion => throw new Exception("Type assertions should be gone.")
       case _: Opaque => throw new Exception("Opaque expressions should be gone.")
       case _: Primitive => Nil
     })

--- a/src/test/scala/apps/separableConvolution2DRewrite.scala
+++ b/src/test/scala/apps/separableConvolution2DRewrite.scala
@@ -37,7 +37,7 @@ class separableConvolution2DRewrite extends test_util.Tests {
   private def ben_eq(a: Expr, b: Expr): Boolean = {
     val na = BENF(a).get
     val nb = BENF(b).get
-    val uab: Rise = toBeTyped(na) !: nb.t
+    val uab: Rise = toBeTyped(na) !: nb
     makeClosed(uab) =~~= makeClosed(nb)
   }
 

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -62,7 +62,6 @@ class showRise extends test_util.Tests {
         case DepApp(f, x)     => line(x.toString) <+: drawASTSimp(f)
         case Literal(d)       => line(d.toString)
         case TypeAnnotation(e, _) => drawASTSimp(e)
-        case TypeAssertion(e, _) => drawASTSimp(e)
         case Opaque(e, _) => drawASTSimp(e)
         case p: Primitive     => line(p.name)
       }
@@ -102,7 +101,6 @@ class showRise extends test_util.Tests {
         case Literal(d) => d.toString
 
         case TypeAnnotation(e, _) => lessBrackets(e, wrapped)
-        case TypeAssertion(e, _) => lessBrackets(e, wrapped)
         case Opaque(e, _) => lessBrackets(e, wrapped)
 
         case p: Primitive => p.name

--- a/src/test/scala/rise/elevate/algorithmic.scala
+++ b/src/test/scala/rise/elevate/algorithmic.scala
@@ -63,8 +63,8 @@ class algorithmic extends test_util.Tests {
   // Swap Nesting of map and reduce
 
   test("lift reduce") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
 
     val addTuple = fun(x => fst(x) + snd(x))
 
@@ -90,9 +90,9 @@ class algorithmic extends test_util.Tests {
   // Tests and Expressions related to loop reordering in Matrix Multiplication
 
   test("MM to MM-LoopMKN") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
     val mm = depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
       fun(ArrayType(M, ArrayType(K, f32)))(a =>
@@ -140,9 +140,9 @@ class algorithmic extends test_util.Tests {
 
   // This one just serves as documentation for different mm-rise-expressions
   ignore("MM-LoopMKN to MM-LoopKMN") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
     val mmMKN = {
       depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
@@ -268,9 +268,9 @@ class algorithmic extends test_util.Tests {
 
   // todo remove once PLDI-TVM tests are in
   ignore("mm tile + reorder") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
     val mm =
       DFNF(depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,

--- a/src/test/scala/rise/elevate/circularBuffering.scala
+++ b/src/test/scala/rise/elevate/circularBuffering.scala
@@ -178,7 +178,7 @@ class circularBuffering extends test_util.Tests {
 
   private def openEquality(typedA: Rise, b: Rise): Boolean = {
     import rise.core.DSL._
-    val typedB: Rise = toBeTyped(b) !: typedA.t
+    val typedB: Rise = toBeTyped(b) !: typedA
     makeClosed(typedA) =~= makeClosed(typedB)
   }
 

--- a/src/test/scala/rise/elevate/tiling.scala
+++ b/src/test/scala/rise/elevate/tiling.scala
@@ -34,7 +34,7 @@ class tiling extends test_util.Tests {
   def betaEtaEquals(a: Rise, b: Rise): Boolean = {
     val na = BENF(a).get
     val nb = BENF(b).get
-    val uab: Rise = toBeTyped(na) !: nb.t
+    val uab: Rise = toBeTyped(na) !: nb
     makeClosed(uab) =~~= makeClosed(nb)
   }
   // Check that DSL makes sense


### PR DESCRIPTION
Removes `Kind.Explicitness`, instead type variables are understood to be globally free, implicit, and for type inference to solve if they are not bound, and explicit otherwise. Type assertions are also removed, they are substituted with type annotations where the FTVs of the asserted type are preserved.

Plenty of tests don't pass, I need to figure out why.