### PR TITLE
Rework rise's type identifiers; alias rise's `NatIdentifier`s to arithexpr's `NamedVar`

### DIFF
--- a/src/main/scala/rise/core/Builder.scala
+++ b/src/main/scala/rise/core/Builder.scala
@@ -7,11 +7,11 @@ trait Builder {
     throw new Exception("apply method must be overridden")
   def apply(e: DSL.ToBeTyped[Expr]): DSL.ToBeTyped[App] =
     DSL.app(DSL.toBeTyped(apply), e)
-  def apply(n: Nat): DSL.ToBeTyped[DepApp[Nat]] =
+  def apply(n: Nat): DSL.ToBeTyped[DepApp[Nat, _]] =
     DSL.depApp(NatKind, DSL.toBeTyped(apply), n)
-  def apply(dt: DataType): DSL.ToBeTyped[DepApp[DataType]] =
+  def apply(dt: DataType): DSL.ToBeTyped[DepApp[DataType, _]] =
     DSL.depApp(DataKind, DSL.toBeTyped(apply), dt)
-  def apply(a: AddressSpace): DSL.ToBeTyped[DepApp[AddressSpace]] =
+  def apply(a: AddressSpace): DSL.ToBeTyped[DepApp[AddressSpace, _]] =
     DSL.depApp(AddressSpaceKind, DSL.toBeTyped(apply), a)
 
   def unapply(arg: Expr): Boolean =

--- a/src/main/scala/rise/core/DSL/TopLevel.scala
+++ b/src/main/scala/rise/core/DSL/TopLevel.scala
@@ -3,6 +3,7 @@ package rise.core.DSL
 import Type.impl
 import util.monads._
 import rise.core.traverse._
+import rise.core.types.Kind._
 import rise.core.types._
 import rise.core.{DSL, Expr, IsClosedForm, Primitive}
 
@@ -27,26 +28,24 @@ object TopLevel {
       subs match {
         case s@Solution(ts, ns, as, ms, fs, n2ds, n2ns, natColls) =>
           ftv match {
-            case i: TypeIdentifier =>
+            case IType(i) =>
               s.copy(ts = ts ++ Map(i -> impl{ x: TypeIdentifier => x }))
-            case i: DataTypeIdentifier =>
+            case IDataType(i) =>
               s.copy(ts = ts ++ Map(i -> impl{ x: DataType => x }))
-            case i: NatIdentifier =>
+            case INat(i) =>
               s.copy(ns = ns ++ Map(i -> impl{ x: Nat => x }))
-            case i: AddressSpaceIdentifier =>
+            case IAddressSpace(i) =>
               s.copy(as = as ++ Map(i -> impl{ x: AddressSpace => x }))
-            case i: MatrixLayoutIdentifier =>
+            case IMatrixLayout(i) =>
               s.copy(ms = ms ++ Map(i -> impl{ x: MatrixLayout => x }))
-            case i: FragmentKindIdentifier =>
+            case IFragmentKind(i) =>
               s.copy(fs = fs ++ Map(i -> impl{ x: FragmentKind => x }))
-            case i: NatToDataIdentifier =>
+            case INatToData(i) =>
               s.copy(n2ds = n2ds ++ Map(i -> impl{ x: NatToData => x }))
-            case i: NatToNatIdentifier =>
+            case INatToNat(i) =>
               s.copy(n2ns = n2ns ++ Map(i -> impl{ x: NatToNat => x }))
-            case i: NatCollectionIdentifier =>
+            case INatCollection(i) =>
               s.copy(natColls = natColls ++ Map(i -> impl{ x: NatCollection => x }))
-            case i =>
-              throw TypeException(s"${i.getClass} is not supported yet")
           }
       }
     )

--- a/src/main/scala/rise/core/DSL/Type.scala
+++ b/src/main/scala/rise/core/DSL/Type.scala
@@ -1,6 +1,7 @@
 package rise.core.DSL
 
 import arithexpr.arithmetic.{Cst, RangeAdd}
+import rise.core.types.Kind.{IAddressSpace, INat, INatToNat}
 import rise.core.types._
 import rise.core.{Expr, freshName}
 
@@ -168,12 +169,12 @@ object Type {
   }
 
   object `:Nat **` {
-    def unapply(arg: DepPairType[Nat, NatIdentifier]): Option[(NatIdentifier, DataType)] =
+    def unapply(arg: DepPairType[Nat, NatIdentifier, _]): Option[(NatIdentifier, DataType)] =
       Some(arg.x, arg.t)
   }
 
   object `:NatCollection **` {
-    def unapply(arg: DepPairType[NatCollection, NatCollectionIdentifier]): Option[(NatCollectionIdentifier, DataType)] =
+    def unapply(arg: DepPairType[NatCollection, NatCollectionIdentifier, _]): Option[(NatCollectionIdentifier, DataType)] =
       Some(arg.x, arg.t)
   }
 
@@ -191,27 +192,27 @@ object Type {
   }
 
   object `(Addr)->:` {
-    def unapply[T, I <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, U]): Option[(AddressSpaceIdentifier, U)] = {
+    def unapply[T, I, KI <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, KI, U]): Option[(AddressSpaceIdentifier, U)] = {
       funType.x match {
-        case a: AddressSpaceIdentifier => Some((a, funType.t))
+        case a : AddressSpaceIdentifier => Some((a, funType.t))
         case _ => throw new Exception("Expected AddressSpace DepFunType")
       }
     }
   }
 
   object `(Nat)->:` {
-    def unapply[T, I <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, U]): Option[(NatIdentifier, U)] = {
+    def unapply[T, I, KI <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, KI, U]): Option[(NatIdentifier, U)] = {
       funType.x match {
-        case n: NatIdentifier => Some((n, funType.t))
+        case n : NatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected Nat DepFunType")
       }
     }
   }
 
   object `(NatToNat)->:` {
-    def unapply[T, I <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, U]): Option[(NatToNatIdentifier, U)] = {
+    def unapply[T, I, KI <: Kind.Identifier, U <: Type](funType: DepFunType[T, I, KI, U]): Option[(NatToNatIdentifier, U)] = {
       funType.x match {
-        case n: NatToNatIdentifier => Some((n, funType.t))
+        case n : NatToNatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected NatToNat DepFunType")
       }
     }

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -19,9 +19,9 @@ package object DSL {
     x >>= (x => e >>= (e => toBeTyped(Lambda(x, e)(TypePlaceholder))))
   def app(f: ToBeTyped[Expr], e: ToBeTyped[Expr]): ToBeTyped[App] =
     f >>= (f => e >>= (e => toBeTyped(App(f, e)(TypePlaceholder))))
-  def depLambda[T, I <: Kind.Identifier](kind: Kind[T, I],x: I, e: ToBeTyped[Expr]): ToBeTyped[DepLambda[T, I]] =
+  def depLambda[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I, e: ToBeTyped[Expr]): ToBeTyped[DepLambda[T, I, KI]] =
     e >>= (e => toBeTyped(DepLambda(kind, x, e)(TypePlaceholder)))
-  def depApp[T](kind: Kind[T, _ <: Kind.Identifier], f: ToBeTyped[Expr], x: T): ToBeTyped[DepApp[T]] =
+  def depApp[T, KI <: Kind.Identifier](kind: Kind[T, _, KI], f: ToBeTyped[Expr], x: T): ToBeTyped[DepApp[T, KI]] =
     f >>= (f => toBeTyped(DepApp(kind, f, x)(TypePlaceholder)))
   def literal(d: semantics.Data): ToBeTyped[Literal] = toBeTyped(Literal(d))
 
@@ -106,15 +106,15 @@ package object DSL {
               e5: ToBeTyped[Expr]): ToBeTyped[App] =
       f(e1)(e2)(e3)(e4)(e5)
 
-    def apply(n: Nat): ToBeTyped[DepApp[Nat]] =
+    def apply(n: Nat): ToBeTyped[DepApp[Nat, _]] =
       depApp(NatKind, f, n)
-    def apply(dt: DataType): ToBeTyped[DepApp[DataType]] =
+    def apply(dt: DataType): ToBeTyped[DepApp[DataType, _]] =
       depApp(DataKind, f, dt)
-    def apply(a: AddressSpace): ToBeTyped[DepApp[AddressSpace]] =
+    def apply(a: AddressSpace): ToBeTyped[DepApp[AddressSpace, _]] =
       depApp(AddressSpaceKind, f, a)
-    def apply(n2n: NatToNat): ToBeTyped[DepApp[NatToNat]] =
+    def apply(n2n: NatToNat): ToBeTyped[DepApp[NatToNat, _]] =
       depApp(NatToNatKind, f, n2n)
-    def apply(n2d: NatToData): ToBeTyped[DepApp[NatToData]] =
+    def apply(n2d: NatToData): ToBeTyped[DepApp[NatToData, _]] =
       depApp(NatToDataKind, f, n2d)
   }
 
@@ -402,34 +402,34 @@ package object DSL {
   object depFun {
     def apply(r: arithexpr.arithmetic.Range,
               w: NatFunction1Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val n = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n, w.f(n))
     }
 
     def apply(w: NatFunction1Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n, w.f(n))
     }
 
     def apply(w: NatFunction2Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n1 = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n1, depFun((n2: Nat) => w.f(n1, n2)))
     }
 
     def apply(w: NatFunction3Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n1 = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n1, depFun((n2: Nat, n3: Nat) => w.f(n1, n2, n3)))
     }
 
     def apply(w: NatFunction4Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n1 = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n1, depFun((n2: Nat, n3: Nat, n4: Nat) =>
@@ -437,7 +437,7 @@ package object DSL {
     }
 
     def apply(w: NatFunction5Wrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+             ): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
       val r = arithexpr.arithmetic.RangeAdd(0, arithexpr.arithmetic.PosInf, 1)
       val n1 = NatIdentifier(freshName("n"), r)
       depLambda(NatKind, n1, depFun((n2: Nat, n3: Nat, n4: Nat, n5: Nat) =>
@@ -445,25 +445,25 @@ package object DSL {
     }
 
     def apply(w: DataTypeFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[DataType, DataTypeIdentifier]] = {
+             ): ToBeTyped[DepLambda[DataType, DataTypeIdentifier, _]] = {
       val x = DataTypeIdentifier(freshName("dt"))
       depLambda(DataKind, x, w.f(x))
     }
 
     def apply(w: NatToDataFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatToData, NatToDataIdentifier]] = {
+             ): ToBeTyped[DepLambda[NatToData, NatToDataIdentifier, _]] = {
       val x = NatToDataIdentifier(freshName("n2d"))
       depLambda(NatToDataKind, x, w.f(x))
     }
 
     def apply(w: NatToNatFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[NatToNat, NatToNatIdentifier]] = {
+             ): ToBeTyped[DepLambda[NatToNat, NatToNatIdentifier, _]] = {
       val x = NatToNatIdentifier(freshName("n2n"))
       depLambda(NatToNatKind, x, w.f(x))
     }
 
     def apply(w: AddressSpaceFunctionWrapper[ToBeTyped[Expr]]
-             ): ToBeTyped[DepLambda[AddressSpace, AddressSpaceIdentifier]] = {
+             ): ToBeTyped[DepLambda[AddressSpace, AddressSpaceIdentifier, _]] = {
       val x = AddressSpaceIdentifier(freshName("a"))
       depLambda(AddressSpaceKind, x, w.f(x))
     }

--- a/src/main/scala/rise/core/Expr.scala
+++ b/src/main/scala/rise/core/Expr.scala
@@ -30,13 +30,13 @@ final case class App(f: Expr, e: Expr)(override val t: Type)
   override def setType(t: Type): App = this.copy(f, e)(t)
 }
 
-final case class DepLambda[T, I <: Kind.Identifier](kind: Kind[T, I],x: I, e: Expr)(override val t: Type) extends Expr {
+final case class DepLambda[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI],x: I, e: Expr)(override val t: Type) extends Expr {
   val kindName: String = kind.name
-  override def setType(t: Type): DepLambda[T, I] = this.copy(kind, x, e)(t)
+  override def setType(t: Type): DepLambda[T, I, KI] = this.copy(kind, x, e)(t)
 }
 
-final case class DepApp[T](kind: Kind[T, _ <: Kind.Identifier], f: Expr, x: T)(override val t: Type) extends Expr {
-  override def setType(t: Type): DepApp[T] = this.copy(kind, f, x)(t)
+final case class DepApp[T, KI <: Kind.Identifier](kind: Kind[T, _, KI], f: Expr, x: T)(override val t: Type) extends Expr {
+  override def setType(t: Type): DepApp[T, KI] = this.copy(kind, f, x)(t)
 }
 
 final case class Literal(d: semantics.Data) extends Expr {

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -47,7 +47,7 @@ object IsClosedForm {
 
     override def nat: Nat => Pair[Nat] = n => {
       val free = n.varList.foldLeft(OrderedSet.empty[Kind.Identifier]) {
-        case (free, v: NamedVar) if !boundT(INat(NatIdentifier(v))) => OrderedSet.add(INat(NatIdentifier(v)) : Kind.Identifier)(free)
+        case (free, v: NamedVar) if !boundT(INat(v)) => OrderedSet.add(INat(v) : Kind.Identifier)(free)
         case (free, _) => free
       }
       accumulate((OrderedSet.empty, free))(n)

--- a/src/main/scala/rise/core/dotPrinter.scala
+++ b/src/main/scala/rise/core/dotPrinter.scala
@@ -1,6 +1,6 @@
 package rise.core
 
-import rise.core.types.Type
+import rise.core.types.{Kind, Type}
 
 // scalastyle:off indentation multiple.string.literals method.length
 case object dotPrinter {
@@ -120,12 +120,12 @@ case object dotPrinter {
           s"""$parent ${attr(fillWhite + Label("Λ").bold.toString)}
             |$parent -> $id ${edgeLabel("id")};
             |$parent -> $expr ${edgeLabel("body")};
-            |$id ${attr(fillWhite + Label(x.name).orange.toString)}
+            |$id ${attr(fillWhite + Label(Kind.idName(kind, x)).orange.toString)}
             |${recurse(e, expr)}""".stripMargin
 
-        case DepLambda(_, x, e) if inlineLambdaIdentifier =>
+        case DepLambda(kind, x, e) if inlineLambdaIdentifier =>
           val expr = getID(e)
-          s"""$parent ${attr(fillWhite + Label(s"Λ.${x.name}").toString)}
+          s"""$parent ${attr(fillWhite + Label(s"Λ.${Kind.idName(kind, x)}").toString)}
             |$parent -> $expr ${edgeLabel("body")};
             |${recurse(e, expr)}""".stripMargin
 

--- a/src/main/scala/rise/core/lifting.scala
+++ b/src/main/scala/rise/core/lifting.scala
@@ -42,9 +42,9 @@ object lifting {
     }
   }
 
-  def liftDepFunExpr[T](kind: Kind[T, _ <: Kind.Identifier], p: Expr): Result[T => Expr] = {
+  def liftDepFunExpr[T, KI <: Kind.Identifier](kind: Kind[T, _, KI], p: Expr): Result[T => Expr] = {
     def chain(r: Result[Expr]): Result[T => Expr] =
-      r.bind(liftDepFunExpr[T](kind, _), f => Expanding((x: T) => depApp(kind, f, x)))
+      r.bind(liftDepFunExpr[T, KI](kind, _), f => Expanding((x: T) => depApp(kind, f, x)))
 
     p match {
       case DepLambda(kind, x, e) =>
@@ -55,9 +55,9 @@ object lifting {
     }
   }
 
-  def liftDependentFunctionType[T, I <: Kind.Identifier](kind: Kind[T, I], ty: Type): T => Type = {
+  def liftDependentFunctionType[T, I](kind: Kind[T, I, _], ty: Type): T => Type = {
     ty match {
-      case DepFunType(_, x, t) =>
+      case DepFunType(kind, x, t) =>
         (a: T) => substitute.kindInType(kind, a, `for` = x, in = t)
       case _ => throw new Exception(s"did not expect $ty")
     }

--- a/src/main/scala/rise/core/makeClosed.scala
+++ b/src/main/scala/rise/core/makeClosed.scala
@@ -1,5 +1,7 @@
 package rise.core
 
+import rise.core.types.Kind.{IAddressSpace, IDataType, INat, INatToData, INatToNat, IType}
+
 import scala.collection.immutable.Map
 import rise.core.types._
 
@@ -9,16 +11,16 @@ object makeClosed {
     val (_, ftvs) = IsClosedForm.varsToClose(e)
     val (expr, ts) = ftvs.foldLeft((e, Map[Type, Type]()))((acc, ftv) => acc match {
       case (expr, ts) => ftv match {
-        case i: TypeIdentifier =>
+        case IType(i) =>
           val dt = DataTypeIdentifier(freshName("dt"))
           (DepLambda(DataKind, dt, expr)(DepFunType(DataKind, dt, expr.t)), (ts ++ Map(i -> dt)))
-        case i: DataTypeIdentifier =>
+        case IDataType(i) =>
           (DepLambda(DataKind, i, expr)(DepFunType(DataKind, i, expr.t)), ts)
-        case i: NatIdentifier =>
+        case INat(i) =>
           (DepLambda(NatKind, i, expr)(DepFunType(NatKind, i, expr.t)), ts)
-        case i: AddressSpaceIdentifier =>
+        case IAddressSpace(i) =>
           (DepLambda(AddressSpaceKind, i, expr)(DepFunType(AddressSpaceKind, i, expr.t)), ts)
-        case i: NatToDataIdentifier =>
+        case INatToData(i) =>
           (DepLambda(NatToDataKind, i, expr)(DepFunType(NatToDataKind, i, expr.t)), ts)
         case i => throw TypeException(s"${i.getClass} is not supported yet")
       }

--- a/src/main/scala/rise/core/showRise.scala
+++ b/src/main/scala/rise/core/showRise.scala
@@ -1,5 +1,6 @@
 package rise.core
 
+import rise.core.types.Kind
 import rise.core.DrawTree.UnicodeConfig
 
 case class RenderException(msg: String) extends Exception {
@@ -243,8 +244,8 @@ class ShowRiseCompact {
         (false, newSize, fr >@> (fd => er >@> (ed => fd :+> ed)))
       }
 
-    case dl @ DepLambda(_, x, e) =>
-      val xs = s"${x.name}:${dl.kindName}"
+    case dl @ DepLambda(k, x, e) =>
+      val xs = s"${Kind.idName(k, x)}:${dl.kindName}"
       val (eInline, eSize, er) = drawAST(e)
       val newSize = eSize + 1
       if ((inlineSize > 0) && eInline) {
@@ -258,8 +259,8 @@ class ShowRiseCompact {
 
     case DepApp(kind, f, x) =>
       val (fInline, fSize, fr) = f match {
-        case _: DepLambda[_, _] => drawAST(f, wrapped = true)
-        case _                  => drawAST(f)
+        case _: DepLambda[_, _, _] => drawAST(f, wrapped = true)
+        case _                     => drawAST(f)
       }
       val xs = x.toString
       val newSize = fSize + 1

--- a/src/main/scala/rise/core/showScala.scala
+++ b/src/main/scala/rise/core/showScala.scala
@@ -1,16 +1,13 @@
 package rise.core
 
+import rise.core.types.Kind.{IDataType, INat}
 import rise.core.types._
 
 object showScala {
-  private def kindIdent[I <: Kind.Identifier](x: I): String = {
-    x match {
-      case n: NatIdentifier =>
-        s"""NatIdentifier("${n.name}", ${n.range})"""
-      case DataTypeIdentifier(n) =>
-        s"""DataTypeIdentifier("$n")"""
-      case _ => throw new Exception(s"missing rule for $x")
-    }
+  private val kindIdent : Kind.Identifier => String = {
+    case INat(n) => s"""NatIdentifier("${n.name}", ${n.range})"""
+    case IDataType(n) => s"""DataTypeIdentifier("$n")"""
+    case x => throw new Exception(s"missing rule for $x")
   }
 
   def nat(n: Nat): String = {
@@ -48,8 +45,8 @@ object showScala {
       case TypeIdentifier(n) => s"""TypeIdentifier("$n")"""
       case FunType(inT, outT) =>
         s"FunType(${`type`(inT)}, ${`type`(outT)})"
-      case DepFunType(_, x, t) =>
-        s"DepFunType(${kindIdent(x)}, ${`type`(t)})"
+      case DepFunType(k, x, t) =>
+        s"DepFunType(${kindIdent(Kind.toIdentifier(k, x))}, ${`type`(t)})"
       case DataTypeIdentifier(n) => s"""DataTypeIdentifier("$n")"""
       case ArrayType(n, e) =>
         s"ArrayType(${nat(n)}, ${`type`(e)})"
@@ -74,12 +71,12 @@ object showScala {
       case Literal(d) => s"Literal(${data(d)})"
       case App(f, a) => s"App(${expr(f)}, ${expr(a)})(${`type`(e.t)})"
       case Lambda(x, b) => s"Lambda(${expr(x)}, ${expr(b)})(${`type`(e.t)})"
-      case DepApp(NatKind, f, v: Nat) =>
+      case DepApp(_, f, v: Nat) =>
         s"DepApp(NatKind, ${expr(f)}, $v)(${`type`(e.t)})"
-      case DepApp(AddressSpaceKind, f, v: AddressSpace) =>
+      case DepApp(_, f, v: AddressSpace) =>
         s"DepApp(AddressSpaceKind, ${expr(f)}, $v)(${`type`(e.t)})"
       case DepApp(_, _, _) => ???
-      case DepLambda(_, x, b) => s"DepLambda(${kindIdent(x)}, ${expr(b)})(${`type`(e.t)})"
+      case DepLambda(k, x, b) => s"DepLambda(${kindIdent(Kind.toIdentifier(k, x))}, ${expr(b)})(${`type`(e.t)})"
     }
   }
 }

--- a/src/main/scala/rise/core/showScala.scala
+++ b/src/main/scala/rise/core/showScala.scala
@@ -13,10 +13,7 @@ object showScala {
   def nat(n: Nat): String = {
     import arithexpr.arithmetic._
     n match {
-      case n: NatIdentifier =>
-        s"""NatIdentifier("${n.name}", ${n.range})"""
-      case n: NamedVar =>
-        s"""NamedVar("${n.name}", ${n.range})"""
+      case n: NatIdentifier => s"""NatIdentifier("${n.name}", ${n.range})"""
       case Prod(factors) => factors.map(nat).mkString("(", " * ", ")")
       case Sum(terms) => terms.map(nat).mkString("(", " + ", ")")
       case Cst(c) => s"Cst($c)"

--- a/src/main/scala/rise/core/substitute.scala
+++ b/src/main/scala/rise/core/substitute.scala
@@ -9,7 +9,7 @@ object substitute {
 
   // substitute in Expr
 
-  def kindInExpr[T, I <: Kind.Identifier](kind: Kind[T, I], x: T, `for`: I, in: Expr): Expr =
+  def kindInExpr[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: T, `for`: I, in: Expr): Expr =
     (kind, x, `for`) match {
       case (DataKind, dt: DataType, forDt: DataTypeIdentifier) =>
         dataTypeInExpr(dt, forDt, in)
@@ -100,7 +100,7 @@ object substitute {
 
   // substitute in Type
 
-  def kindInType[T, I <: Kind.Identifier, U <: Type](kind: Kind[T, I], x: T, `for`: I, in: U): U = {
+  def kindInType[T, I, KI <: Kind.Identifier, U <: Type](kind: Kind[T, I, KI], x: T, `for`: I, in: U): U = {
     (kind, x, `for`) match {
       case (DataKind, dt: DataType, forDt: DataTypeIdentifier) => typeInType(dt, forDt, in)
       case (NatKind, n: Nat, forN: NatIdentifier) => natInType(n, forN, in)

--- a/src/main/scala/rise/core/typedLifting.scala
+++ b/src/main/scala/rise/core/typedLifting.scala
@@ -27,7 +27,7 @@ object typedLifting {
     }
   }
 
-  def liftDepFunExpr[T](kind: Kind[T, _ <: Kind.Identifier], p: Expr): Result[T => Expr] = {
+  def liftDepFunExpr[T,KI <: Kind.Identifier](kind: Kind[T, _, KI], p: Expr): Result[T => Expr] = {
     def chain(r: Result[Expr]): Result[T => Expr] =
       r.bind(
         liftDepFunExpr(kind, _),

--- a/src/main/scala/rise/core/types/AddressSpace.scala
+++ b/src/main/scala/rise/core/types/AddressSpace.scala
@@ -3,7 +3,7 @@ package rise.core.types
 // TODO: should not be in the core
 sealed trait AddressSpace
 
-final case class AddressSpaceIdentifier( name: String) extends AddressSpace with Kind.Identifier {
+final case class AddressSpaceIdentifier( name: String) extends AddressSpace {
   override def toString: String = name
 }
 

--- a/src/main/scala/rise/core/types/Kinds.scala
+++ b/src/main/scala/rise/core/types/Kinds.scala
@@ -1,39 +1,77 @@
 package rise.core.types
 
-sealed trait Kind[+T, +I <: Kind.Identifier] {
+sealed trait Kind[+T, +I, KI <: Kind.Identifier] {
   def name :String
 }
 
+
 object Kind {
-  trait Identifier {
-    def name: String
+  trait Identifier { def name: String }
+  case class IType(id : TypeIdentifier) extends Identifier { def name : String = id.name }
+  case class IDataType(id : DataTypeIdentifier) extends Identifier { def name : String = id.name }
+  case class INat(id : NatIdentifier) extends Identifier { def name : String = id.name }
+  case class IAddressSpace(id : AddressSpaceIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToNat(id : NatToNatIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToData(id : NatToDataIdentifier) extends Identifier { def name : String = id.name }
+  case class IMatrixLayout(id : MatrixLayoutIdentifier) extends Identifier { def name : String = id.name }
+  case class IFragmentKind(id : FragmentKindIdentifier) extends Identifier { def name : String = id.name }
+  case class INatCollection(id : NatCollectionIdentifier) extends Identifier { def name : String = id.name }
+
+  def idName[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : String = kind match {
+    case TypeKind => i.asInstanceOf[TypeIdentifier].name
+    case DataKind => i.asInstanceOf[DataTypeIdentifier].name
+    case NatKind => i.asInstanceOf[NatIdentifier].name
+    case AddressSpaceKind => i.asInstanceOf[AddressSpaceIdentifier].name
+    case NatToNatKind => i.asInstanceOf[NatToNatIdentifier].name
+    case NatToDataKind => i.asInstanceOf[NatToDataIdentifier].name
+    case NatCollectionKind => i.asInstanceOf[NatCollectionIdentifier].name
+  }
+
+  def toIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : KI = kind match {
+    case TypeKind => IType(i.asInstanceOf[TypeIdentifier]).asInstanceOf[KI]
+    case DataKind => IDataType(i.asInstanceOf[DataTypeIdentifier]).asInstanceOf[KI]
+    case NatKind => INat(i.asInstanceOf[NatIdentifier]).asInstanceOf[KI]
+    case AddressSpaceKind => IAddressSpace(i.asInstanceOf[AddressSpaceIdentifier]).asInstanceOf[KI]
+    case NatToNatKind => INatToNat(i.asInstanceOf[NatToNatIdentifier]).asInstanceOf[KI]
+    case NatToDataKind => INatToData(i.asInstanceOf[NatToDataIdentifier]).asInstanceOf[KI]
+    case NatCollectionKind => INatCollection(i.asInstanceOf[NatCollectionIdentifier]).asInstanceOf[KI]
+  }
+
+  def fromIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : KI) : I = kind match {
+    case TypeKind => i.asInstanceOf[IType].id.asInstanceOf[I]
+    case DataKind => i.asInstanceOf[IDataType].id.asInstanceOf[I]
+    case NatKind => i.asInstanceOf[INat].id.asInstanceOf[I]
+    case AddressSpaceKind => i.asInstanceOf[IAddressSpace].id.asInstanceOf[I]
+    case NatToNatKind => i.asInstanceOf[INatToNat].id.asInstanceOf[I]
+    case NatToDataKind => i.asInstanceOf[INatToData].id.asInstanceOf[I]
+    case NatCollectionKind => i.asInstanceOf[INatCollection].id.asInstanceOf[I]
   }
 }
 
-case object TypeKind extends Kind[Type, TypeIdentifier] {
+case object TypeKind extends Kind[Type, TypeIdentifier, Kind.IType] {
   override def name: String = "type"
 }
 
-case object DataKind extends Kind[DataType, DataTypeIdentifier] {
+case object DataKind extends Kind[DataType, DataTypeIdentifier, Kind.IDataType] {
   override def name: String = "data"
 }
 
-case object NatKind extends Kind[Nat, NatIdentifier] {
+case object NatKind extends Kind[Nat, NatIdentifier, Kind.INat] {
   override def name: String = "nat"
 }
 
-case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier] {
+case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier, Kind.IAddressSpace] {
   override def name: String = "addressSpace"
 }
 
-case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier] {
+case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier, Kind.INatToNat] {
   override def name: String = "nat->nat"
 }
 
-case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier] {
+case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier, Kind.INatToData] {
   override def name: String = "nat->data"
 }
 
-case object NatCollectionKind extends Kind[NatCollection, NatCollectionIdentifier] {
+case object NatCollectionKind extends Kind[NatCollection, NatCollectionIdentifier, Kind.INatCollection] {
   override def name: String = "nats"
 }

--- a/src/main/scala/rise/core/types/Nat.scala
+++ b/src/main/scala/rise/core/types/Nat.scala
@@ -4,17 +4,9 @@ import arithexpr.arithmetic._
 import rise.core.types
 
 
-class NatIdentifier(override val name: String, override val range: Range = RangeUnknown) extends NamedVar(name, range) {
-  override lazy val toString: String = name
-  override def copy(r: Range): NatIdentifier = new NatIdentifier(name, r)
-  override def cloneSimplified(): NatIdentifier with SimplifiedExpr =
-    new NatIdentifier(name, range) with SimplifiedExpr
-}
-
 object NatIdentifier {
-  def apply(name: String): NatIdentifier = new NatIdentifier(name)
-  def apply(name: String, range: Range): NatIdentifier = new NatIdentifier(name, range)
-  def apply(nv: NamedVar): NatIdentifier = new NatIdentifier(nv.name, nv.range)
+  def apply(name: String): NatIdentifier = new NamedVar(name)
+  def apply(name: String, range: Range): NatIdentifier = new NamedVar(name, range)
 }
 
 final class NatToNatApply(val f: NatToNat, val n: Nat)

--- a/src/main/scala/rise/core/types/Nat.scala
+++ b/src/main/scala/rise/core/types/Nat.scala
@@ -4,8 +4,7 @@ import arithexpr.arithmetic._
 import rise.core.types
 
 
-class NatIdentifier(override val name: String, override val range: Range = RangeUnknown)
-  extends NamedVar(name, range) with types.Kind.Identifier {
+class NatIdentifier(override val name: String, override val range: Range = RangeUnknown) extends NamedVar(name, range) {
   override lazy val toString: String = name
   override def copy(r: Range): NatIdentifier = new NatIdentifier(name, r)
   override def cloneSimplified(): NatIdentifier with SimplifiedExpr =

--- a/src/main/scala/rise/core/types/NatCollection.scala
+++ b/src/main/scala/rise/core/types/NatCollection.scala
@@ -26,7 +26,7 @@ sealed abstract class NatCollection {
   def apply(idxs: Nat*): Nat = new NatCollectionIndexing(this, idxs)
 }
 
-final case class NatCollectionIdentifier(name: String) extends NatCollection with Kind.Identifier {
+final case class NatCollectionIdentifier(name: String) extends NatCollection {
   override def toString: String = name
 }
 

--- a/src/main/scala/rise/core/types/NatToData.scala
+++ b/src/main/scala/rise/core/types/NatToData.scala
@@ -11,7 +11,7 @@ sealed trait NatToData {
   def apply(n: Nat): DataType = NatToDataApply(this, n)
 }
 
-final case class NatToDataIdentifier(name: String) extends NatToData with Kind.Identifier {
+final case class NatToDataIdentifier(name: String) extends NatToData {
   override def toString: String = name
 }
 

--- a/src/main/scala/rise/core/types/NatToNat.scala
+++ b/src/main/scala/rise/core/types/NatToNat.scala
@@ -6,7 +6,7 @@ sealed trait NatToNat {
   def apply(n: Nat): Nat = NatToNatApply(this, n)
 }
 
-final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier {
+final case class NatToNatIdentifier(name: String) extends NatToNat {
   override def toString: String = name
 }
 

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -91,7 +91,6 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToDataLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToDataLambda(xSub, apply(body).asInstanceOf[DataType])
@@ -104,7 +103,6 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToNatLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToNatLambda(xSub, apply(body))

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -141,18 +141,18 @@ case class Solution(ts: Map[Type, Type],
     case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
     case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
     case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
-    case DepConstraint(NatKind, df, arg: Nat, t) => DepConstraint(NatKind, apply(df), apply(arg), apply(t))
-    case DepConstraint(DataKind, df, arg: DataType, t) =>
+    case DepConstraint(_, df, arg: Nat, t) => DepConstraint(NatKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(_, df, arg: DataType, t) =>
       DepConstraint(DataKind, apply(df), apply(arg).asInstanceOf[DataType], apply(t))
-    case DepConstraint(TypeKind, df, arg: Type, t) =>
+    case DepConstraint(_, df, arg: Type, t) =>
       DepConstraint(TypeKind, apply(df), apply(arg), apply(t))
-    case DepConstraint(AddressSpaceKind, df, arg: AddressSpace, t) =>
+    case DepConstraint(_, df, arg: AddressSpace, t) =>
       DepConstraint(AddressSpaceKind, apply(df), apply(arg), apply(t))
-    case DepConstraint(NatToDataKind, df, arg: NatToData, t) =>
+    case DepConstraint(_, df, arg: NatToData, t) =>
       DepConstraint(NatToDataKind, apply(df), apply(arg), apply(t))
-    case DepConstraint(NatToNatKind, df, arg: NatToNat, t) =>
+    case DepConstraint(_, df, arg: NatToNat, t) =>
       DepConstraint(NatToNatKind, apply(df), apply(arg), apply(t))
-    case DepConstraint(NatCollectionKind, df, arg: NatCollection, t) =>
+    case DepConstraint(_, df, arg: NatCollection, t) =>
       DepConstraint(NatCollectionKind, apply(df), apply(arg), apply(t))
     case DepConstraint(_, _, _, _) => throw new Exception("Impossible case")
   }

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -13,7 +13,7 @@ object TypePlaceholder extends Type {
   override def toString: String = "?"
 }
 
-final case class TypeIdentifier(name: String) extends Type with Kind.Identifier {
+final case class TypeIdentifier(name: String) extends Type {
   override def toString: String = "_" + name
 }
 
@@ -22,17 +22,16 @@ final case class FunType[T <: Type, U <: Type](inT: T, outT: U)
   override def toString: String = s"($inT -> $outT)"
 }
 
-final case class DepFunType[T, I <: Kind.Identifier, U <: Type]
-                           (kind: Kind[T, I],x: I, t: U) extends Type {
+final case class DepFunType[T, I, KI <: Kind.Identifier, U <: Type] (kind: Kind[T, I, KI],x: I, t: U) extends Type {
   override def toString: String =
-    s"(${x.name}: ${kind.name} -> $t)"
+    s"(${Kind.idName(kind, x)}: ${kind.name} -> $t)"
 }
 
 // == Data types ==============================================================
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(name: String) extends DataType with Kind.Identifier {
+final case class DataTypeIdentifier(name: String) extends DataType {
   override def toString: String = name
 }
 
@@ -88,7 +87,7 @@ object MatrixLayout {
   object None extends MatrixLayout
 }
 
-final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout with Kind.Identifier {
+final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout {
   override def toString: String = name
 }
 
@@ -100,7 +99,7 @@ object FragmentKind {
   object Accumulator extends FragmentKind { override def toString = "Accumulator"}
 }
 
-final case class FragmentKindIdentifier(name: String) extends FragmentKind with Kind.Identifier {
+final case class FragmentKindIdentifier(name: String) extends FragmentKind {
   override def toString: String = name
 }
 
@@ -129,8 +128,8 @@ final case class ManagedBufferType(dt: DataType) extends DataType {
 
 }
 
-final case class DepPairType[T, I <: Kind.Identifier](kind: Kind[T, I], x: I, t: DataType) extends DataType {
-  override def toString: String = s"(${x.name}: ${kind.name} ** $t)"
+final case class DepPairType[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I, t: DataType) extends DataType {
+  override def toString: String = s"(${Kind.idName(kind, x)}: ${kind.name} ** $t)"
 }
 
 

--- a/src/main/scala/rise/core/types/check.scala
+++ b/src/main/scala/rise/core/types/check.scala
@@ -48,12 +48,12 @@ object check {
       expr `:` DepFunType(kind, x, t)
 
     case DepApp(kind, f, e) =>
-      val (x, t) = ctx `|-` f match {
-        case DepFunType(kind2, x, t) if kind == kind2 => (x, t)
+      val (k, x, t) = ctx `|-` f match {
+        case DepFunType(kind2, x, t) if kind == kind2 => (kind2, x, t)
         case t => throw TypeException(s"expected dependent function type and got $t")
       }
       // ----------- DepApp
-      expr `:` substitute.kindInType(kind, e, `for`= x, in = t)
+      expr `:` substitute.kindInType(k, e, `for`= x, in = t)
 
     case Literal(d) =>
       // ----------- Literal

--- a/src/main/scala/rise/core/types/package.scala
+++ b/src/main/scala/rise/core/types/package.scala
@@ -7,15 +7,15 @@ package object types {
 
   type ->[T1 <: Type, T2 <: Type] = FunType[T1, T2]
 
-  type `(dt)->`[T <: Type] = DataDepFunType[T]
-  type DataDepFunType[T <: Type] = DepFunType[DataType, DataTypeIdentifier, T]
+  type `(dt)->`[T <: Type, KI <: Kind.Identifier] = DataDepFunType[T, KI]
+  type DataDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[DataType, DataTypeIdentifier, KI, T]
 
-  type `(nat)->`[T <: Type] = NatDepFunType[T]
-  type NatDepFunType[T <: Type] = DepFunType[Nat, NatIdentifier, T]
+  type `(nat)->`[T <: Type, KI <: Kind.Identifier] = NatDepFunType[T, KI]
+  type NatDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[Nat, NatIdentifier, KI, T]
 
-  type `(nat->nat)->`[T <: Type] = NatToNatDepFunType[T]
-  type NatToNatDepFunType[T <: Type] = DepFunType[NatToNat, NatToNatIdentifier, T]
+  type `(nat->nat)->`[T <: Type, KI <: Kind.Identifier] = NatToNatDepFunType[T, KI]
+  type NatToNatDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[NatToNat, NatToNatIdentifier, KI, T]
 
-  type `(nat->data)->`[T <: Type] = NatToDataDepFunType[T]
-  type NatToDataDepFunType[T <: Type] = DepFunType[NatToData, NatToDataIdentifier, T]
+  type `(nat->data)->`[T <: Type, KI <: Kind.Identifier] = NatToDataDepFunType[T, KI]
+  type NatToDataDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[NatToData, NatToDataIdentifier, KI, T]
 }

--- a/src/main/scala/rise/core/types/package.scala
+++ b/src/main/scala/rise/core/types/package.scala
@@ -1,8 +1,9 @@
 package rise.core
 
-import arithexpr.arithmetic.ArithExpr
+import arithexpr.arithmetic.{ArithExpr, NamedVar}
 
 package object types {
+  type NatIdentifier = NamedVar
   type Nat = ArithExpr
 
   type ->[T1 <: Type, T2 <: Type] = FunType[T1, T2]

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -2,6 +2,7 @@ package rise.core
 
 import util.monads._
 import rise.core.traverse._
+import rise.core.types.Kind.{IAddressSpace, IDataType, INat}
 import rise.core.types._
 
 object uniqueNames {
@@ -47,85 +48,89 @@ object uniqueNames {
       aN
     }
 
-    def renameInExpr(e: Expr)(values: Map[Identifier, Identifier],
-                              types: Map[Kind.Identifier, Kind.Identifier]): Pure[Expr] =
-      Renaming(values, types).expr(e)
+    def renameInExpr(e: Expr)(
+      values: Map[Identifier, Identifier],
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
+    ): Pure[Expr] = Renaming(values, nats, dts, ass).expr(e)
 
-    def renameInTypes[T <: Type](t: T)(types: Map[Kind.Identifier, Kind.Identifier]): Pure[T] =
-      Renaming(Map(), types).`type`(t)
+    def renameInTypes[T <: Type](t: T)(
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
+    ): Pure[T] = Renaming(Map(), nats, dts, ass).`type`(t)
 
-    def renameInNat(n: Nat)(types: Map[Kind.Identifier, Kind.Identifier]): Nat = {
+    def renameInNat(n: Nat)(types: Map[NatIdentifier, NatIdentifier]): Nat = {
       n.visitAndRebuild({
-        case i: NatIdentifier =>
-          types.get(i)
-            .map(_.asInstanceOf[NatIdentifier])
-            .getOrElse(i)
+        case i: NatIdentifier => types.getOrElse(i, i)
         case ae => ae
       })
     }
 
     case class Renaming(
       values: Map[Identifier, Identifier],
-      types: Map[Kind.Identifier, Kind.Identifier]
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
     ) extends PureTraversal {
-      override def nat : Nat => Pure[Nat] = n => return_(renameInNat(n)(types))
+      override def nat : Nat => Pure[Nat] = n => return_(renameInNat(n)(nats))
       override def expr : Expr => Pure[Expr] = {
         case x: Identifier => return_(values(x) : Expr)
 
         case l@Lambda(x, b) => for {
-          xt2 <- renameInTypes(x.t)(types)
+          xt2 <- renameInTypes(x.t)(nats, dts, ass)
           x2 = x.copy(s"x$nextValN")(xt2)
-          b2 <- renameInExpr(b)(values + (x -> x2), types)
-          t2 <- renameInTypes(l.t)(types)
+          b2 <- renameInExpr(b)(values + (x -> x2), nats, dts, ass)
+          t2 <- renameInTypes(l.t)(nats, dts, ass)
         } yield Lambda(x2, b2)(t2)
 
-        case d@DepLambda(NatKind, x: NatIdentifier, b) =>
+        case d@DepLambda(_, x: NatIdentifier, b) =>
           val x2 = NatIdentifier(s"n$nextNatN", x.range)
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types + (x -> x2))
+            b2 <- renameInExpr(b)(values, nats + (x -> x2), dts, ass)
+            t2 <- renameInTypes(d.t)(nats + (x -> x2), dts, ass)
           } yield DepLambda(NatKind, x2, b2)(t2)
 
-        case d@DepLambda(DataKind, x: DataTypeIdentifier, b) =>
+        case d@DepLambda(_, x: DataTypeIdentifier, b) =>
           val x2 = DataTypeIdentifier(s"dt$nextDtN")
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types)
+            b2 <- renameInExpr(b)(values, nats, dts + (x -> x2), ass)
+            t2 <- renameInTypes(d.t)(nats, dts, ass)
           } yield DepLambda(DataKind, x2, b2)(t2)
 
-        case d@DepLambda(AddressSpaceKind, x: AddressSpaceIdentifier, b) =>
+        case d@DepLambda(_, x: AddressSpaceIdentifier, b) =>
           val x2 = AddressSpaceIdentifier(s"a$nextAN")
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types)
+            b2 <- renameInExpr(b)(values, nats, dts, ass + (x -> x2))
+            t2 <- renameInTypes(d.t)(nats, dts, ass)
           } yield DepLambda(AddressSpaceKind, x2, b2)(t2)
 
         case e => super.expr(e)
       }
 
       override def `type`[T <: Type] : T => Pure[T] = {
-        case i: DataTypeIdentifier =>
-          return_(types.getOrElse(i, i).asInstanceOf[T])
+        case i: DataTypeIdentifier => return_(dts.getOrElse(i, i).asInstanceOf[T])
 
-        case DepFunType(NatKind, x: NatIdentifier, b) =>
-          val x2 = types.getOrElse(x, NatIdentifier(s"n$nextNatN", x.range)).asInstanceOf[NatIdentifier]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
+        case DepFunType(_, x: NatIdentifier, b) =>
+          val x2 = nats.getOrElse(x, NatIdentifier(s"n$nextNatN", x.range))
+          for { b2 <- renameInTypes(b)(nats + (x -> x2), dts, ass) }
             yield DepFunType(NatKind, x2, b2).asInstanceOf[T]
 
-        case DepFunType(DataKind, x: DataTypeIdentifier, b) =>
-          val x2 = types.getOrElse(x, DataTypeIdentifier(s"dt$nextDtN")).asInstanceOf[DataTypeIdentifier]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
+        case DepFunType(_, x: DataTypeIdentifier, b) =>
+          val x2 = dts.getOrElse(x, DataTypeIdentifier(s"dt$nextDtN"))
+          for { b2 <- renameInTypes(b)(nats, dts + (x -> x2), ass) }
             yield DepFunType(DataKind, x2, b2).asInstanceOf[T]
 
-        case DepFunType(AddressSpaceKind, x: AddressSpaceIdentifier, b) =>
-          val x2 = types.getOrElse(x, AddressSpaceIdentifier(s"dt$nextAN")).asInstanceOf[AddressSpaceIdentifier]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
+        case DepFunType(_, x: AddressSpaceIdentifier, b) =>
+          val x2 = ass.getOrElse(x, AddressSpaceIdentifier(s"dt$nextAN"))
+          for { b2 <- renameInTypes(b)(nats, dts, ass + (x -> x2)) }
             yield DepFunType(AddressSpaceKind, x2, b2).asInstanceOf[T]
 
         case e => super.`type`(e)
       }
     }
 
-    Renaming(Map(), Map()).expr(e).unwrap
+    Renaming(Map(), Map(), Map(), Map()).expr(e).unwrap
   }
 }

--- a/src/main/scala/rise/elevate/rules/algorithmic.scala
+++ b/src/main/scala/rise/elevate/rules/algorithmic.scala
@@ -58,7 +58,7 @@ object algorithmic {
 
   // padEmpty n >> padEmpty m -> padEmpty n + m
   @rule def padEmptyFusion: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), m: Nat), App(DepApp(NatKind, padEmpty(), n: Nat), in)) =>
+    case e @ App(DepApp(_, padEmpty(), m: Nat), App(DepApp(_, padEmpty(), n: Nat), in)) =>
       Success(padEmpty(n+m)(in) !: e.t)
   }
 
@@ -135,7 +135,7 @@ object algorithmic {
   // constraint: n - m = u - v
   // v = u + m - n
   @rule def slideOverlap(u: Nat): Strategy[Rise] = {
-    case e @ DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat) =>
+    case e @ DepApp(_, DepApp(_, slide(), n: Nat), m: Nat) =>
       val v = u + m - n
       Success((slide(u)(v) >> map(slide(n)(m)) >> join) !: e.t)
   }
@@ -144,12 +144,12 @@ object algorithmic {
 
   // slide n 1 >> drop l -> slide (n+l) 1 >> map(drop l)
   @rule def dropInSlide: Strategy[Rise] = {
-    case e@App(DepApp(NatKind, drop(), l: Nat), App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)), in)) =>
+    case e@App(DepApp(_, drop(), l: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), Cst(1)), in)) =>
       Success(app(map(drop(l)), app(slide(n + l)(1), preserveType(in))) !: e.t)
   }
   // slide n 1 >> take (N - r) -> slide (n+r) 1 >> map(take (n - r))
   @rule def takeInSlide: Strategy[Rise] = {
-    case e@App(t@DepApp(NatKind, take(), rem: Nat), App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)), in)) =>
+    case e@App(t@DepApp(_, take(), rem: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), Cst(1)), in)) =>
       t.t match {
         case FunType(ArrayType(size, _), _) =>
           val r = size - rem
@@ -159,18 +159,18 @@ object algorithmic {
   }
 
   @rule def dropNothing: Strategy[Rise] = {
-    case expr @ DepApp(NatKind, drop(), Cst(0)) => Success(fun(x => x) !: expr.t)
+    case expr @ DepApp(_, drop(), Cst(0)) => Success(fun(x => x) !: expr.t)
   }
 
   @rule def takeAll: Strategy[Rise] = {
-    case expr @ DepApp(NatKind, take(), n: Nat) => expr.t match {
+    case expr @ DepApp(_, take(), n: Nat) => expr.t match {
       case FunType(ArrayType(m, _), _) if n == m => Success(fun(x => x) !: expr.t)
       case _ => Failure(takeAll)
     }
   }
 
   @rule def padEmptyNothing: Strategy[Rise] = {
-    case e @ DepApp(NatKind, padEmpty(), Cst(0)) => Success(fun(x => x) !: e.t)
+    case e @ DepApp(_, padEmpty(), Cst(0)) => Success(fun(x => x) !: e.t)
   }
 
   @rule def mapIdentity: Strategy[Rise] = {
@@ -198,7 +198,7 @@ object algorithmic {
 
   // J >> drop d -> drop (d / m) >> J >> drop (d % m)
   @rule def dropBeforeJoin: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, drop(), d: Nat), App(join(), in)) => in.t match {
+    case e @ App(DepApp(_, drop(), d: Nat), App(join(), in)) => in.t match {
       case ArrayType(_, ArrayType(m, _)) =>
         Success(app(drop(d % m), join(drop(d / m)(in))) !: e.t)
       case _ => throw new Exception("this should not happen")
@@ -209,7 +209,7 @@ object algorithmic {
   // -> dropLast (d / m) >> J >> dropLast (d % m)
   // -> take (n - d / m) >> J >> take ((n - d / m)*m - d % m)
   @rule def takeBeforeJoin: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, take(), nmd: Nat), App(join(), in)) => in.t match {
+    case e @ App(DepApp(_, take(), nmd: Nat), App(join(), in)) => in.t match {
       case ArrayType(n, ArrayType(m, _)) =>
         val d = n*m - nmd
         val t1 = n - d / m
@@ -221,7 +221,7 @@ object algorithmic {
 
   // take n >> padEmpty m -> padEmpty m'
   @rule def removeTakeBeforePadEmpty: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), m: Nat), App(DepApp(NatKind, take(), n: Nat), in)) =>
+    case e @ App(DepApp(_, padEmpty(), m: Nat), App(DepApp(_, take(), n: Nat), in)) =>
       in.t match {
         case ArrayType(size, _)
         if ArithExpr.isSmaller(size - n, m + 1).contains(true) =>
@@ -370,15 +370,15 @@ object algorithmic {
   // zip (slide n m a) (slide n m b) -> map unzip (slide n m (zip a b))
   @rule def slideOutsideZip: Strategy[Rise] = {
     case expr @ App(App(zip(),
-      App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat), a)),
-      App(DepApp(NatKind, DepApp(NatKind, slide(), n2: Nat), m2: Nat), b)
+      App(DepApp(_, DepApp(_, slide(), n: Nat), m: Nat), a)),
+      App(DepApp(_, DepApp(_, slide(), n2: Nat), m2: Nat), b)
     ) if n == n2 && m == m2 =>
       Success(map(unzip)(slide(n)(m)(zip(a)(b))) !: expr.t)
   }
 
   // slide n m (zip a b) -> map zip (zip (slide n m a) (slide n m b))
   @rule def slideInsideZip: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat),
+    case expr @ App(DepApp(_, DepApp(_, slide(), n: Nat), m: Nat),
       App(App(zip(), a), b)
     ) =>
       Success(map(fun(p => zip(fst(p))(snd(p))))(
@@ -441,8 +441,8 @@ object algorithmic {
   @rule def zipAsVectorUnzipSimplification: Strategy[Rise] = {
     case e @ App(
       Lambda(x, App(App(zip(),
-        App(DepApp(NatKind, asVector(), v: Nat), App(fst(), x2))),
-        App(DepApp(NatKind, asVector(), v2: Nat), App(snd(), x3)))),
+        App(DepApp(_, asVector(), v: Nat), App(fst(), x2))),
+        App(DepApp(_, asVector(), v2: Nat), App(snd(), x3)))),
       App(unzip(), in)
     ) if x =~= x2 && x =~= x3 && v == v2 =>
       println(in.t)

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -85,12 +85,12 @@ object lowering {
 
   // TODO: load identity instead, then change with other rules?
   @rule def circularBuffer(load: Expr): Strategy[Rise] = {
-    case e@DepApp(NatKind, DepApp(NatKind, slide(), sz: Nat), Cst(1)) => Success(
+    case e@DepApp(_, DepApp(_, slide(), sz: Nat), Cst(1)) => Success(
       p.circularBuffer(sz)(sz)(eraseType(load)) !: e.t)
   }
 
   @rule def rotateValues(write: Expr): Strategy[Rise] = {
-    case e@DepApp(NatKind, DepApp(NatKind, slide(), sz: Nat), Cst(1)) => Success(
+    case e@DepApp(_, DepApp(_, slide(), sz: Nat), Cst(1)) => Success(
       p.rotateValues(sz)(eraseType(write)) !: e.t)
   }
 
@@ -319,7 +319,7 @@ object lowering {
     }
 
     @rule def circularBuffer(a: AddressSpace): Strategy[Rise] = {
-      case e@DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(_, DepApp(_, slide(), n: Nat), Cst(1)) =>
         Success(
           oclCircularBuffer(a)(n)(n)(fun(x => x))
             !: e.t)
@@ -327,14 +327,14 @@ object lowering {
 
     @rule def circularBufferLoadFusion: Strategy[Rise] = {
       case e@App(App(
-        cb @ DepApp(NatKind, DepApp(NatKind, DepApp(AddressSpaceKind, oclCircularBuffer(), _), _), _),
+        cb @ DepApp(_, DepApp(_, DepApp(_, oclCircularBuffer(), _), _), _),
         load), App(App(map(), f), in)
       ) =>
         Success(eraseType(cb)(preserveType(f) >> load, in) !: e.t)
     }
 
     @rule def rotateValues(a: AddressSpace, write: Expr): Strategy[Rise] = {
-      case e@DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(_, DepApp(_, slide(), n: Nat), Cst(1)) =>
         Success(
           oclRotateValues(a)(n)(eraseType(write))
             !: e.t)

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -57,8 +57,8 @@ object movement {
   // split/slide
 
   def isSplitOrSlide(s: Expr): Boolean = s match {
-    case DepApp(NatKind, DepApp(NatKind, slide(), _: Nat), _: Nat) => true
-    case DepApp(NatKind, split(), _: Nat)                          => true
+    case DepApp(_, DepApp(_, slide(), _: Nat), _: Nat) => true
+    case DepApp(_, split(), _: Nat)                          => true
     case _                                                         => false
   }
 
@@ -70,13 +70,13 @@ object movement {
 
   def slideBeforeMap: Strategy[Rise] = `*f >> S -> S >> **f`
   @rule def `*f >> S -> S >> **f`: Strategy[Rise] = {
-    case e@App(s @ DepApp(NatKind, DepApp(NatKind, slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
+    case e@App(s @ DepApp(_, DepApp(_, slide(), _: Nat), _: Nat), App(App(map(), f), y)) =>
       Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e.t)
   }
 
   // *f >> S -> S >> **f
   @rule def splitBeforeMap: Strategy[Rise] = {
-    case e@App(s @ DepApp(NatKind, split(), _: Nat), App(App(map(), f), y)) =>
+    case e@App(s @ DepApp(_, split(), _: Nat), App(App(map(), f), y)) =>
       Success((preserveType(y) |> eraseType(s) |> map(map(f))) !: e.t)
   }
 
@@ -98,32 +98,32 @@ object movement {
 
   def dropBeforeMap: Strategy[Rise] = `*f >> drop n -> drop n >> *f`
   @rule def `*f >> drop n -> drop n >> *f`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, drop(), n: Nat), App(App(map(), f), in)) =>
+    case expr @ App(DepApp(_, drop(), n: Nat), App(App(map(), f), in)) =>
       Success(app(map(f), app(drop(n), preserveType(in))) !: expr.t)
   }
 
   def takeBeforeMap: Strategy[Rise] = `*f >> take n -> take n >> *f`
   @rule def `*f >> take n -> take n >> *f`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, take(), n: Nat), App(App(map(), f), in)) =>
+    case expr @ App(DepApp(_, take(), n: Nat), App(App(map(), f), in)) =>
       Success(app(map(f), app(take(n), preserveType(in))) !: expr.t)
   }
 
   // take n >> *f -> *f >> take n
   @rule def takeAfterMap: Strategy[Rise] = {
-    case e @ App(App(map(), f), App(DepApp(NatKind, take(), n: Nat), in)) =>
+    case e @ App(App(map(), f), App(DepApp(_, take(), n: Nat), in)) =>
       Success(take(n)(map(f)(in)) !: e.t)
   }
 
   def takeInZip: Strategy[Rise] = `take n (zip a b) -> zip (take n a) (take n b)`
   @rule def `take n (zip a b) -> zip (take n a) (take n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, take(), n), App(App(zip(), a), b)) =>
+    case expr @ App(DepApp(_, take(), n), App(App(zip(), a), b)) =>
       Success(zip(depApp(NatKind, take, n)(a))(depApp(NatKind, take, n)(b)) !: expr.t)
   }
 
   // zip (take n a) (take n b) -> take n (zip a b)
   @rule def takeOutisdeZip: Strategy[Rise] = {
     case e @ App(App(zip(),
-      App(DepApp(NatKind, take(), n1: Nat), a)), App(DepApp(NatKind, take(), n2: Nat), b)
+      App(DepApp(_, take(), n1: Nat), a)), App(DepApp(_, take(), n2: Nat), b)
     ) if n1 == n2 =>
       Success(take(n1)(zip(a)(b)) !: e.t)
   }
@@ -132,76 +132,74 @@ object movement {
   // TODO: can get any function out, see asScalarOutsidePair
   @rule def takeOutsidePair: Strategy[Rise] = {
     case e @ App(App(makePair(),
-      App(DepApp(NatKind, take(), n: Nat), a)), App(DepApp(NatKind, take(), m: Nat), b)
+      App(DepApp(_, take(), n: Nat), a)), App(DepApp(_, take(), m: Nat), b)
     ) =>
       Success((makePair(a)(b) |> mapFst(take(n)) |> mapSnd(take(m))) !: e.t)
   }
 
   def dropInZip: Strategy[Rise] = `drop n (zip a b) -> zip (drop n a) (drop n b)`
   @rule def `drop n (zip a b) -> zip (drop n a) (drop n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, drop(), n), App(App(zip(), a), b)) =>
+    case expr @ App(DepApp(_, drop(), n), App(App(zip(), a), b)) =>
       Success(zip(depApp(NatKind, drop, n)(a))(depApp(NatKind, drop, n)(b)) !: expr.t)
   }
 
   def takeInSelect: Strategy[Rise] = `take n (select t a b) -> select t (take n a) (take n b)`
   @rule def `take n (select t a b) -> select t (take n a) (take n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, take(), n), App(App(App(select(), t), a), b)) =>
+    case expr @ App(DepApp(_, take(), n), App(App(App(select(), t), a), b)) =>
       Success(select(t)(depApp(NatKind, take, n)(a), depApp(NatKind, take, n)(b)) !: expr.t)
   }
 
   def dropInSelect: Strategy[Rise] = `drop n (select t a b) -> select t (drop n a) (drop n b)`
   @rule def `drop n (select t a b) -> select t (drop n a) (drop n b)`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, drop(), n), App(App(App(select(), t), a), b)) =>
+    case expr @ App(DepApp(_, drop(), n), App(App(App(select(), t), a), b)) =>
       Success(select(t)(depApp(NatKind, drop, n)(a), depApp(NatKind, drop, n)(b)) !: expr.t)
   }
 
   def dropBeforeTake: Strategy[Rise] = `take (n+m) >> drop m -> drop m >> take n`
   @rule def `take (n+m) >> drop m -> drop m >> take n`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, drop(), m: Nat), App(DepApp(NatKind, take(), nm: Nat), in)) =>
+    case expr @ App(DepApp(_, drop(), m: Nat), App(DepApp(_, take(), nm: Nat), in)) =>
       Success(app(take(nm - m), app(drop(m), preserveType(in))) !: expr.t)
   }
 
   def takeBeforeDrop: Strategy[Rise] = `drop m >> take n -> take (n+m) >> drop m`
   @rule def `drop m >> take n -> take (n+m) >> drop m`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, take(), n: Nat), App(DepApp(NatKind, drop(), m: Nat), in)) =>
+    case expr @ App(DepApp(_, take(), n: Nat), App(DepApp(_, drop(), m: Nat), in)) =>
       Success(app(drop(m), app(take(n+m), preserveType(in))) !: expr.t)
   }
 
   def takeBeforeSlide: Strategy[Rise] = `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`
   @rule def `slide n m >> take t -> take (m * (t - 1) + n) >> slide n m`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, take(), t: Nat), App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat), in)) =>
+    case expr @ App(DepApp(_, take(), t: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), m: Nat), in)) =>
       Success(app(slide(n)(m), take(m * (t - 1) + n)(in)) !: expr.t)
   }
 
   def dropBeforeSlide: Strategy[Rise] = `slide n m >> drop d -> drop (d * m) >> slide n m`
   @rule def `slide n m >> drop d -> drop (d * m) >> slide n m`: Strategy[Rise] = {
-    case expr @ App(DepApp(NatKind, drop(), d: Nat), App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat), in)) =>
+    case expr @ App(DepApp(_, drop(), d: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), m: Nat), in)) =>
       Success(app(slide(n)(m), drop(d * m)(in)) !: expr.t)
   }
 
   // slide n m >> padEmpty p -> padEmpty (p * m) >> slide n m
   @rule def padEmptyBeforeSlide: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), p: Nat),
-      App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), m: Nat), in)
-    ) =>
+    case e @ App(DepApp(_, padEmpty(), p: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), m: Nat), in) ) =>
       Success(slide(n)(m)(padEmpty(p * m)(in)) !: e.t)
   }
 
   // map f >> padEmpty n -> padEmpty n >> map f
   @rule def padEmptyBeforeMap: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), n: Nat), App(App(map(), f), in)) =>
+    case e @ App(DepApp(_, padEmpty(), n: Nat), App(App(map(), f), in)) =>
       Success(map(f)(padEmpty(n)(in)) !: e.t)
   }
 
   // transpose >> padEmpty n -> map (padEmpty n) >> transpose
   @rule def padEmptyBeforeTranspose: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), n: Nat), App(transpose(), in)) =>
+    case e @ App(DepApp(_, padEmpty(), n: Nat), App(transpose(), in)) =>
       Success(transpose(map(padEmpty(n))(in)) !: e.t)
   }
 
   // padEmpty n (zip a b) -> zip (padEmpty n a) (padEmpty n b)
   @rule def padEmptyInsideZip: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), n: Nat), App(App(zip(), a), b)) =>
+    case e @ App(DepApp(_, padEmpty(), n: Nat), App(App(zip(), a), b)) =>
       Success(zip(padEmpty(n)(a))(padEmpty(n)(b)) !: e.t)
   }
 
@@ -209,7 +207,7 @@ object movement {
   // zip (fst e) (snd e) |> padEmpty n ->
   // (mapFst padEmpty n) (mapSnd padEmpty n) |> fun(p => zip (fst p) (snd(p))
   @rule def padEmptyBeforeZip: Strategy[Rise] = {
-    case e @ App(DepApp(NatKind, padEmpty(), n: Nat),
+    case e @ App(DepApp(_, padEmpty(), n: Nat),
       App(App(zip(), App(fst(), e1)), App(snd(), e2)))
     if e1 =~= e2 =>
       Success((preserveType(e1) |>
@@ -282,15 +280,15 @@ object movement {
 
   def slideBeforeSplit: Strategy[Rise] = `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`
   @rule def `slide(n)(s) >> split(k) -> slide(k+n-s)(k) >> map(slide(n)(s))`: Strategy[Rise] = {
-    case e@App(DepApp(NatKind, split(), k: Nat), App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), s: Nat), y)) =>
+    case e@App(DepApp(_, split(), k: Nat), App(DepApp(_, DepApp(_, slide(), n: Nat), s: Nat), y)) =>
       Success((preserveType(y) |> slide(k + n - s)(k) |> map(slide(n)(s))) !: e.t)
   }
 
   // TODO: what if s != 1?
   // slide(n)(s=1) >> slide(m)(k) -> slide(m+n-1)(k) >> map(slide(n)(1))
   @rule def slideBeforeSlide: Strategy[Rise] = {
-    case e@App(DepApp(NatKind, DepApp(NatKind, slide(), m: Nat), k: Nat),
-            App(DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), s: Nat), in)
+    case e@App(DepApp(_, DepApp(_, slide(), m: Nat), k: Nat),
+            App(DepApp(_, DepApp(_, slide(), n: Nat), s: Nat), in)
          ) if s == (1: Nat) =>
       Success((preserveType(in) |> slide(m+n-s)(k) |> map(slide(n)(s))) !: e.t)
   }

--- a/src/main/scala/rise/elevate/rules/package.scala
+++ b/src/main/scala/rise/elevate/rules/package.scala
@@ -16,7 +16,7 @@ package object rules {
     case App(Lambda(x, b), v) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
     case DepApp(k1, DepLambda(k2, x, b), v) if k1 == k2 =>
-      Success(substitute.kindInExpr(k1, v, `for` = x, in = b))
+      Success(substitute.kindInExpr(k2, v, `for` = x, in = b))
     case _ => Failure(betaReduction)
   }
 
@@ -34,7 +34,7 @@ package object rules {
     case App(Lambda(x, b), v) if !containsAtLeast(1, x)(ev)(b) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
     case DepApp(k1, DepLambda(k2, x, b), v) if k1 == k2 =>
-      Success(substitute.kindInExpr(k1, v, `for` = x, in = b))
+      Success(substitute.kindInExpr(k2, v, `for` = x, in = b))
     case _ => Failure(gentleBetaReduction())
   }
 

--- a/src/main/scala/rise/elevate/strategies/predicate.scala
+++ b/src/main/scala/rise/elevate/strategies/predicate.scala
@@ -26,7 +26,7 @@ object predicate {
   }
 
   def isLambda: is = is(_.isInstanceOf[Lambda], "Lambda")
-  def isDepLambda: is = is(_.isInstanceOf[DepLambda[_, _]], "DepLambda")
+  def isDepLambda: is = is(_.isInstanceOf[DepLambda[_, _, _]], "DepLambda")
   def isIdentifier: is = is(_.isInstanceOf[Identifier], "Identifier")
   def isApply: is = is(_.isInstanceOf[App], "Apply")
 

--- a/src/main/scala/rise/eqsat/Expr.scala
+++ b/src/main/scala/rise/eqsat/Expr.scala
@@ -127,15 +127,13 @@ object Expr {
       case i: core.Identifier => Var(bound.indexOf(i))
       case core.App(f, e) => App(fromNamed(f, bound), fromNamed(e, bound))
       case core.Lambda(i, e) => Lambda(fromNamed(e, bound + i))
-      case core.DepApp(rct.NatKind, f, n: rct.Nat) =>
+      case core.DepApp(_, f, n: rct.Nat) =>
         NatApp(fromNamed(f, bound), Nat.fromNamed(n, bound))
-      case core.DepApp(rct.DataKind, f, dt: rct.DataType) =>
+      case core.DepApp(_, f, dt: rct.DataType) =>
         DataApp(fromNamed(f, bound), DataType.fromNamed(dt, bound))
       case core.DepApp(_, _, _) => ???
-      case core.DepLambda(rct.NatKind, n: rct.NatIdentifier, e) =>
-        NatLambda(fromNamed(e, bound + n))
-      case core.DepLambda(rct.DataKind, dt: rct.DataTypeIdentifier, e) =>
-        DataLambda(fromNamed(e, bound + dt))
+      case core.DepLambda(_, n: rct.NatIdentifier, e) => NatLambda(fromNamed(e, bound + n))
+      case core.DepLambda(_, dt: rct.DataTypeIdentifier, e) => DataLambda(fromNamed(e, bound + dt))
       case core.DepLambda(_, _, _) => ???
       case core.Literal(d) => Literal(d)
       // note: we set the primitive type to a place holder here,

--- a/src/main/scala/rise/eqsat/TypeNode.scala
+++ b/src/main/scala/rise/eqsat/TypeNode.scala
@@ -115,8 +115,8 @@ object Type {
     Type(t match {
       case dt: rct.DataType => DataType.fromNamed(dt, bound).node
       case rct.FunType(a, b) => FunType(fromNamed(a, bound), fromNamed(b, bound))
-      case rct.DepFunType(rct.NatKind, x: rct.NatIdentifier, t) => NatFunType(fromNamed(t, bound + x))
-      case rct.DepFunType(rct.DataKind, x: rct.DataTypeIdentifier, t) => DataFunType(fromNamed(t, bound + x))
+      case rct.DepFunType(_, x: rct.NatIdentifier, t) => NatFunType(fromNamed(t, bound + x))
+      case rct.DepFunType(_, x: rct.DataTypeIdentifier, t) => DataFunType(fromNamed(t, bound + x))
       case rct.DepFunType(_, _, _) => ???
       case rct.TypePlaceholder | rct.TypeIdentifier(_) =>
         throw new Exception(s"did not expect $t")
@@ -150,7 +150,7 @@ object DataType {
       case rct.IndexType(s) => IndexType(Nat.fromNamed(s, bound))
       case rct.PairType(dt1, dt2) => PairType(fromNamed(dt1, bound), fromNamed(dt2, bound))
       case rct.ArrayType(s, et) => ArrayType(Nat.fromNamed(s, bound), fromNamed(et, bound))
-      case _: rct.DepArrayType | _: rct.DepPairType[_, _] |
+      case _: rct.DepArrayType | _: rct.DepPairType[_, _, _] |
            _: rct.NatToDataApply | _: rct.FragmentType | _: rct.ManagedBufferType | _: rct.OpaqueType =>
         throw new Exception(s"did not expect $dt")
     })

--- a/src/main/scala/rise/openCL/DSL.scala
+++ b/src/main/scala/rise/openCL/DSL.scala
@@ -32,17 +32,17 @@ object DSL {
                                    to: ToBeTyped[A],
                                    f: ToBeTyped[B]
                                  ): ToBeTyped[rise.core.Lambda] = fun(x => to(f(x)))
-  val toGlobal: ToBeTyped[rise.core.DepApp[AddressSpace]] = toMem(
+  val toGlobal: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Global
   )
   def toGlobalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toGlobal, f)
-  val toLocal: ToBeTyped[rise.core.DepApp[AddressSpace]] = toMem(
+  val toLocal: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Local
   )
   def toLocalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toLocal, f)
-  val toPrivate: ToBeTyped[rise.core.DepApp[AddressSpace]] = toMem(
+  val toPrivate: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Private
   )
   def toPrivateFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -304,8 +304,8 @@ private class InferAccessAnnotation {
           (gs1 `(Nat)->:` (gs2 `(Nat)->:` (gs3 `(Nat)->:`
           ((t: rt.DataType) ->: (_: rt.DataType))
         ))))) =>
-          nFunT(ls1, nFunT(ls2, nFunT(ls3,
-            nFunT(gs1, nFunT(gs2, nFunT(gs3,
+          nFunT(fromRise.natIdentifier(ls1), nFunT(fromRise.natIdentifier(ls2), nFunT(fromRise.natIdentifier(ls3),
+            nFunT(fromRise.natIdentifier(gs1), nFunT(fromRise.natIdentifier(gs2), nFunT(fromRise.natIdentifier(gs3),
               expT(t, write) ->: expT(t, write)))))))
         case _ => error()
       }
@@ -350,7 +350,7 @@ private class InferAccessAnnotation {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(n, expT(dt1, ai) ->: expT(dt2, ai))
+          nFunT(fromRise.natIdentifier(n), expT(dt1, ai) ->: expT(dt2, ai))
         case _ => error()
       }
 
@@ -377,7 +377,7 @@ private class InferAccessAnnotation {
 
       case rp.natAsIndex() | rp.take() | rp.drop() => p.t match {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
-          nFunT(n, expT(dt1, read) ->: expT(dt2, read))
+          nFunT(fromRise.natIdentifier(n), expT(dt1, read) ->: expT(dt2, read))
         case _ => error()
       }
 
@@ -414,7 +414,7 @@ private class InferAccessAnnotation {
         case tile `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(tile,
+          nFunT(fromRise.natIdentifier(tile),
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, write))
         case _ => error()
@@ -425,7 +425,7 @@ private class InferAccessAnnotation {
         case  sz `(Nat)->:`
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(sz,
+          nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(s, write)) ->:
             expT(inT, read) ->: expT(outT, read))
         case _ => error()
@@ -435,7 +435,7 @@ private class InferAccessAnnotation {
         case alloc `(Nat)->:` (sz `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
-          nFunT(alloc, nFunT(sz,
+          nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -446,7 +446,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
           aFunT(a,
-            nFunT(sz,
+            nFunT(fromRise.natIdentifier(sz),
               (expT(s, read) ->: expT(s, write)) ->:
               expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -457,7 +457,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)))) =>
 
-          aFunT(a, nFunT(alloc, nFunT(sz,
+          aFunT(a, nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(t, write)) ->:
               expT(inT, read) ->: expT(outT, read))))
         case _ => error()
@@ -466,7 +466,7 @@ private class InferAccessAnnotation {
       case rp.slide() | rp.padClamp() => p.t match {
         case sz `(Nat)->:` (sp `(Nat)->:`
           ((dt1: rt.DataType) ->: (dt2: rt.DataType))) =>
-          nFunT(sz, nFunT(sp,
+          nFunT(fromRise.natIdentifier(sz), nFunT(fromRise.natIdentifier(sp),
             expT(dt1, read) ->: expT(dt2, read)))
         case _ => error()
       }
@@ -475,8 +475,8 @@ private class InferAccessAnnotation {
         case k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType)) =>
-          nFunT(k,
-            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
+          nFunT(fromRise.natIdentifier(k),
+            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
             expT(at3, read) ->: expT(at4, write) )
         case _ => error()
       }
@@ -485,8 +485,8 @@ private class InferAccessAnnotation {
         case a `(Addr)->:` (k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType))) =>
-          aFunT(a, nFunT(k,
-            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
+          aFunT(a, nFunT(fromRise.natIdentifier(k),
+            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
               expT(at3, read) ->: expT(at4, write) ))
         case _ => error()
       }
@@ -502,7 +502,7 @@ private class InferAccessAnnotation {
 
       case rp.padEmpty() => p.t match {
         case r `(Nat)->:` ((n`.`t) ->: (_`.`_)) =>
-          nFunT(r, expT(n`.`t, write) ->: expT((n + r)`.`t, write))
+          nFunT(fromRise.natIdentifier(r), expT(n`.`t, write) ->: expT((n + r)`.`t, write))
         case _ => error()
       }
 
@@ -510,7 +510,7 @@ private class InferAccessAnnotation {
         case l `(Nat)->:` (q `(Nat)->:`
           ((t: rt.DataType) ->: (n`.`_) ->: (_`.`_))) =>
 
-          nFunT(l, nFunT(q,
+          nFunT(fromRise.natIdentifier(l), nFunT(fromRise.natIdentifier(q),
             expT(t, read) ->: expT(n`.`t, read) ->:
               expT((l + n + q)`.`t, read)))
         case _ => error()
@@ -527,7 +527,7 @@ private class InferAccessAnnotation {
         case (n `(Nat)->:` (idxF `(NatToNat)->:` (idxFinv `(NatToNat)->:` ((_`.`t) ->: (_`.`_) )))) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(n, n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
+          nFunT(fromRise.natIdentifier(n), n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
         case _ => error()
       }
 

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -125,10 +125,6 @@ package object DPIA {
   }
 
   object nFunT {
-    def apply(n: rt.NatIdentifier, t: PhraseType): PhraseType = {
-      DepFunType(NatKind, fromRise.natIdentifier(n), t)
-    }
-
     def apply(n: NatIdentifier, t: PhraseType): PhraseType = {
       DepFunType(NatKind, n, t)
     }

--- a/src/test/scala/apps/asum.scala
+++ b/src/test/scala/apps/asum.scala
@@ -31,7 +31,7 @@ class asum extends test_util.TestsWithExecutor {
   test("High level asum type inference works") {
     val typed = high_level.toExpr
 
-    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type]].x
+    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     assertResult(DepFunType(NatKind, N, FunType(inputT(N), f32))) {
       typed.t
     }

--- a/src/test/scala/apps/dot.scala
+++ b/src/test/scala/apps/dot.scala
@@ -24,7 +24,7 @@ class dot extends test_util.Tests {
   )))
 
   test("Simple dot product type inference works") {
-    val N = simpleDotProduct.t.asInstanceOf[NatDepFunType[_ <: Type]].x
+    val N = simpleDotProduct.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     assertResult(
       DepFunType(NatKind, N, FunType(xsT(N), FunType(ysT(N), f32)))
     ) {

--- a/src/test/scala/apps/gemvCheck.scala
+++ b/src/test/scala/apps/gemvCheck.scala
@@ -14,10 +14,10 @@ class gemvCheck extends test_util.Tests {
   test("high-level gemv type inference works") {
     val typed = gemvHighLevel.toExpr
 
-    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type]].x
+    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     val M = typed.t
-      .asInstanceOf[NatDepFunType[_ <: Type]].t
-      .asInstanceOf[NatDepFunType[_ <: Type]].x
+      .asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].t
+      .asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     assertResult(
       DepFunType(NatKind, N,
         DepFunType(NatKind, M,

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -57,8 +57,7 @@ class showRise extends test_util.Tests {
         case i: Identifier => line(i.name)
         case Lambda(x, e)  => block(s"λ${x.name}", drawASTSimp(e))
         case App(f, e)     => drawASTSimp(f) :+> drawASTSimp(e)
-        case DepLambda(kind, x, e) =>
-          block(s"Λ${x.name}:${kind.name}", drawASTSimp(e))
+        case DepLambda(kind, x, e) => block(s"Λ${Kind.idName(kind, x)}:${kind.name}", drawASTSimp(e))
         case DepApp(_, f, x)     => line(x.toString) <+: drawASTSimp(f)
         case Literal(d)       => line(d.toString)
         case TypeAnnotation(e, _) => drawASTSimp(e)
@@ -88,14 +87,14 @@ class showRise extends test_util.Tests {
           if (wrapped) s"($fs $es)" else s"$fs $es"
 
         case DepLambda(kind, x, e) =>
-          val xs = s"${x.name}:${kind.name}"
+          val xs = s"${Kind.idName(kind, x)}:${kind.name}"
           val es = lessBrackets(e)
           if (wrapped) s"[Λ$xs. $es]" else s"Λ$xs. $es"
 
         case DepApp(_, f, x) =>
           val fs = f match {
-            case _: DepLambda[_, _] => lessBrackets(f, wrapped = true)
-            case _                  => lessBrackets(f)
+            case _: DepLambda[_, _, _] => lessBrackets(f, wrapped = true)
+            case _                     => lessBrackets(f)
           }
           if (wrapped) s"($fs $x)" else s"$fs $x"
 

--- a/src/test/scala/rise/core/traverseTest.scala
+++ b/src/test/scala/rise/core/traverseTest.scala
@@ -22,7 +22,7 @@ class traverseTest extends test_util.Tests {
 
   class TypeTraceVisitor extends PureAccumulatorTraversal[Seq[Any]] {
     override val accumulator = SeqMonoid[Any]
-    override def typeIdentifier[I <: Kind.Identifier] : VarType => I => Pair[I] =
+    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] =
       vt => i => accumulate(Seq(i))(i)
   }
 

--- a/src/test/scala/rise/elevate/tiling.scala
+++ b/src/test/scala/rise/elevate/tiling.scala
@@ -249,7 +249,7 @@ class tiling extends test_util.Tests {
   def wrapInLambda[T <: Expr](dim: Int,
                               f: ToBeTyped[Identifier] => ToBeTyped[T],
                               genInputType: List[Nat] => ArrayType,
-                              natIds: List[Nat] = List()): ToBeTyped[DepLambda[Nat, NatIdentifier]] = {
+                              natIds: List[Nat] = List()): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
     dim match {
       case 1 => depFun((n: Nat) => fun(genInputType( natIds :+ n))(f))
       case d => depFun((n: Nat) => wrapInLambda(d - 1, f, genInputType, natIds :+ n))

--- a/src/test/scala/rise/elevate/traversals.scala
+++ b/src/test/scala/rise/elevate/traversals.scala
@@ -6,6 +6,7 @@ import rise.elevate.util._
 import rise.core.DSL._
 import rise.core.makeClosed
 import rise.core.primitives._
+import rise.core.types.Kind.INat
 import rise.core.types.{Nat, NatKind}
 import rise.elevate.meta.fission.bodyFission
 import rise.elevate.meta.traversal.inBody
@@ -69,8 +70,8 @@ class traversals extends test_util.Tests {
   }
 
   test("RNF did not normalize") {
-    val expr2 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η125"), app(app(map, lambda(identifier("ee3"), app(join, app(app(map, lambda(identifier("η124"), app(app(map, lambda(identifier("η123"), app(identifier("ee2"), identifier("η123")))), identifier("η124")))), app(depApp[Nat](NatKind, split, 4), identifier("ee3")))))), identifier("η125")))), app(depApp[Nat](NatKind, split, 4), identifier("ee1"))))))
-    val expr5 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η141"), app(app(map, lambda(identifier("η140"), app(join, identifier("η140")))), identifier("η141")))), app(app(map, lambda(identifier("η145"), app(app(map, lambda(identifier("η144"), app(app(map, lambda(identifier("η143"), app(app(map, lambda(identifier("η142"), app(identifier("ee2"), identifier("η142")))), identifier("η143")))), identifier("η144")))), identifier("η145")))), app(app(map, lambda(identifier("η147"), app(app(map, lambda(identifier("η146"), app(depApp[Nat](NatKind, split, 4), identifier("η146")))), identifier("η147")))), app(depApp[Nat](NatKind, split, 4), identifier("ee1"))))))))
+    val expr2 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η125"), app(app(map, lambda(identifier("ee3"), app(join, app(app(map, lambda(identifier("η124"), app(app(map, lambda(identifier("η123"), app(identifier("ee2"), identifier("η123")))), identifier("η124")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee3")))))), identifier("η125")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee1"))))))
+    val expr5 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η141"), app(app(map, lambda(identifier("η140"), app(join, identifier("η140")))), identifier("η141")))), app(app(map, lambda(identifier("η145"), app(app(map, lambda(identifier("η144"), app(app(map, lambda(identifier("η143"), app(app(map, lambda(identifier("η142"), app(identifier("ee2"), identifier("η142")))), identifier("η143")))), identifier("η144")))), identifier("η145")))), app(app(map, lambda(identifier("η147"), app(app(map, lambda(identifier("η146"), app(depApp[Nat, INat](NatKind, split, 4), identifier("η146")))), identifier("η147")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee1"))))))))
 
     assert(makeClosed(RNF(expr2).get) =~= makeClosed(toExpr(expr5)))
   }

--- a/src/test/scala/rise/elevate/util/package.scala
+++ b/src/test/scala/rise/elevate/util/package.scala
@@ -19,7 +19,7 @@ package object util {
 
   // notation
   def T: ToBeTyped[Rise] = transpose
-  def S: ToBeTyped[DepApp[Nat]] = split(tileSize) //slide(3)(1)
+  def S: ToBeTyped[DepApp[Nat, _]] = split(tileSize) //slide(3)(1)
   def J: ToBeTyped[Rise] = join
   def *(x: ToBeTyped[Rise]): ToBeTyped[App] = map(x)
   def **(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(x))


### PR DESCRIPTION
This PR gets eliminates the need to subclass `Kind.Identifier` when creating something that is meant to be considered a type identifier. Instead, it uses `Kind.Identifier` as a closed trait where each constructor accepts as its only argument an identifier of the desired type. It is then the kinding system which relates the two with `Kind[+T, +I, KI <: Kind.Identifier]`. Two functions `toIdentifier` and `fromIdentifier` are provided that box and unbox the identifiers into and out of `Kind.Identifier`. These two functions and `idName` are defined as functions instead of as methods in the `Kind` trait so that we can have a covariant `+I`.

Whenever a set of identifiers of different kinds is required, `Kind.Identifier` can be used. In its current form, there is some boxing-unboxing overhead in traversals, but I think this can be avoided.

As a result of this PR, variables in arithexpr and variables in rise are one and the same: `NamedVar`. The idea is to do something similar for dpia, thus having a uniform `NamedVar` all across the codebase.