### PR TITLE
Do not rely on any explicitness information for inference and constraint resolution

### DIFF
--- a/src/main/scala/rise/core/DSL/TopLevel.scala
+++ b/src/main/scala/rise/core/DSL/TopLevel.scala
@@ -4,7 +4,7 @@ import Type.impl
 import util.monads._
 import rise.core.traverse._
 import rise.core.types._
-import rise.core.{DSL, Expr, Primitive}
+import rise.core.{DSL, Expr, IsClosedForm, Primitive}
 
 final case class TopLevel(e: Expr, inst: Solution = Solution())(
   override val t: Type = e.t
@@ -23,7 +23,7 @@ final case class TopLevel(e: Expr, inst: Solution = Solution())(
 object TopLevel {
   private def instantiate(t: Type): Solution = {
     import scala.collection.immutable.Map
-    infer.getFTVs(t).foldLeft(Solution())((subs, ftv) =>
+    IsClosedForm.varsToClose(t).foldLeft(Solution())((subs, ftv) =>
       subs match {
         case s@Solution(ts, ns, as, ms, fs, n2ds, n2ns, natColls) =>
           ftv match {

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -43,12 +43,8 @@ object infer {
     val (e_preserve, e_wo_assertions) = traverse(e, collectPreserve)
     // Collect constraints
     val (typed_e, constraints) = constrainTypes(exprEnv)(e_wo_assertions)
-    // Collect free variables both before and after constraint gathering:
-    // Some types in the collected constraints might not be present after constraint gathering (Fixme: BUG?)
-    val ftvs = IsClosedForm.freeVars(e_wo_assertions)._2.toSet ++ IsClosedForm.freeVars(typed_e)._2.toSet
-    val toSubstitute = (ftvs removedAll e_preserve) removedAll typeEnv
     // Solve constraints while preserving the FTVs in preserve
-    val solution = Constraint.solve(constraints, toSubstitute, Seq())
+    val solution = Constraint.solve(constraints, e_preserve ++ typeEnv, Seq())
     // Apply the solution
     val res = traverse(typed_e, Visitor(solution))
     if (printFlag == Flags.PrintTypesAndTypeHoles.On) {

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -34,7 +34,10 @@ object infer {
     traverse(e, Traversal(Set()))._1
   }
 
-  def apply(e: Expr, exprEnv: Map[String, Type] = Map(), typeEnv : Set[Kind.Identifier] = Set(),
+  type ExprEnv = Map[String, Type]
+  type TypeEnv = Set[Kind.Identifier]
+
+  def apply(e: Expr, exprEnv: ExprEnv = Map(), typeEnv : TypeEnv = Set(),
             printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off,
             explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off): Expr = {
     // TODO: Get rid of TypeAssertion and deprecate, instead evaluate !: in place and use `preserving` directly
@@ -113,11 +116,11 @@ object infer {
   private def ifTyped[T] : Type => T => Seq[T] =
     t => c => if (t == TypePlaceholder) Nil else Seq(c)
 
-  def constrainTypes(exprEnv : Map[String, Type], typeEnv : Set[Kind.Identifier]) : Expr => (Expr, Seq[ScopedConstraint]) = {
+  def constrainTypes(exprEnv : ExprEnv, typeEnv : TypeEnv) : Expr => (Expr, Seq[(Constraint, TypeEnv)]) = {
     case i: Identifier =>
       val t = exprEnv.getOrElse(i.name,
         if (i.t == TypePlaceholder) error(s"$i has no type")(Seq()) else i.t )
-      val c = ScopedConstraint(TypeConstraint(t, i.t), typeEnv)
+      val c = (TypeConstraint(t, i.t), typeEnv)
       (i.setType(t), Nil :+ c)
 
     case expr@Lambda(x, e) =>
@@ -125,14 +128,14 @@ object infer {
       val exprEnv1 : Map[String, Type] = exprEnv + (tx.name -> tx.t)
       val (te, cs) = constrainTypes(exprEnv1, typeEnv)(e)
       val ft = FunType(tx.t, te.t)
-      val cs1 = ifTyped(expr.t)(ScopedConstraint(TypeConstraint(expr.t, ft), typeEnv))
+      val cs1 = ifTyped(expr.t)((TypeConstraint(expr.t, ft), typeEnv))
       (Lambda(tx, te)(ft), cs ++ cs1)
 
     case expr@App(f, e) =>
       val (tf, csF) = constrainTypes(exprEnv, typeEnv)(f)
       val (te, csE) = constrainTypes(exprEnv, typeEnv)(e)
       val exprT = genType(expr)
-      val c = ScopedConstraint(TypeConstraint(tf.t, FunType(te.t, exprT)), typeEnv)
+      val c = (TypeConstraint(tf.t, FunType(te.t, exprT)), typeEnv)
       (App(tf, te)(exprT), csF ++ csE :+ c)
 
     case expr@DepLambda(x, e) =>
@@ -149,23 +152,23 @@ object infer {
         case n2n: NatToNatIdentifier =>
           DepLambda[NatToNatKind](n2n, te)(DepFunType[NatToNatKind, Type](n2n, te.t))
       }
-      val csE1 = ifTyped(expr.t)(ScopedConstraint(TypeConstraint(expr.t, tf.t), typeEnv1))
+      val csE1 = ifTyped(expr.t)((TypeConstraint(expr.t, tf.t), typeEnv1))
       (tf, csE ++ csE1)
 
     case expr@DepApp(f, x) =>
       val (tf, csF) = constrainTypes(exprEnv, typeEnv)(f)
       val exprT = genType(expr)
-      val c = ScopedConstraint(DepConstraint(tf.t, x, exprT), typeEnv)
+      val c = (DepConstraint(tf.t, x, exprT), typeEnv)
       (DepApp(tf, x)(exprT), csF :+ c)
 
     case TypeAnnotation(e, t) =>
       val (te, csE) = constrainTypes(exprEnv, typeEnv)(e)
-      val c = ScopedConstraint(TypeConstraint(te.t, t), typeEnv)
+      val c = (TypeConstraint(te.t, t), typeEnv)
       (te, csE :+ c)
 
     case TypeAssertion(e, t) =>
       val (te, csE) = constrainTypes(exprEnv, typeEnv)(e)
-      val c = ScopedConstraint(TypeConstraint(te.t, t), typeEnv)
+      val c = (TypeConstraint(te.t, t), typeEnv)
       (te, csE :+ c)
 
     case o: Opaque => (o, Nil)

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -74,31 +74,19 @@ object infer {
   private val collectPreserve = new PureAccumulatorTraversal[Set[Kind.Identifier]] {
     override val accumulator = SetMonoid
 
-    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = _ => {
-      case i: Kind.Explicitness =>
-        accumulate(if (i.isExplicit) Set(i) else Set())(i.asInstanceOf[I])
-      case i => accumulate(Set())(i)
-    }
-
-    override def nat: Nat => Pair[Nat] = ae => {
-      val pres = mutable.ListBuffer[Kind.Identifier]()
-      val r = ae.visitAndRebuild({
-        case i: NatIdentifier if i.isExplicit => pres += i; i
-        case n => n
-      })
-      accumulate(pres.toSet)(r)
+    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
+      case Binding => i => accumulate(Set(i))(i)
+      case _ => return_
     }
 
     override def expr: Expr => Pair[Expr] = {
       // Transform assertions into annotations, collect FTVs
       case TypeAssertion(e, t) =>
         val (s1, e1) = expr(e).unwrap
-        val (s2, _) = `type`(t).unwrap
-        accumulate(s1 ++ s2 ++ IsClosedForm.varsToClose(t))(TypeAnnotation(e1, t) : Expr)
+        accumulate(s1 ++ IsClosedForm.varsToClose(t))(TypeAnnotation(e1, t) : Expr)
       // Collect FTVs
       case Opaque(e, t) =>
-        val (s, _) = `type`(t).unwrap
-        accumulate(s ++ IsClosedForm.varsToClose(t).toSet)(Opaque(e, t) : Expr)
+        accumulate(IsClosedForm.varsToClose(t).toSet)(Opaque(e, t) : Expr)
       case e => super.expr(e)
     }
   }

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -83,10 +83,10 @@ object infer {
       // Transform assertions into annotations, collect FTVs
       case TypeAssertion(e, t) =>
         val (s1, e1) = expr(e).unwrap
-        accumulate(s1 ++ IsClosedForm.varsToClose(t))(TypeAnnotation(e1, t) : Expr)
+        accumulate(s1 ++ IsClosedForm.freeVars(t).set)(TypeAnnotation(e1, t) : Expr)
       // Collect FTVs
       case Opaque(e, t) =>
-        accumulate(IsClosedForm.varsToClose(t).toSet)(Opaque(e, t) : Expr)
+        accumulate(IsClosedForm.freeVars(t).set)(Opaque(e, t) : Expr)
       case e => super.expr(e)
     }
   }

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -74,8 +74,18 @@ object IsClosedForm {
   def freeVars(expr: Expr): (Set[Identifier], Set[Kind.Identifier]) =
     traverse(expr, Visitor(Set(), Set()))._1
 
+  def varsToClose(expr : Expr): (Seq[Identifier], Seq[Kind.Identifier]) = {
+    val (fV, fT) = freeVars(expr)
+    // Exclude matrix layout and fragment kind identifiers, since they cannot currently be bound
+    (fV, fT.flatMap {
+      case i : MatrixLayoutIdentifier => Seq()
+      case i : FragmentKindIdentifier => Seq()
+      case e => Seq(e)
+    })
+  }
+
   def apply(expr: Expr): Boolean = {
-    val (freeV, freeT) = freeVars(expr)
+    val (freeV, freeT) = varsToClose(expr)
     freeV.isEmpty && freeT.isEmpty
   }
 }

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -36,7 +36,12 @@ object IsClosedForm {
     }
 
     override def expr: Expr => Pair[Expr] = {
-      case Lambda(x, b) => this.copy(boundV = boundV + x).expr(b)
+      case l@Lambda(x, e) =>
+        // The binder's type itself might contain free type variables
+        val ((fVx, fTx), x1) = identifier(Binding)(x).unwrap
+        val ((fVe, fTe), e1) = this.copy(boundV = boundV + x1).expr(e).unwrap
+        val ((fVt, fTt), t1) = `type`(l.t).unwrap
+        accumulate((fVx ++ fVe ++ fVt, fTx ++ fTe ++ fTt))(Lambda(x1, e1)(t1) : Expr)
       case DepLambda(x, b) => this.copy(boundT = boundT + x).expr(b)
       case e => super.expr(e)
     }

--- a/src/main/scala/rise/core/makeClosed.scala
+++ b/src/main/scala/rise/core/makeClosed.scala
@@ -11,7 +11,7 @@ object makeClosed {
       Map[AddressSpaceIdentifier, AddressSpace],
       Map[NatToDataIdentifier, NatToData]) = (Map(), Map(), Map(), Map())
 
-    val (expr, (ts, ns, as, n2ds)) = DSL.infer.getFTVsRec(e).foldLeft((e, emptySubs))((acc, ftv) => acc match {
+    val (expr, (ts, ns, as, n2ds)) = IsClosedForm.varsToClose(e)._2.foldLeft((e, emptySubs))((acc, ftv) => acc match {
       case (expr, (ts, ns, as, n2ds)) => ftv match {
         case i: TypeIdentifier =>
           val dt = DataTypeIdentifier(freshName("dt"), isExplicit = true)

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -268,14 +268,14 @@ object Constraint {
         } else if (canBeSubstituted(preserve, j)) {
           Solution.subs(j, i)
         } else {
-          error(s"cannot unify $i and $j, they are both explicit or in $preserve")
+          error(s"cannot unify $i and $j, they are both in $preserve")
         }
       case _ if occurs(i, t) => error(s"circular use: $i occurs in $t")
       case _ =>
         if (canBeSubstituted(preserve, i)) {
           Solution.subs(i, t)
         } else {
-          error(s"cannot substitute $i, it is explicit")
+          error(s"cannot substitute $i, it is $preserve")
         }
     }
   }

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -43,13 +43,13 @@ case class NatCollectionConstraint(a: NatCollection, b: NatCollection)
   override def toString: String = s"$a ~ $b"
 }
 
-case class ScopedConstraint(constr : Constraint, preserve : Set[Kind.Identifier])
-
 object Constraint {
+  type Scope = Set[Kind.Identifier]
+
   def canBeSubstituted(preserve: Set[Kind.Identifier], i: Kind.Identifier): Boolean =
     !preserve.contains(i)
 
-  def solve(cs: Seq[ScopedConstraint], trace: Seq[Constraint])
+  def solve(cs: Seq[(Constraint, Scope)], trace: Seq[Constraint])
      (implicit explDep: Flags.ExplicitDependence): Solution =
   solveRec(cs, Nil, trace)
   /* faster but not always enough:
@@ -61,23 +61,23 @@ object Constraint {
   }
   */
 
-  def solveRec(cs: Seq[ScopedConstraint], rs: Seq[ScopedConstraint], trace: Seq[Constraint])
+  def solveRec(cs: Seq[(Constraint, Scope)], rs: Seq[(Constraint, Scope)], trace: Seq[Constraint])
               (implicit explDep: Flags.ExplicitDependence): Solution = (cs, rs) match {
     case (Nil, Nil) => Solution()
     case (Nil, _) => error(s"could not solve constraints ${rs}")(trace)
     case (scoped +: cs, _) =>
-      val ScopedConstraint(c, scope) = scoped
+      val (c, scope) = scoped
       val s = try { solveOne(c, scope, trace) }
               catch { case e: InferenceException =>
                 println(e.msg)
-                return solveRec(cs, rs :+ ScopedConstraint(c, scope), trace) }
+                return solveRec(cs, rs :+ (c, scope), trace) }
       s ++ solve(s.apply(rs ++ cs), trace)
   }
 
   // scalastyle:off method.length
   def solveOne(c: Constraint, preserve : Set[Kind.Identifier], trace: Seq[Constraint]) (implicit explDep: Flags.ExplicitDependence): Solution = {
     implicit val _trace: Seq[Constraint] = trace
-    def decomposed(cs: Seq[Constraint], preserve : Set[Kind.Identifier]) = solve(cs.map(ScopedConstraint(_, preserve)), c +: trace)
+    def decomposed(cs: Seq[Constraint], preserve : Set[Kind.Identifier]) = solve(cs.map((_, preserve)), c +: trace)
 
     c match {
       case TypeConstraint(a, b) =>
@@ -316,7 +316,7 @@ object Constraint {
 
     def unify(a: Nat, b: Nat, preserve : Set[Kind.Identifier])
              (implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs.map(ScopedConstraint(_, preserve)), NatConstraint(a, b) +: trace)
+      def decomposed(cs: Seq[Constraint]) = solve(cs.map((_, preserve)), NatConstraint(a, b) +: trace)
       (a, b) match {
         case (i: NatIdentifier, _) => nat.unifyIdent(i, b, preserve)
         case (_, i: NatIdentifier) => nat.unifyIdent(i, a, preserve)
@@ -477,7 +477,7 @@ object Constraint {
     def unify(a: BoolExpr, b: BoolExpr, preserve : Set[Kind.Identifier])(
       implicit trace: Seq[Constraint], explDep: Flags.ExplicitDependence
     ): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs.map(ScopedConstraint(_, preserve)), BoolConstraint(a, b) +: trace)
+      def decomposed(cs: Seq[Constraint]) = solve(cs.map((_, preserve)), BoolConstraint(a, b) +: trace)
       (a, b) match {
         case _ if a == b => Solution()
         case (ArithPredicate(lhs1, rhs1, op1), ArithPredicate(lhs2, rhs2, op2)) if op1 == op2 =>

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -44,11 +44,11 @@ case class NatCollectionConstraint(a: NatCollection, b: NatCollection)
 }
 
 object Constraint {
-  def canBeSubstituted(toSubstitute: Set[Kind.Identifier], i: Kind.Identifier): Boolean =
-    toSubstitute.contains(i)
+  def canBeSubstituted(preserve: Set[Kind.Identifier], i: Kind.Identifier): Boolean =
+    !preserve.contains(i)
 
-  def solve(cs: Seq[Constraint], toSubstitute: Set[Kind.Identifier], trace: Seq[Constraint]): Solution =
-  solveRec(cs,  Nil, toSubstitute, trace)
+  def solve(cs: Seq[Constraint], preserve: Set[Kind.Identifier], trace: Seq[Constraint]): Solution =
+  solveRec(cs,  Nil, preserve, trace)
   /* faster but not always enough:
    cs match {
     case Nil => Solution()
@@ -58,34 +58,34 @@ object Constraint {
   }
   */
 
-  def solveRec(cs: Seq[Constraint], rs: Seq[Constraint], toSubstitute: Set[Kind.Identifier], trace: Seq[Constraint]): Solution = (cs, rs) match {
+  def solveRec(cs: Seq[Constraint], rs: Seq[Constraint], preserve: Set[Kind.Identifier], trace: Seq[Constraint]): Solution = (cs, rs) match {
     case (Nil, Nil) => Solution()
     case (Nil, _) => error(s"could not solve constraints ${rs}")(trace)
     case (c +: cs, _) =>
-      val s = try { solveOne(c, toSubstitute, trace) }
+      val s = try { solveOne(c, preserve, trace) }
               catch { case e: InferenceException =>
                 println(e.msg)
-                return solveRec(cs, rs :+ c, toSubstitute, trace) }
-      s ++ solve(s.apply(rs ++ cs), toSubstitute, trace)
+                return solveRec(cs, rs :+ c, preserve, trace) }
+      s ++ solve(s.apply(rs ++ cs), preserve, trace)
   }
 
   // scalastyle:off method.length
-  def solveOne(c: Constraint, toSubstitute : Set[Kind.Identifier], trace: Seq[Constraint]): Solution = {
+  def solveOne(c: Constraint, preserve : Set[Kind.Identifier], trace: Seq[Constraint]): Solution = {
     implicit val _trace: Seq[Constraint] = trace
-    def decomposedPreserve(cs: Seq[Constraint], toSubstitute : Set[Kind.Identifier]) = solve(cs, toSubstitute, c +: trace)
-    def decomposed(cs: Seq[Constraint]) = solve(cs, toSubstitute, c +: trace)
+    def decomposedPreserve(cs: Seq[Constraint], preserve : Set[Kind.Identifier]) = solve(cs, preserve, c +: trace)
+    def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, c +: trace)
 
     c match {
       case TypeConstraint(a, b) =>
         (a, b) match {
           case (TypePlaceholder, _) => Solution()
           case (_, TypePlaceholder) => Solution()
-          case (i: TypeIdentifier, _) => unifyTypeIdent(i, b, toSubstitute)
-          case (_, i: TypeIdentifier) => unifyTypeIdent(i, a, toSubstitute)
+          case (i: TypeIdentifier, _) => unifyTypeIdent(i, b, preserve)
+          case (_, i: TypeIdentifier) => unifyTypeIdent(i, a, preserve)
           case (i: DataTypeIdentifier, dt: DataType) =>
-            unifyDataTypeIdent(i, dt, toSubstitute)
+            unifyDataTypeIdent(i, dt, preserve)
           case (dt: DataType, i: DataTypeIdentifier) =>
-            unifyDataTypeIdent(i, dt, toSubstitute)
+            unifyDataTypeIdent(i, dt, preserve)
           case (_: ScalarType | _: NatType.type |
                 _: IndexType  | _: VectorType,
           _: ScalarType | _: NatType.type |
@@ -115,7 +115,7 @@ object Constraint {
                 NatConstraint(n, na),
                 NatConstraint(n, nb),
                 TypeConstraint(ta, tb),
-              ), toSubstitute + na + nb)
+              ), preserve + n - na - nb)
           case (
             DepFunType(dta: DataTypeIdentifier, ta),
             DepFunType(dtb: DataTypeIdentifier, tb)
@@ -125,7 +125,7 @@ object Constraint {
               TypeConstraint(dt, dta),
               TypeConstraint(dt, dtb),
               TypeConstraint(ta, tb),
-            ), toSubstitute + dta + dtb)
+            ), preserve + dt - dta - dtb)
           case (
             DepFunType(_: AddressSpaceIdentifier, _),
             DepFunType(_: AddressSpaceIdentifier, _)
@@ -141,7 +141,7 @@ object Constraint {
               NatConstraint(n, x1),
               NatConstraint(n, x2),
               TypeConstraint(t1, t2),
-            ), toSubstitute + x1 + x2)
+            ), preserve + n - x1 - x2)
 
           case (
             DepPairType(x1: NatCollectionIdentifier, t1),
@@ -152,7 +152,7 @@ object Constraint {
               NatCollectionConstraint(n, x1),
               NatCollectionConstraint(n, x2),
               TypeConstraint(t1, t2),
-            ), toSubstitute + x1 + x2)
+            ), preserve + n - x1 - x2)
 
           case (
             NatToDataApply(f: NatToDataIdentifier, _),
@@ -193,8 +193,8 @@ object Constraint {
             error(s"expected a dependent function type, but got $df")
         }
 
-      case NatConstraint(a, b) => nat.unify(a, b, toSubstitute)
-      case BoolConstraint(a, b) => bool.unify(a, b, toSubstitute)
+      case NatConstraint(a, b) => nat.unify(a, b, preserve)
+      case BoolConstraint(a, b) => bool.unify(a, b, preserve)
       case NatToDataConstraint(a, b) =>
         (a, b) match {
           case (i: NatToDataIdentifier, _) => natToData.unifyIdent(i, b)
@@ -206,15 +206,15 @@ object Constraint {
               NatConstraint(n, x1),
               NatConstraint(n, x2),
               TypeConstraint(dt1, dt2),
-            ), toSubstitute + x1 + x2)
+            ), preserve + n - x1 - x2)
 
           case _ => error(s"cannot unify $a and $b")
         }
 
       case NatCollectionConstraint(a, b) =>
         (a,b) match {
-          case (i: NatCollectionIdentifier, _) => natCollection.unifyIdent(i, b, toSubstitute)
-          case (_, i: NatCollectionIdentifier) => natCollection.unifyIdent(i, b, toSubstitute)
+          case (i: NatCollectionIdentifier, _) => natCollection.unifyIdent(i, b, preserve)
+          case (_, i: NatCollectionIdentifier) => natCollection.unifyIdent(i, b, preserve)
           case _ if a == b                    => Solution()
           case (NatCollectionFromArray(e1), NatCollectionFromArray(e2)) =>
             // What to do here???
@@ -223,9 +223,9 @@ object Constraint {
 
       case MatrixLayoutConstraint(a, b) =>
         (a, b) match {
-          case (i: MatrixLayoutIdentifier, _) if canBeSubstituted(toSubstitute, i) =>
+          case (i: MatrixLayoutIdentifier, _) if canBeSubstituted(preserve, i) =>
             Solution.subs(i, b)
-          case (_, i: MatrixLayoutIdentifier) if canBeSubstituted(toSubstitute, i) =>
+          case (_, i: MatrixLayoutIdentifier) if canBeSubstituted(preserve, i) =>
             Solution.subs(i, a)
           case _ if a == b                 => Solution()
           case _                           => error(s"cannot unify $a and $b")
@@ -233,9 +233,9 @@ object Constraint {
 
       case FragmentTypeConstraint(a, b) =>
         (a, b) match {
-          case (i: FragmentKindIdentifier, _) if canBeSubstituted(toSubstitute, i) =>
+          case (i: FragmentKindIdentifier, _) if canBeSubstituted(preserve, i) =>
             Solution.subs(i, b)
-          case (_, i: FragmentKindIdentifier) if canBeSubstituted(toSubstitute, i) =>
+          case (_, i: FragmentKindIdentifier) if canBeSubstituted(preserve, i) =>
             Solution.subs(i, a)
           case _ if a == b                 => Solution()
           case _                           => error(s"cannot unify $a and $b")
@@ -244,39 +244,38 @@ object Constraint {
   }
   // scalastyle:on method.length
 
-  def unifyTypeIdent(i: TypeIdentifier, t: Type, toSubstitute: Set[Kind.Identifier])
-                    (implicit trace: Seq[Constraint]): Solution = {
+  def unifyTypeIdent(i: TypeIdentifier, t: Type, preserve: Set[Kind.Identifier]): Solution = {
     t match {
-      case _ if canBeSubstituted(toSubstitute, i) =>
+      case _ if canBeSubstituted(preserve, i) =>
         Solution.subs(i, t)
       case _ if i == t => Solution()
-      case i2: TypeIdentifier if canBeSubstituted(toSubstitute, i2) =>
+      case i2: TypeIdentifier if canBeSubstituted(preserve, i2) =>
         Solution.subs(i2, i)
       case _ =>
-        error(s"$i cannot be substituted for $t, neither is in $toSubstitute")
+        throw new Exception(s"$i cannot be substituted for $t")
     }
   }
 
   // FIXME: datatypes and types are mixed up
-  def unifyDataTypeIdent(i: DataTypeIdentifier, t: DataType, toSubstitute : Set[Kind.Identifier])
+  def unifyDataTypeIdent(i: DataTypeIdentifier, t: DataType, preserve : Set[Kind.Identifier])
                         (implicit trace: Seq[Constraint]): Solution = {
     t match {
       case j: DataTypeIdentifier =>
         if (i == j) {
           Solution()
-        } else if (canBeSubstituted(toSubstitute, i)) {
+        } else if (canBeSubstituted(preserve, i)) {
           Solution.subs(i, j)
-        } else if (canBeSubstituted(toSubstitute, j)) {
+        } else if (canBeSubstituted(preserve, j)) {
           Solution.subs(j, i)
         } else {
-          error(s"cannot unify $i and $j, neither is in $toSubstitute")
+          error(s"cannot unify $i and $j, they are both explicit or in $preserve")
         }
       case _ if occurs(i, t) => error(s"circular use: $i occurs in $t")
       case _ =>
-        if (canBeSubstituted(toSubstitute, i)) {
+        if (canBeSubstituted(preserve, i)) {
           Solution.subs(i, t)
         } else {
-          error(s"cannot substitute $i, it is not in $toSubstitute")
+          error(s"cannot substitute $i, it is explicit")
         }
     }
   }
@@ -284,14 +283,14 @@ object Constraint {
   private object nat {
     import arithexpr.arithmetic._
 
-    def unify(a: Nat, b: Nat, toSubstitute : Set[Kind.Identifier])
+    def unify(a: Nat, b: Nat, preserve : Set[Kind.Identifier])
              (implicit trace: Seq[Constraint]): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs, toSubstitute, NatConstraint(a, b) +: trace)
+      def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, NatConstraint(a, b) +: trace)
       (a, b) match {
-        case (i: NatIdentifier, _) => nat.unifyIdent(i, b, toSubstitute)
-        case (_, i: NatIdentifier) => nat.unifyIdent(i, a, toSubstitute)
-        case (app: NatToNatApply, _) => nat.unifyApply(app, b, toSubstitute)
-        case (_, app: NatToNatApply) => nat.unifyApply(app, a, toSubstitute)
+        case (i: NatIdentifier, _) => nat.unifyIdent(i, b, preserve)
+        case (_, i: NatIdentifier) => nat.unifyIdent(i, a, preserve)
+        case (app: NatToNatApply, _) => nat.unifyApply(app, b, preserve)
+        case (_, app: NatToNatApply) => nat.unifyApply(app, a, preserve)
         case _ if a == b => Solution()
         // case _ if !nat.potentialPivots(a).isEmpty => nat.tryPivots(a, b)
         // case _ if !nat.potentialPivots(b).isEmpty => nat.tryPivots(b, a)
@@ -304,42 +303,42 @@ object Constraint {
           decomposed(Seq(
             NatConstraint(t1, t2), NatConstraint(e1, e2), BoolConstraint(c1, c2)
           ))
-        case (s: arithexpr.arithmetic.Sum, _) => nat.unifySum(s, b, toSubstitute)
-        case (_, s: arithexpr.arithmetic.Sum) => nat.unifySum(s, a, toSubstitute)
-        case (p: arithexpr.arithmetic.Prod, _) => nat.unifyProd(p, b, toSubstitute)
-        case (_, p: arithexpr.arithmetic.Prod) => nat.unifyProd(p, a, toSubstitute)
-        case (p: arithexpr.arithmetic.Pow, _) => nat.unifyProd(p, b, toSubstitute)
-        case (_, p: arithexpr.arithmetic.Pow) => nat.unifyProd(p, a, toSubstitute)
-        case (p: arithexpr.arithmetic.IntDiv, _) => nat.unifyProd(p, b, toSubstitute)
-        case (_, p: arithexpr.arithmetic.IntDiv) => nat.unifyProd(p, a, toSubstitute)
+        case (s: arithexpr.arithmetic.Sum, _) => nat.unifySum(s, b, preserve)
+        case (_, s: arithexpr.arithmetic.Sum) => nat.unifySum(s, a, preserve)
+        case (p: arithexpr.arithmetic.Prod, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.Prod) => nat.unifyProd(p, a, preserve)
+        case (p: arithexpr.arithmetic.Pow, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.Pow) => nat.unifyProd(p, a, preserve)
+        case (p: arithexpr.arithmetic.IntDiv, _) => nat.unifyProd(p, b, preserve)
+        case (_, p: arithexpr.arithmetic.IntDiv) => nat.unifyProd(p, a, preserve)
         case (arithexpr.arithmetic.Mod(x1, m1),
           arithexpr.arithmetic.Mod(x2: NatIdentifier, m2))
-          if m1 == m2 && canBeSubstituted(toSubstitute, x2) =>
+          if m1 == m2 && canBeSubstituted(preserve, x2) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
           Solution.subs(x2, k*m1 + x1%m1)
         case (arithexpr.arithmetic.Mod(x2: NatIdentifier, m2),
           arithexpr.arithmetic.Mod(x1, m1))
-          if m1 == m2 && canBeSubstituted(toSubstitute, x2) =>
+          if m1 == m2 && canBeSubstituted(preserve, x2) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
           Solution.subs(x2, k*m1 + x1%m1)
         case _ => error(s"cannot unify $a and $b")
       }
     }
 
-    def freeOccurences(n: Nat, toSubstitute : Set[Kind.Identifier]): Map[NatIdentifier, Integer] = {
+    def freeOccurences(n: Nat, preserve : Set[Kind.Identifier]): Map[NatIdentifier, Integer] = {
       val free_occurrences = mutable
         .Map[NatIdentifier, Integer]()
         .withDefault(_ => 0)
       ArithExpr.visit(n, {
-        case v: NatIdentifier if canBeSubstituted(toSubstitute, v) => free_occurrences(v) += 1
+        case v: NatIdentifier if canBeSubstituted(preserve, v) => free_occurrences(v) += 1
         case _ =>
       })
       free_occurrences.toMap
     }
 
     // collect free variables with only 1 occurrence
-    def potentialPivots(n: Nat, toSubstitute : Set[Kind.Identifier]): Set[NatIdentifier] = {
-      freeOccurences(n, toSubstitute).foldLeft(Set[NatIdentifier]())({
+    def potentialPivots(n: Nat, preserve : Set[Kind.Identifier]): Set[NatIdentifier] = {
+      freeOccurences(n, preserve).foldLeft(Set[NatIdentifier]())({
         case (potential, (v, c)) =>
           if (c == 1) {
             potential + v
@@ -384,53 +383,53 @@ object Constraint {
       }
     }
 
-    def tryPivots(n: Nat, value: Nat, toSubstitute : Set[Kind.Identifier])
+    def tryPivots(n: Nat, value: Nat, preserve : Set[Kind.Identifier])
                  (implicit trace: Seq[Constraint]): Solution = {
-      potentialPivots(n, toSubstitute).foreach(pivotSolution(_, n, value) match {
+      potentialPivots(n, preserve).foreach(pivotSolution(_, n, value) match {
         case Some(s) => return s
         case None    =>
       })
       error(s"could not pivot $n = $value")
     }
 
-    def unifyProd(p: Nat, n: Nat, toSubstitute : Set[Kind.Identifier])
+    def unifyProd(p: Nat, n: Nat, preserve : Set[Kind.Identifier])
                  (implicit trace: Seq[Constraint]): Solution = {
       // n = p --> 1 = p * (1/n)
-      tryPivots(p /^ n, 1, toSubstitute)
+      tryPivots(p /^ n, 1, preserve)
     }
 
-    def unifySum(s: Sum, n: Nat, toSubstitute : Set[Kind.Identifier])
+    def unifySum(s: Sum, n: Nat, preserve : Set[Kind.Identifier])
                 (implicit trace: Seq[Constraint]): Solution = {
       // n = s --> 0 = s + (-n)
-      tryPivots(s - n, 0, toSubstitute)
+      tryPivots(s - n, 0, preserve)
     }
 
-    def unifyIdent(i: NatIdentifier, n: Nat, toSubstitute : Set[Kind.Identifier])
+    def unifyIdent(i: NatIdentifier, n: Nat, preserve : Set[Kind.Identifier])
                   (implicit trace: Seq[Constraint]): Solution = n match {
       case j: NatIdentifier =>
         if (i == j) {
           Solution()
-        } else if (canBeSubstituted(toSubstitute, i)) {
+        } else if (canBeSubstituted(preserve, i)) {
           Solution.subs(i, j)
-        } else if (canBeSubstituted(toSubstitute, j)) {
+        } else if (canBeSubstituted(preserve, j)) {
           Solution.subs(j, i)
         } else {
           error(s"cannot unify $i and $j")
         }
-      case fx: NatToNatApply => unifyApply(fx, i, toSubstitute)
-      case _ if !ArithExpr.contains(n, i) && (canBeSubstituted(toSubstitute, i)) =>
+      case fx: NatToNatApply => unifyApply(fx, i, preserve)
+      case _ if !ArithExpr.contains(n, i) && (canBeSubstituted(preserve, i)) =>
         Solution.subs(i, n)
-      case p: Prod => unifyProd(p, i, toSubstitute)
-      case s: Sum  => unifySum(s, i, toSubstitute)
+      case p: Prod => unifyProd(p, i, preserve)
+      case s: Sum  => unifySum(s, i, preserve)
       case _       => error(s"cannot unify $i and $n")
     }
 
-    def unifyApply(apply: NatToNatApply, nat: Nat, toSubstitute: Set[Kind.Identifier])
+    def unifyApply(apply: NatToNatApply, nat: Nat, preserve: Set[Kind.Identifier])
                   (implicit trace: Seq[Constraint]): Solution = {
       val NatToNatApply(f1, n1) = apply
       nat match {
         case NatToNatApply(f2, n2) =>
-          natToNat.unify(f1, f2, toSubstitute) ++ unify(n1, n2, toSubstitute)
+          natToNat.unify(f1, f2, preserve) ++ unify(n1, n2, preserve)
         case _ => (f1, n1) match {
           case (f1: NatToNatIdentifier, n1: NatIdentifier) =>
             val freshVar = NatIdentifier(freshName("n"), isExplicit = true)
@@ -445,9 +444,9 @@ object Constraint {
   private object bool {
     import arithexpr.arithmetic._
 
-    def unify(a: BoolExpr, b: BoolExpr, toSubstitute : Set[Kind.Identifier])
+    def unify(a: BoolExpr, b: BoolExpr, preserve : Set[Kind.Identifier])
              (implicit trace: Seq[Constraint]): Solution = {
-      def decomposed(cs: Seq[Constraint]) = solve(cs, toSubstitute, BoolConstraint(a, b) +: trace)
+      def decomposed(cs: Seq[Constraint]) = solve(cs, preserve, BoolConstraint(a, b) +: trace)
       (a, b) match {
         case _ if a == b => Solution()
         case (ArithPredicate(lhs1, rhs1, op1), ArithPredicate(lhs2, rhs2, op2)) if op1 == op2 =>
@@ -471,7 +470,7 @@ object Constraint {
   }
 
   object natToNat {
-    def unify(f1: NatToNat, f2: NatToNat, toSubstitute: Set[Kind.Identifier])
+    def unify(f1: NatToNat, f2: NatToNat, preserve: Set[Kind.Identifier])
              (implicit trace: Seq[Constraint]): Solution = f1 match {
       case id1: NatToNatIdentifier => Solution.subs(id1, f2)
       case NatToNatLambda(x1, body1) => f2 match {
@@ -481,13 +480,13 @@ object Constraint {
           nat.unify(
             substitute.natInNat(n, `for` = x1, body1),
             substitute.natInNat(n, `for`=x2, body2),
-            toSubstitute)
+            preserve + n)
       }
     }
   }
 
   object natCollection {
-    def unifyIdent(i: NatCollectionIdentifier, n: NatCollection, toSubstitute : Set[Kind.Identifier])
+    def unifyIdent(i: NatCollectionIdentifier, n: NatCollection, preserve : Set[Kind.Identifier])
                   (implicit trace: Seq[Constraint]): Solution = n match {
       case j: NatCollectionIdentifier =>
         if (i == j) {

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -132,9 +132,11 @@ case class Solution(ts: Map[Type, Type],
     combine(this, other)
   }
 
+  type Scope = Set[Kind.Identifier]
+
   // def apply(constraints: Seq[Constraint]): Seq[Constraint] = constraints.map(apply)
-  def apply(constraints: Seq[ScopedConstraint]): Seq[ScopedConstraint] =
-    constraints.map {case ScopedConstraint(c, s) => ScopedConstraint(apply(c), s)}
+  def apply(constraints: Seq[(Constraint, Scope)]): Seq[(Constraint, Scope)] =
+    constraints.map {case (c, s) => (apply(c), s)}
 
   def apply(constraint: Constraint): Constraint = constraint match {
     case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -132,12 +132,7 @@ case class Solution(ts: Map[Type, Type],
     combine(this, other)
   }
 
-  type Scope = Set[Kind.Identifier]
-
-  // def apply(constraints: Seq[Constraint]): Seq[Constraint] = constraints.map(apply)
-  def apply(constraints: Seq[(Constraint, Scope)]): Seq[(Constraint, Scope)] =
-    constraints.map {case (c, s) => (apply(c), s)}
-
+  def apply(constraints: Seq[Constraint]): Seq[Constraint] = constraints.map(apply)
   def apply(constraint: Constraint): Constraint = constraint match {
     case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
     case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -132,29 +132,31 @@ case class Solution(ts: Map[Type, Type],
     combine(this, other)
   }
 
-  def apply(constraints: Seq[Constraint]): Seq[Constraint] = {
-    constraints.map {
-      case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
-      case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))
-      case BoolConstraint(a, b) => BoolConstraint(apply(a), apply(b))
-      case MatrixLayoutConstraint(a, b) => MatrixLayoutConstraint(apply(a), apply(b))
-      case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
-      case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
-      case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
-      case DepConstraint(df, arg: Nat, t) => DepConstraint[NatKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: DataType, t) =>
-        DepConstraint[DataKind](apply(df), apply(arg).asInstanceOf[DataType], apply(t))
-      case DepConstraint(df, arg: Type, t) =>
-        DepConstraint[TypeKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: AddressSpace, t) =>
-        DepConstraint[AddressSpaceKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatToData, t) =>
-        DepConstraint[NatToDataKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatToNat, t) =>
-        DepConstraint[NatToNatKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatCollection, t) =>
-        DepConstraint[NatCollectionKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(_, _, _) => throw new Exception("Impossible case")
-    }
+  // def apply(constraints: Seq[Constraint]): Seq[Constraint] = constraints.map(apply)
+  def apply(constraints: Seq[ScopedConstraint]): Seq[ScopedConstraint] =
+    constraints.map {case ScopedConstraint(c, s) => ScopedConstraint(apply(c), s)}
+
+  def apply(constraint: Constraint): Constraint = constraint match {
+    case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
+    case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))
+    case BoolConstraint(a, b) => BoolConstraint(apply(a), apply(b))
+    case MatrixLayoutConstraint(a, b) => MatrixLayoutConstraint(apply(a), apply(b))
+    case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
+    case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
+    case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
+    case DepConstraint(df, arg: Nat, t) => DepConstraint[NatKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(df, arg: DataType, t) =>
+      DepConstraint[DataKind](apply(df), apply(arg).asInstanceOf[DataType], apply(t))
+    case DepConstraint(df, arg: Type, t) =>
+      DepConstraint[TypeKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(df, arg: AddressSpace, t) =>
+      DepConstraint[AddressSpaceKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(df, arg: NatToData, t) =>
+      DepConstraint[NatToDataKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(df, arg: NatToNat, t) =>
+      DepConstraint[NatToNatKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(df, arg: NatCollection, t) =>
+      DepConstraint[NatCollectionKind](apply(df), apply(arg), apply(t))
+    case DepConstraint(_, _, _) => throw new Exception("Impossible case")
   }
 }

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -19,7 +19,7 @@ object NamedRewrite {
     }
     val typedLhs = infer(lhs, untypedFreeV, Set())
     val freeV = infer.collectFreeEnv(typedLhs)
-    val (_, freeT) = rise.core.IsClosedForm.freeVars(typedLhs)
+    val freeT = rise.core.IsClosedForm.freeVars(typedLhs)._2.toSet
     val typedRhs = infer(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
 
     trait PatVarStatus

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -19,7 +19,7 @@ object NamedRewrite {
     }
     val typedLhs = infer(lhs, untypedFreeV, Set())
     val freeV = infer.collectFreeEnv(typedLhs)
-    val freeT = rise.core.IsClosedForm.freeVars(typedLhs)._2.toSet
+    val freeT = rise.core.IsClosedForm.freeVars(typedLhs)._2.set
     val typedRhs = infer(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
 
     trait PatVarStatus

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -9,18 +9,18 @@ object NamedRewrite {
   def init(name: String,
            rule: (NamedRewriteDSL.Pattern, NamedRewriteDSL.Pattern)
           ): Rewrite[DefaultAnalysisData] = {
-    import rise.core.DSL.infer.{preservingWithEnv, collectFreeEnv}
+    import rise.core.DSL.infer
     import arithexpr.{arithmetic => ae}
 
     val (lhs, rhs) = rule
-    val untypedFreeV = collectFreeEnv(lhs).map { case (name, t) =>
+    val untypedFreeV = infer.collectFreeEnv(lhs).map { case (name, t) =>
       assert(t == rct.TypePlaceholder)
       name -> rct.TypeIdentifier("t" + name)
     }
-    val typedLhs = preservingWithEnv(lhs, untypedFreeV, Set())
-    val freeV = collectFreeEnv(typedLhs)
+    val typedLhs = infer(lhs, untypedFreeV, Set())
+    val freeV = infer.collectFreeEnv(typedLhs)
     val (_, freeT) = rise.core.IsClosedForm.freeVars(typedLhs)
-    val typedRhs = preservingWithEnv(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
+    val typedRhs = infer(rc.TypeAnnotation(rhs, typedLhs.t), freeV, freeT)
 
     trait PatVarStatus
     case object Unknown extends PatVarStatus

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -16,7 +16,8 @@ import scala.collection.mutable
 object fromRise {
   def apply(expr: r.Expr)(implicit ev: Traversable[Rise]): Phrase[_ <: PhraseType] = {
     if (!r.IsClosedForm(expr)) {
-      throw new Exception(s"expression is not in closed form: $expr\n\n with type ${expr.t}")
+      val (fV, fT) = r.IsClosedForm.varsToClose(expr)
+      throw new Exception(s"expression is not in closed form: $expr\n\n with type ${expr.t}\n free vars: $fV\n free type vars: $fT\n\n")
     }
     val bnfExpr = normalize(ev).apply(betaReduction)(expr).get
     val rwMap = inferAccess(bnfExpr)

--- a/src/test/scala/rise/core/dependentTypes.scala
+++ b/src/test/scala/rise/core/dependentTypes.scala
@@ -153,12 +153,13 @@ class dependentTypes extends test_util.Tests {
     function.asStringFromExpr(inferred)
   }
 
-  test("Simple nested") {
+  // Relies on the explicitly dependent work
+  ignore("Simple nested") {
     val e = depFun((n: Nat) => fun(n `*.` (i => (i+1) `.` f32))(array =>
         depMapSeq(depFun((_: Nat) => mapSeq(fun(x => x))))(array)
       ))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     assert(inferred.t =~=
@@ -167,12 +168,13 @@ class dependentTypes extends test_util.Tests {
     function.asStringFromExpr(inferred)
   }
 
-  test("Simple reduce") {
+  // Relies on the explicitly dependent work
+  ignore("Simple reduce") {
     val e = depFun((n: Nat) => fun(n `*.` (i => (i+1) `.` f32))(array =>
       depMapSeq(depFun((_: Nat) => reduceSeq(fun(x => fun(y => x + y)))(lf32(0.0f))))(array)
     ))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     assert(inferred.t =~=
@@ -201,7 +203,7 @@ class dependentTypes extends test_util.Tests {
       }
     ))))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     function.asStringFromExpr(inferred)


### PR DESCRIPTION
Currently we use a global set of type variables to `preserve`, but we still rely on explicitness information to preserve bound variables. Given that we have globally unique variable names we can simply add every bound variable to the set of variables to preserve. The `preserve` set needs to be modified in recursive calls to `solveOne` (we currently don't have to do that because we use `_.asImplicit` on some variables instead).

Fragment kinds and matrix layouts are now traversed too and their identifiers are correctly picked up. These identifiers are however ignored by `makeClosed`, because they cannot be bound.

`IsClosedForm` now correctly traverses lambdas, it used to skip their types.

It doesn't seem to make a noticeable impact on the performance of the test suite.