### PR TITLE
Merge master into autotuning branch

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -1,3 +1,5 @@
+const math = require('remark-math');
+const katex = require('rehype-katex');
 module.exports = {
   title: 'RISE Language Documentation',
   tagline: 'A functional pattern-based data-parallel language',
@@ -8,6 +10,15 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'rise-lang', // Usually your GitHub org/user name.
   projectName: 'doc', // Usually your repo name.
+  stylesheets: [
+    {
+      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.2/dist/katex.min.css',
+      type: 'text/css',
+      integrity:
+          'sha384-Cqd8ihRLum0CCg8rz0hYKPoLZ3uw+gES2rXQXycqnL5pgVQIflxAUDS7ZSjITLb5',
+      crossorigin: 'anonymous',
+    },
+  ],
   themeConfig: {
     navbar: {
       title: 'RISE',
@@ -43,6 +54,8 @@ module.exports = {
           path: 'docs',
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          remarkPlugins: [math],
+          rehypePlugins: [katex],
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -17,7 +17,9 @@
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",
     "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "react-dom": "^16.8.4",
+    "rehype-katex": "^4.0.0",
+    "remark-math": "^3.0.1"
   },
   "browserslist": {
     "production": [

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -33,6 +33,14 @@ module.exports = {
         //   ],
         // },
       ],
+    },
+    {
+      type: 'category',
+      label: 'Reference',
+      collapsed: false,
+      items: [
+        'language-reference/rise-types'
+      ],
     }
   ],
 };

--- a/docs-website/yarn.lock
+++ b/docs-website/yarn.lock
@@ -139,10 +139,10 @@
   dependencies:
     "@babel/highlight" "^7.12.13"
 
-"@babel/compat-data@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.13.tgz#27e19e0ed3726ccf54067ced4109501765e7e2e8"
-  integrity sha512-U/hshG5R+SIoW7HVWIdmy1cB7s3ki+r3FpyEZiCgpi4tFgPnX/vynY80ZGSASOIrUM6O7VxOgCZgdt7h97bUGg==
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.4.tgz#45720fe0cecf3fd42019e1d12cc3d27fadc98d58"
+  integrity sha512-i2wXrWQNkH6JplJQGn3Rd2I4Pij8GdHkXwHMxm+zV5YG/Jci+bCNrWZEWC4o+umiDkRrRs4dVzH3X4GP7vyjQQ==
 
 "@babel/core@7.12.9":
   version "7.12.9"
@@ -167,32 +167,32 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.12.3":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.16.tgz#8c6ba456b23b680a6493ddcfcd9d3c3ad51cab7c"
-  integrity sha512-t/hHIB504wWceOeaOoONOhu+gX+hpjfeN6YRBT209X/4sibZQfSF1I0HFRRlBe97UZZosGx5XwUg1ZgNbelmNw==
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.3.tgz#5395e30405f0776067fbd9cf0884f15bfb770a38"
+  integrity sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.12.15"
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helpers" "^7.12.13"
-    "@babel/parser" "^7.12.16"
+    "@babel/generator" "^7.14.3"
+    "@babel/helper-compilation-targets" "^7.13.16"
+    "@babel/helper-module-transforms" "^7.14.2"
+    "@babel/helpers" "^7.14.0"
+    "@babel/parser" "^7.14.3"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/traverse" "^7.14.2"
+    "@babel/types" "^7.14.2"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
+    gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
-    lodash "^4.17.19"
-    semver "^5.4.1"
+    semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.13", "@babel/generator@^7.12.15", "@babel/generator@^7.12.5":
-  version "7.12.15"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.15.tgz#4617b5d0b25cc572474cc1aafee1edeaf9b5368f"
-  integrity sha512-6F2xHxBiFXWNSGb7vyCUTBF8RCLY66rS0zEPcP8t/nQyXjha5EuK4z7H5o7fWG8B4M7y6mqVWq1J+1PuwRhecQ==
+"@babel/generator@^7.12.13", "@babel/generator@^7.12.5", "@babel/generator@^7.14.2", "@babel/generator@^7.14.3":
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.3.tgz#0c2652d91f7bddab7cccc6ba8157e4f40dcedb91"
+  integrity sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.2"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -211,50 +211,65 @@
     "@babel/helper-explode-assignable-expression" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/helper-compilation-targets@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.16.tgz#6905238b4a5e02ba2d032c1a49dd1820fe8ce61b"
-  integrity sha512-dBHNEEaZx7F3KoUYqagIhRIeqyyuI65xMndMZ3WwGwEBI609I4TleYQHcrS627vbKyNTXqShoN+fvYD9HuQxAg==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.16", "@babel/helper-compilation-targets@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.4.tgz#33ebd0ffc34248051ee2089350a929ab02f2a516"
+  integrity sha512-JgdzOYZ/qGaKTVkn5qEDV/SXAh8KcyUVkCoSWGN8T3bwrgd6m+/dJa2kVGi6RJYJgEYPBdZ84BZp9dUjNWkBaA==
   dependencies:
-    "@babel/compat-data" "^7.12.13"
-    "@babel/helper-validator-option" "^7.12.16"
-    browserslist "^4.14.5"
-    semver "^5.5.0"
+    "@babel/compat-data" "^7.14.4"
+    "@babel/helper-validator-option" "^7.12.17"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.12.13", "@babel/helper-create-class-features-plugin@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.16.tgz#955d5099fd093e5afb05542190f8022105082c61"
-  integrity sha512-KbSEj8l9zYkMVHpQqM3wJNxS1d9h3U9vm/uE5tpjMbaj3lTp+0noe3KPsV5dSD9jxKnf9jO9Ip9FX5PKNZCKow==
+"@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.14.0", "@babel/helper-create-class-features-plugin@^7.14.3", "@babel/helper-create-class-features-plugin@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.4.tgz#abf888d836a441abee783c75229279748705dc42"
+  integrity sha512-idr3pthFlDCpV+p/rMgGLGYIVtazeatrSOQk8YzO2pAepIjQhCN3myeihVg58ax2bbbGK9PUE1reFi7axOYIOw==
   dependencies:
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-member-expression-to-functions" "^7.12.16"
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-function-name" "^7.14.2"
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
     "@babel/helper-optimise-call-expression" "^7.12.13"
-    "@babel/helper-replace-supers" "^7.12.13"
+    "@babel/helper-replace-supers" "^7.14.4"
     "@babel/helper-split-export-declaration" "^7.12.13"
 
 "@babel/helper-create-regexp-features-plugin@^7.12.13":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.16.tgz#3b31d13f39f930fad975e151163b7df7d4ffe9d3"
-  integrity sha512-jAcQ1biDYZBdaAxB4yg46/XirgX7jBDiMHDbwYQOgtViLBXGxJpZQ24jutmBqAIB/q+AwB6j+NbBXjKxEY8vqg==
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.3.tgz#149aa6d78c016e318c43e2409a0ae9c136a86688"
+  integrity sha512-JIB2+XJrb7v3zceV2XzDhGIB902CmKGSpSl4q2C6agU9SNLG/2V1RtFRGPG1Ajh9STj3+q6zJMOC+N/pp2P9DA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
     regexpu-core "^4.7.1"
 
-"@babel/helper-explode-assignable-expression@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.13.tgz#0e46990da9e271502f77507efa4c9918d3d8634a"
-  integrity sha512-5loeRNvMo9mx1dA/d6yNi+YiKziJZFylZnCo1nmFF4qPU4yJ14abhWESuSMQSlQxWdxdOFzxXjk/PpfudTtYyw==
+"@babel/helper-define-polyfill-provider@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz#0525edec5094653a282688d34d846e4c75e9c0b6"
+  integrity sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/helper-compilation-targets" "^7.13.0"
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/traverse" "^7.13.0"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+    semver "^6.1.2"
 
-"@babel/helper-function-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
-  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+"@babel/helper-explode-assignable-expression@^7.12.13":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.13.0.tgz#17b5c59ff473d9f956f40ef570cf3a76ca12657f"
+  integrity sha512-qS0peLTDP8kOisG1blKbaoBg/o9OSa1qoumMjTK5pM+KDTtpxpsiubnCGP34vK8BXGcb2M9eigwgvoJryrzwWA==
+  dependencies:
+    "@babel/types" "^7.13.0"
+
+"@babel/helper-function-name@^7.12.13", "@babel/helper-function-name@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz#397688b590760b6ef7725b5f0860c82427ebaac2"
+  integrity sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==
   dependencies:
     "@babel/helper-get-function-arity" "^7.12.13"
     "@babel/template" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.2"
 
 "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
@@ -263,28 +278,29 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-hoist-variables@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.12.13.tgz#13aba58b7480b502362316ea02f52cca0e9796cd"
-  integrity sha512-KSC5XSj5HreRhYQtZ3cnSnQwDzgnbdUDEFsxkN0m6Q3WrCRt72xrnZ8+h+pX7YxM7hr87zIO3a/v5p/H3TrnVw==
+"@babel/helper-hoist-variables@^7.13.0":
+  version "7.13.16"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz#1b1651249e94b51f8f0d33439843e33e39775b30"
+  integrity sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/traverse" "^7.13.15"
+    "@babel/types" "^7.13.16"
 
-"@babel/helper-member-expression-to-functions@^7.12.13", "@babel/helper-member-expression-to-functions@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.16.tgz#41e0916b99f8d5f43da4f05d85f4930fa3d62b22"
-  integrity sha512-zYoZC1uvebBFmj1wFAlXwt35JLEgecefATtKp20xalwEK8vHAixLBXTGxNrVGEmTT+gzOThUgr8UEdgtalc1BQ==
+"@babel/helper-member-expression-to-functions@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz#dfe368f26d426a07299d8d6513821768216e6d72"
+  integrity sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-imports@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz#ec67e4404f41750463e455cc3203f6a32e93fcb0"
-  integrity sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
+"@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz#c6a369a6f3621cb25da014078684da9196b61977"
+  integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
-"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.12.13":
+"@babel/helper-module-transforms@^7.12.1":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.13.tgz#01afb052dcad2044289b7b20beb3fa8bd0265bea"
   integrity sha512-acKF7EjqOR67ASIlDTupwkKM1eUisNAjaSduo5Cz+793ikfnpe7p4Q7B7EWU2PCoSTPWsQkR7hRUWEIZPiVLGA==
@@ -299,6 +315,20 @@
     "@babel/types" "^7.12.13"
     lodash "^4.17.19"
 
+"@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.14.0", "@babel/helper-module-transforms@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz#ac1cc30ee47b945e3e0c4db12fa0c5389509dfe5"
+  integrity sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-replace-supers" "^7.13.12"
+    "@babel/helper-simple-access" "^7.13.12"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/helper-validator-identifier" "^7.14.0"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.14.2"
+    "@babel/types" "^7.14.2"
+
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz#5c02d171b4c8615b1e7163f888c1c81c30a2aaea"
@@ -311,36 +341,36 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz#174254d0f2424d8aefb4dd48057511247b0a9eeb"
-  integrity sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz#806526ce125aed03373bc416a828321e3a6a33af"
+  integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
 
-"@babel/helper-remap-async-to-generator@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.13.tgz#170365f4140e2d20e5c88f8ba23c24468c296878"
-  integrity sha512-Qa6PU9vNcj1NZacZZI1Mvwt+gXDH6CTfgAkSjeRMLE8HxtDK76+YDId6NQR+z7Rgd5arhD2cIbS74r0SxD6PDA==
+"@babel/helper-remap-async-to-generator@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz#376a760d9f7b4b2077a9dd05aa9c3927cadb2209"
+  integrity sha512-pUQpFBE9JvC9lrQbpX0TmeNIy5s7GnZjna2lhhcHC7DzgBs6fWn722Y5cfwgrtrqc7NAJwMvOa0mKhq6XaE4jg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
-    "@babel/helper-wrap-function" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/helper-wrap-function" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helper-replace-supers@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz#00ec4fb6862546bd3d0aff9aac56074277173121"
-  integrity sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==
+"@babel/helper-replace-supers@^7.12.13", "@babel/helper-replace-supers@^7.13.12", "@babel/helper-replace-supers@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.4.tgz#b2ab16875deecfff3ddfcd539bc315f72998d836"
+  integrity sha512-zZ7uHCWlxfEAAOVDYQpEf/uyi1dmeC7fX4nCf2iz9drnCwi1zvwXL3HwWWNXUQEJ1k23yVn3VbddiI9iJEXaTQ==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.12.13"
+    "@babel/helper-member-expression-to-functions" "^7.13.12"
     "@babel/helper-optimise-call-expression" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/traverse" "^7.14.2"
+    "@babel/types" "^7.14.4"
 
-"@babel/helper-simple-access@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz#8478bcc5cacf6aa1672b251c1d2dde5ccd61a6c4"
-  integrity sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==
+"@babel/helper-simple-access@^7.12.13", "@babel/helper-simple-access@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz#dd6c538afb61819d205a012c31792a39c7a5eaf6"
+  integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.13.12"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -356,27 +386,27 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
-"@babel/helper-validator-identifier@^7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
-  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
+  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
 
-"@babel/helper-validator-option@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.16.tgz#f73cbd3bbba51915216c5dea908e9b206bb10051"
-  integrity sha512-uCgsDBPUQDvzr11ePPo4TVEocxj8RXjUVSC/Y8N1YpVAI/XDdUwGJu78xmlGhTxj2ntaWM7n9LQdRtyhOzT2YQ==
+"@babel/helper-validator-option@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz#d1fbf012e1a79b7eebbfdc6d270baaf8d9eb9831"
+  integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
 
-"@babel/helper-wrap-function@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.12.13.tgz#e3ea8cb3ee0a16911f9c1b50d9e99fe8fe30f9ff"
-  integrity sha512-t0aZFEmBJ1LojdtJnhOaQEVejnzYhyjWHSsNSNo8vOYRbAJNh6r6GQF7pd36SqG7OKGbn+AewVQ/0IfYfIuGdw==
+"@babel/helper-wrap-function@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.13.0.tgz#bdb5c66fda8526ec235ab894ad53a1235c79fcc4"
+  integrity sha512-1UX9F7K3BS42fI6qd2A4BjKzgGjToscyZTdp1DjknHLCIvpgne6918io+aL5LXFcER/8QWiwpoY902pVEqgTXA==
   dependencies:
     "@babel/helper-function-name" "^7.12.13"
     "@babel/template" "^7.12.13"
-    "@babel/traverse" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/traverse" "^7.13.0"
+    "@babel/types" "^7.13.0"
 
-"@babel/helpers@^7.12.13", "@babel/helpers@^7.12.5":
+"@babel/helpers@^7.12.5":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.13.tgz#3c75e993632e4dadc0274eae219c73eb7645ba47"
   integrity sha512-oohVzLRZ3GQEk4Cjhfs9YkJA4TdIDTObdBEZGrd6F/T0GPSnuV6l22eMcxlvcvzVIPH3VTtxbseudM1zIE+rPQ==
@@ -385,83 +415,115 @@
     "@babel/traverse" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/highlight@^7.12.13", "@babel/highlight@^7.8.3":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.12.13.tgz#8ab538393e00370b26271b01fa08f7f27f2e795c"
-  integrity sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==
+"@babel/helpers@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.0.tgz#ea9b6be9478a13d6f961dbb5f36bf75e2f3b8f62"
+  integrity sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
+    "@babel/template" "^7.12.13"
+    "@babel/traverse" "^7.14.0"
+    "@babel/types" "^7.14.0"
+
+"@babel/highlight@^7.12.13", "@babel/highlight@^7.8.3":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
+  integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.13", "@babel/parser@^7.12.16", "@babel/parser@^7.12.5", "@babel/parser@^7.12.7":
+"@babel/parser@^7.12.13", "@babel/parser@^7.14.2", "@babel/parser@^7.14.3":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.4.tgz#a5c560d6db6cd8e6ed342368dea8039232cbab18"
+  integrity sha512-ArliyUsWDUqEGfWcmzpGUzNfLxTdTp6WU4IuP6QFSp9gGfWS6boxFCkJSJ/L4+RG8z/FnIU3WxCk6hPL9SSWeA==
+
+"@babel/parser@^7.12.5", "@babel/parser@^7.12.7":
   version "7.12.16"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.16.tgz#cc31257419d2c3189d394081635703f549fc1ed4"
   integrity sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==
 
-"@babel/plugin-proposal-async-generator-functions@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.13.tgz#d1c6d841802ffb88c64a2413e311f7345b9e66b5"
-  integrity sha512-1KH46Hx4WqP77f978+5Ye/VUbuwQld2hph70yaw2hXS2v7ER2f3nlpNMu909HO2rbvP0NKLlMVDPh9KXklVMhA==
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
+  version "7.13.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz#a3484d84d0b549f3fc916b99ee4783f26fabad2a"
+  integrity sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-remap-async-to-generator" "^7.12.13"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.13.12"
 
-"@babel/plugin-proposal-class-properties@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.13.tgz#3d2ce350367058033c93c098e348161d6dc0d8c8"
-  integrity sha512-8SCJ0Ddrpwv4T7Gwb33EmW1V9PY5lggTO+A8WjyIwxrSHDUyBw4MtF96ifn1n8H806YlxbVCoKXbbmzD6RD+cA==
+"@babel/plugin-proposal-async-generator-functions@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.2.tgz#3a2085abbf5d5f962d480dbc81347385ed62eb1e"
+  integrity sha512-b1AM4F6fwck4N8ItZ/AtC4FP/cqZqmKRQ4FaTDutwSYyjuhtvsGEMLK4N/ztV/ImP40BjIDyMgBQAeAMsQYVFQ==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-remap-async-to-generator" "^7.13.0"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
 
-"@babel/plugin-proposal-dynamic-import@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.16.tgz#b9f33b252e3406d492a15a799c9d45a9a9613473"
-  integrity sha512-yiDkYFapVxNOCcBfLnsb/qdsliroM+vc3LHiZwS4gh7pFjo5Xq3BDhYBNn3H3ao+hWPvqeeTdU+s+FIvokov+w==
+"@babel/plugin-proposal-class-properties@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"
+  integrity sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/helper-create-class-features-plugin" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-proposal-export-namespace-from@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz#393be47a4acd03fa2af6e3cde9b06e33de1b446d"
-  integrity sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==
+"@babel/plugin-proposal-class-static-block@^7.14.3":
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.3.tgz#5a527e2cae4a4753119c3a3e7f64ecae8ccf1360"
+  integrity sha512-HEjzp5q+lWSjAgJtSluFDrGGosmwTgKwCXdDQZvhKsRlwv3YdkUEqxNrrjesJd+B9E9zvr1PVPVBvhYZ9msjvQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-create-class-features-plugin" "^7.14.3"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-class-static-block" "^7.12.13"
+
+"@babel/plugin-proposal-dynamic-import@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.2.tgz#01ebabd7c381cff231fa43e302939a9de5be9d9f"
+  integrity sha512-oxVQZIWFh91vuNEMKltqNsKLFWkOIyJc95k2Gv9lWVyDfPUQGSSlbDEgWuJUU1afGE9WwlzpucMZ3yDRHIItkA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+
+"@babel/plugin-proposal-export-namespace-from@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.2.tgz#62542f94aa9ce8f6dba79eec698af22112253791"
+  integrity sha512-sRxW3z3Zp3pFfLAgVEvzTFutTXax837oOatUIvSG9o5gRj9mKwm3br1Se5f4QalTQs9x4AzlA/HrCWbQIHASUQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-proposal-json-strings@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.13.tgz#ced7888a2db92a3d520a2e35eb421fdb7fcc9b5d"
-  integrity sha512-v9eEi4GiORDg8x+Dmi5r8ibOe0VXoKDeNPYcTTxdGN4eOWikrJfDJCJrr1l5gKGvsNyGJbrfMftC2dTL6oz7pg==
+"@babel/plugin-proposal-json-strings@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.2.tgz#830b4e2426a782e8b2878fbfe2cba85b70cbf98c"
+  integrity sha512-w2DtsfXBBJddJacXMBhElGEYqCZQqN99Se1qeYn8DVLB33owlrlLftIbMzn5nz1OITfDVknXF433tBrLEAOEjA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
 
-"@babel/plugin-proposal-logical-assignment-operators@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.13.tgz#575b5d9a08d8299eeb4db6430da6e16e5cf14350"
-  integrity sha512-fqmiD3Lz7jVdK6kabeSr1PZlWSUVqSitmHEe3Z00dtGTKieWnX9beafvavc32kjORa5Bai4QNHgFDwWJP+WtSQ==
+"@babel/plugin-proposal-logical-assignment-operators@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.2.tgz#222348c080a1678e0e74ea63fe76f275882d1fd7"
+  integrity sha512-1JAZtUrqYyGsS7IDmFeaem+/LJqujfLZ2weLR9ugB0ufUPjzf8cguyVT1g5im7f7RXxuLq1xUxEzvm68uYRtGg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.13.tgz#24867307285cee4e1031170efd8a7ac807deefde"
-  integrity sha512-Qoxpy+OxhDBI5kRqliJFAl4uWXk3Bn24WeFstPH0iLymFehSAUR8MHpqU7njyXv/qbo7oN6yTy5bfCmXdKpo1Q==
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.2.tgz#425b11dc62fc26939a2ab42cbba680bdf5734546"
+  integrity sha512-ebR0zU9OvI2N4qiAC38KIAK75KItpIPTpAtd2r4OZmMFeKbKJpUFLYP2EuDut82+BmYi8sz42B+TfTptJ9iG5Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
 
-"@babel/plugin-proposal-numeric-separator@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz#bd9da3188e787b5120b4f9d465a8261ce67ed1db"
-  integrity sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==
+"@babel/plugin-proposal-numeric-separator@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.2.tgz#82b4cc06571143faf50626104b335dd71baa4f9e"
+  integrity sha512-DcTQY9syxu9BpU3Uo94fjCB3LN9/hgPS8oUL7KrSW3bA2ePrKZZPJcc5y0hoJAM9dft3pGfErtEUvxXQcfLxUg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
 "@babel/plugin-proposal-object-rest-spread@7.12.1":
@@ -473,39 +535,51 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-transform-parameters" "^7.12.1"
 
-"@babel/plugin-proposal-object-rest-spread@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.13.tgz#f93f3116381ff94bc676fdcb29d71045cd1ec011"
-  integrity sha512-WvA1okB/0OS/N3Ldb3sziSrXg6sRphsBgqiccfcQq7woEn5wQLNX82Oc4PlaFcdwcWHuQXAtb8ftbS8Fbsg/sg==
+"@babel/plugin-proposal-object-rest-spread@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.4.tgz#0e2b4de419915dc0b409378e829412e2031777c4"
+  integrity sha512-AYosOWBlyyXEagrPRfLJ1enStufsr7D1+ddpj8OLi9k7B6+NdZ0t/9V7Fh+wJ4g2Jol8z2JkgczYqtWrZd4vbA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-transform-parameters" "^7.12.13"
+    "@babel/compat-data" "^7.14.4"
+    "@babel/helper-compilation-targets" "^7.14.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-transform-parameters" "^7.14.2"
 
-"@babel/plugin-proposal-optional-catch-binding@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.13.tgz#4640520afe57728af14b4d1574ba844f263bcae5"
-  integrity sha512-9+MIm6msl9sHWg58NvqpNpLtuFbmpFYk37x8kgnGzAHvX35E1FyAwSUt5hIkSoWJFSAH+iwU8bJ4fcD1zKXOzg==
+"@babel/plugin-proposal-optional-catch-binding@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.2.tgz#150d4e58e525b16a9a1431bd5326c4eed870d717"
+  integrity sha512-XtkJsmJtBaUbOxZsNk0Fvrv8eiqgneug0A6aqLFZ4TSkar2L5dSXWcnUKHgmjJt49pyB/6ZHvkr3dPgl9MOWRQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.16.tgz#600c7531f754186b0f2096e495a92da7d88aa139"
-  integrity sha512-O3ohPwOhkwji5Mckb7F/PJpJVJY3DpPsrt/F0Bk40+QMk9QpAIqeGusHWqu/mYqsM8oBa6TziL/2mbERWsUZjg==
+"@babel/plugin-proposal-optional-chaining@^7.12.1", "@babel/plugin-proposal-optional-chaining@^7.13.12", "@babel/plugin-proposal-optional-chaining@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.2.tgz#df8171a8b9c43ebf4c1dabe6311b432d83e1b34e"
+  integrity sha512-qQByMRPwMZJainfig10BoaDldx/+VDtNcrA7qdNaEOAj6VXud+gfrkA8j4CRAU5HjnWREXqIpSpH30qZX1xivA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-proposal-private-methods@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.13.tgz#ea78a12554d784ecf7fc55950b752d469d9c4a71"
-  integrity sha512-sV0V57uUwpauixvR7s2o75LmwJI6JECwm5oPUY5beZB1nBl2i37hc7CJGqB5G+58fur5Y6ugvl3LRONk5x34rg==
+"@babel/plugin-proposal-private-methods@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.13.0.tgz#04bd4c6d40f6e6bbfa2f57e2d8094bad900ef787"
+  integrity sha512-MXyyKQd9inhx1kDYPkFRVOBXQ20ES8Pto3T7UZ92xj2mY0EVD8oAVzeyYuVfy/mxAdTSIayOvg+aVzcHV2bn6Q==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-create-class-features-plugin" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+
+"@babel/plugin-proposal-private-property-in-object@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.14.0.tgz#b1a1f2030586b9d3489cc26179d2eb5883277636"
+  integrity sha512-59ANdmEwwRUkLjB7CRtwJxxwtjESw+X2IePItA+RGQh+oy5RmpCh/EvVVvh5XQc3yxsm5gtv0+i9oBZhaDNVTg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.13"
+    "@babel/helper-create-class-features-plugin" "^7.14.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.12.13", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
   version "7.12.13"
@@ -515,7 +589,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.13"
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-async-generators@^7.8.0":
+"@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
   integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
@@ -529,7 +603,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.0", "@babel/plugin-syntax-dynamic-import@^7.8.3":
+"@babel/plugin-syntax-class-static-block@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.12.13.tgz#8e3d674b0613e67975ceac2776c97b60cafc5c9c"
+  integrity sha512-ZmKQ0ZXR0nYpHZIIuj9zE7oIqCx2hw9TKi+lIo73NNrMPAZGHfS92/VRV0ZmPj6H2ffBgyFHXvJ5NYsNeEaP2A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
@@ -543,7 +624,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-json-strings@^7.8.0":
+"@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
@@ -571,7 +652,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
@@ -585,26 +666,33 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-object-rest-spread@7.8.3", "@babel/plugin-syntax-object-rest-spread@^7.8.0":
+"@babel/plugin-syntax-object-rest-spread@7.8.3", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.0":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.0.tgz#762a4babec61176fec6c88480dec40372b140c0b"
+  integrity sha512-bda3xF8wGl5/5btF794utNOL0Jw+9jE5C1sLZcoK7c4uonE/y3iQiyG+KbkF3WBV/paX58VCpjhxLPkdj5Fe4w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-syntax-top-level-await@^7.12.13":
   version "7.12.13"
@@ -620,21 +708,21 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-arrow-functions@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.13.tgz#eda5670b282952100c229f8a3bd49e0f6a72e9fe"
-  integrity sha512-tBtuN6qtCTd+iHzVZVOMNp+L04iIJBpqkdY42tWbmjIT5wvR2kx7gxMBsyhQtFzHwBbyGi9h8J8r9HgnOpQHxg==
+"@babel/plugin-transform-arrow-functions@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.13.0.tgz#10a59bebad52d637a027afa692e8d5ceff5e3dae"
+  integrity sha512-96lgJagobeVmazXFaDrbmCLQxBysKu7U6Do3mLsx27gf5Dk85ezysrs2BZUpXD703U/Su1xTBDxxar2oa4jAGg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-async-to-generator@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.13.tgz#fed8c69eebf187a535bfa4ee97a614009b24f7ae"
-  integrity sha512-psM9QHcHaDr+HZpRuJcE1PXESuGWSCcbiGFFhhwfzdbTxaGDVzuVtdNYliAwcRo3GFg0Bc8MmI+AvIGYIJG04A==
+"@babel/plugin-transform-async-to-generator@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.13.0.tgz#8e112bf6771b82bf1e974e5e26806c5c99aa516f"
+  integrity sha512-3j6E004Dx0K3eGmhxVJxwwI89CTJrce7lg3UrtFuDAVQ/2+SJ/h/aSFOeE6/n0WB1GsOffsJp6MnPQNQ8nmwhg==
   dependencies:
     "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-remap-async-to-generator" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-remap-async-to-generator" "^7.13.0"
 
 "@babel/plugin-transform-block-scoped-functions@^7.12.13":
   version "7.12.13"
@@ -643,39 +731,39 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-block-scoping@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz#f36e55076d06f41dfd78557ea039c1b581642e61"
-  integrity sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==
+"@babel/plugin-transform-block-scoping@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.4.tgz#caf140b0b2e2462c509553d140e6d0abefb61ed8"
+  integrity sha512-5KdpkGxsZlTk+fPleDtGKsA+pon28+ptYmMO8GBSa5fHERCJWAzj50uAfCKBqq42HO+Zot6JF1x37CRprwmN4g==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-classes@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.13.tgz#9728edc1838b5d62fc93ad830bd523b1fcb0e1f6"
-  integrity sha512-cqZlMlhCC1rVnxE5ZGMtIb896ijL90xppMiuWXcwcOAuFczynpd3KYemb91XFFPi3wJSe/OcrX9lXoowatkkxA==
+"@babel/plugin-transform-classes@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.4.tgz#a83c15503fc71a0f99e876fdce7dadbc6575ec3a"
+  integrity sha512-p73t31SIj6y94RDVX57rafVjttNr8MvKEgs5YFatNB/xC68zM3pyosuOEcQmYsYlyQaGY9R7rAULVRcat5FKJQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
-    "@babel/helper-function-name" "^7.12.13"
+    "@babel/helper-function-name" "^7.14.2"
     "@babel/helper-optimise-call-expression" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-replace-supers" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-replace-supers" "^7.14.4"
     "@babel/helper-split-export-declaration" "^7.12.13"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.13.tgz#6a210647a3d67f21f699cfd2a01333803b27339d"
-  integrity sha512-dDfuROUPGK1mTtLKyDPUavmj2b6kFu82SmgpztBFEO974KMjJT+Ytj3/oWsTUMBmgPcp9J5Pc1SlcAYRpJ2hRA==
+"@babel/plugin-transform-computed-properties@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.13.0.tgz#845c6e8b9bb55376b1fa0b92ef0bdc8ea06644ed"
+  integrity sha512-RRqTYTeZkZAz8WbieLTvKUEUxZlUTdmL5KGMyZj7FnMfLNKV4+r5549aORG/mgojRmFlQMJDUupwAMiF2Q7OUg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-destructuring@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.13.tgz#fc56c5176940c5b41735c677124d1d20cecc9aeb"
-  integrity sha512-Dn83KykIFzjhA3FDPA1z4N+yfF3btDGhjnJwxIj0T43tP0flCujnU8fKgEkf0C1biIpSv9NZegPBQ1J6jYkwvQ==
+"@babel/plugin-transform-destructuring@^7.14.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.4.tgz#acbec502e9951f30f4441eaca1d2f29efade59ed"
+  integrity sha512-JyywKreTCGTUsL1OKu1A3ms/R1sTP0WxbpXlALeGzF53eB3bxtNkYdMj9SDgK7g6ImPy76J5oYYKoTtQImlhQA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-dotall-regex@^7.12.13", "@babel/plugin-transform-dotall-regex@^7.4.4":
   version "7.12.13"
@@ -700,12 +788,12 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.12.13"
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-for-of@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.13.tgz#561ff6d74d9e1c8879cb12dbaf4a14cd29d15cf6"
-  integrity sha512-xCbdgSzXYmHGyVX3+BsQjcd4hv4vA/FDy7Kc8eOpzKmBBPEOTurt0w5fCRQaGl+GSBORKgJdstQ1rHl4jbNseQ==
+"@babel/plugin-transform-for-of@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.13.0.tgz#c799f881a8091ac26b54867a845c3e97d2696062"
+  integrity sha512-IHKT00mwUVYE0zzbkDgNRP6SRzvfGCYsOxIRz8KsiaaHCcT9BWIkO+H9QRJseHBLOGBZkHUdHiqj6r0POsdytg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-function-name@^7.12.13":
   version "7.12.13"
@@ -729,43 +817,43 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-modules-amd@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.13.tgz#43db16249b274ee2e551e2422090aa1c47692d56"
-  integrity sha512-JHLOU0o81m5UqG0Ulz/fPC68/v+UTuGTWaZBUwpEk1fYQ1D9LfKV6MPn4ttJKqRo5Lm460fkzjLTL4EHvCprvA==
+"@babel/plugin-transform-modules-amd@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.2.tgz#6622806fe1a7c07a1388444222ef9535f2ca17b0"
+  integrity sha512-hPC6XBswt8P3G2D1tSV2HzdKvkqOpmbyoy+g73JG0qlF/qx2y3KaMmXb1fLrpmWGLZYA0ojCvaHdzFWjlmV+Pw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-module-transforms" "^7.14.2"
+    "@babel/helper-plugin-utils" "^7.13.0"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.13.tgz#5043b870a784a8421fa1fd9136a24f294da13e50"
-  integrity sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==
+"@babel/plugin-transform-modules-commonjs@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.0.tgz#52bc199cb581e0992edba0f0f80356467587f161"
+  integrity sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-simple-access" "^7.12.13"
+    "@babel/helper-module-transforms" "^7.14.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-simple-access" "^7.13.12"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-systemjs@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.13.tgz#351937f392c7f07493fc79b2118201d50404a3c5"
-  integrity sha512-aHfVjhZ8QekaNF/5aNdStCGzwTbU7SI5hUybBKlMzqIMC7w7Ho8hx5a4R/DkTHfRfLwHGGxSpFt9BfxKCoXKoA==
+"@babel/plugin-transform-modules-systemjs@^7.13.8":
+  version "7.13.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz#6d066ee2bff3c7b3d60bf28dec169ad993831ae3"
+  integrity sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==
   dependencies:
-    "@babel/helper-hoist-variables" "^7.12.13"
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-hoist-variables" "^7.13.0"
+    "@babel/helper-module-transforms" "^7.13.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-validator-identifier" "^7.12.11"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-umd@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.13.tgz#26c66f161d3456674e344b4b1255de4d530cfb37"
-  integrity sha512-BgZndyABRML4z6ibpi7Z98m4EVLFI9tVsZDADC14AElFaNHHBcJIovflJ6wtCqFxwy2YJ1tJhGRsr0yLPKoN+w==
+"@babel/plugin-transform-modules-umd@^7.14.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.0.tgz#2f8179d1bbc9263665ce4a65f305526b2ea8ac34"
+  integrity sha512-nPZdnWtXXeY7I87UZr9VlsWme3Y0cfFFE41Wbxz4bbaexAjNMInXPFUpRRUJ8NoMm0Cw+zxbqjdPmLhcjfazMw==
   dependencies:
-    "@babel/helper-module-transforms" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-module-transforms" "^7.14.0"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-named-capturing-groups-regex@^7.12.13":
   version "7.12.13"
@@ -789,12 +877,19 @@
     "@babel/helper-plugin-utils" "^7.12.13"
     "@babel/helper-replace-supers" "^7.12.13"
 
-"@babel/plugin-transform-parameters@^7.12.1", "@babel/plugin-transform-parameters@^7.12.13":
+"@babel/plugin-transform-parameters@^7.12.1":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.13.tgz#461e76dfb63c2dfd327b8a008a9e802818ce9853"
   integrity sha512-e7QqwZalNiBRHCpJg/P8s/VJeSRYgmtWySs1JwvfwPqhBbiWfOcHDKdeAi6oAyIimoKWBlwc8oTgbZHdhCoVZA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-transform-parameters@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.2.tgz#e4290f72e0e9e831000d066427c4667098decc31"
+  integrity sha512-NxoVmA3APNCC1JdMXkdYXuQS+EMdqy0vIwyDHeKHiJKRxmp1qGSdb0JLEIoPRhkx6H/8Qi3RJ3uqOCYw8giy9A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-property-literals@^7.12.13":
   version "7.12.13"
@@ -804,36 +899,36 @@
     "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-transform-react-constant-elements@^7.12.1":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.12.13.tgz#f8ee56888545d53d80f766b3cc1563ab2c241f92"
-  integrity sha512-qmzKVTn46Upvtxv8LQoQ8mTCdUC83AOVQIQm57e9oekLT5cmK9GOMOfcWhe8jMNx4UJXn/UDhVZ/7lGofVNeDQ==
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.13.13.tgz#0208b1d942bf939cd4f7aa5b255d42602aa4a920"
+  integrity sha512-SNJU53VM/SjQL0bZhyU+f4kJQz7bQQajnrZRSaU21hruG/NWY41AEM9AWXeXX90pYr/C2yAmTgI6yW3LlLrAUQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-react-display-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.13.tgz#c28effd771b276f4647411c9733dbb2d2da954bd"
-  integrity sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.14.2.tgz#2e854544d42ab3bb9c21f84e153d62e800fbd593"
+  integrity sha512-zCubvP+jjahpnFJvPaHPiGVfuVUjXHhFvJKQdNnsmSsiU9kR/rCZ41jHc++tERD2zV+p7Hr6is+t5b6iWTCqSw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
-"@babel/plugin-transform-react-jsx-development@^7.12.12":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.16.tgz#af187e749d123b54ae49bc7e034057a0c1d4d568"
-  integrity sha512-GOp5SkMC4zhHwLbOSYhF+WpIZSf5bGzaKQTT9jWkemJRDM/CE6FtPydXjEYO3pHcna2Zjvg4mQ1lfjOR/4jsaQ==
+"@babel/plugin-transform-react-jsx-development@^7.12.17":
+  version "7.12.17"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.17.tgz#f510c0fa7cd7234153539f9a362ced41a5ca1447"
+  integrity sha512-BPjYV86SVuOaudFhsJR1zjgxxOhJDt6JHNoD48DxWEIxUCAMjV1ys6DYw4SDYZh0b1QsS2vfIA9t/ZsQGsDOUQ==
   dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.12.16"
+    "@babel/plugin-transform-react-jsx" "^7.12.17"
 
-"@babel/plugin-transform-react-jsx@^7.12.13", "@babel/plugin-transform-react-jsx@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.16.tgz#07c341e02a3e4066b00413534f30c42519923230"
-  integrity sha512-dNu0vAbIk8OkqJfGtYF6ADk6jagoyAl+Ks5aoltbAlfoKv8d6yooi3j+kObeSQaCj9PgN6KMZPB90wWyek5TmQ==
+"@babel/plugin-transform-react-jsx@^7.12.17", "@babel/plugin-transform-react-jsx@^7.13.12":
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.3.tgz#0e26597805cf0862da735f264550933c38babb66"
+  integrity sha512-uuxuoUNVhdgYzERiHHFkE4dWoJx+UFVyuAl0aqN8P2/AKFHwqgUC5w2+4/PjpKXJsFgBlYAFXlUmDQ3k3DUkXw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.12.13"
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-jsx" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.2"
 
 "@babel/plugin-transform-react-pure-annotations@^7.12.1":
   version "7.12.1"
@@ -843,10 +938,10 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-regenerator@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz#b628bcc9c85260ac1aeb05b45bde25210194a2f5"
-  integrity sha512-lxb2ZAvSLyJ2PEe47hoGWPmW22v7CtSl9jW8mingV4H2sEX/JOcrAj2nPuGWi56ERUm2bUpjKzONAuT6HCn2EA==
+"@babel/plugin-transform-regenerator@^7.13.15":
+  version "7.13.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.13.15.tgz#e5eb28945bf8b6563e7f818945f966a8d2997f39"
+  integrity sha512-Bk9cOLSz8DiurcMETZ8E2YtIVJbFCPGW28DJWUakmyVWtQSm6Wsf0p4B4BfEr/eL2Nkhe/CICiUiMOCi1TPhuQ==
   dependencies:
     regenerator-transform "^0.14.2"
 
@@ -858,13 +953,16 @@
     "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/plugin-transform-runtime@^7.12.1":
-  version "7.12.15"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz#4337b2507288007c2b197059301aa0af8d90c085"
-  integrity sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.3.tgz#1fd885a2d0de1d3c223795a4e9be72c2db4515cf"
+  integrity sha512-t960xbi8wpTFE623ef7sd+UpEC5T6EEguQlTBJDEO05+XwnIWVfuqLw/vdLWY6IdFmtZE+65CZAfByT39zRpkg==
   dependencies:
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    semver "^5.5.1"
+    "@babel/helper-module-imports" "^7.13.12"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    babel-plugin-polyfill-corejs2 "^0.2.0"
+    babel-plugin-polyfill-corejs3 "^0.2.0"
+    babel-plugin-polyfill-regenerator "^0.2.0"
+    semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.12.13":
   version "7.12.13"
@@ -873,12 +971,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-spread@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.13.tgz#ca0d5645abbd560719c354451b849f14df4a7949"
-  integrity sha512-dUCrqPIowjqk5pXsx1zPftSq4sT0aCeZVAxhdgs3AMgyaDmoUT0G+5h3Dzja27t76aUEIJWlFgPJqJ/d4dbTtg==
+"@babel/plugin-transform-spread@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.13.0.tgz#84887710e273c1815ace7ae459f6f42a5d31d5fd"
+  integrity sha512-V6vkiXijjzYeFmQTr3dBxPtZYLPcUfY34DebOU27jIl2M/Y8Egm52Hw82CSjjPqd54GTlJs5x+CR7HeNr24ckg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
 "@babel/plugin-transform-sticky-regex@^7.12.13":
@@ -888,12 +986,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-template-literals@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.13.tgz#655037b07ebbddaf3b7752f55d15c2fd6f5aa865"
-  integrity sha512-arIKlWYUgmNsF28EyfmiQHJLJFlAJNYkuQO10jL46ggjBpeb2re1P9K9YGxNJB45BqTbaslVysXDYm/g3sN/Qg==
+"@babel/plugin-transform-template-literals@^7.13.0":
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.13.0.tgz#a36049127977ad94438dee7443598d1cefdf409d"
+  integrity sha512-d67umW6nlfmr1iehCcBv69eSUSySk1EsIS8aTDX4Xo9qajAh6mYtcl4kJrBkGXuxZPEgVr7RVfAvNW6YQkd4Mw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
 
 "@babel/plugin-transform-typeof-symbol@^7.12.13":
   version "7.12.13"
@@ -902,13 +1000,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-typescript@^7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.16.tgz#3f30b829bdd15683f71c32fa31330c2af8c1b732"
-  integrity sha512-88hep+B6dtDOiEqtRzwHp2TYO+CN8nbAV3eh5OpBGPsedug9J6y1JwLKzXRIGGQZDC8NlpxpQMIIxcfIW96Wgw==
+"@babel/plugin-transform-typescript@^7.13.0":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.4.tgz#1c48829fa6d5f2de646060cd08abb6cda4b521a7"
+  integrity sha512-WYdcGNEO7mCCZ2XzRlxwGj3PgeAr50ifkofOUC/+IN/GzKLB+biDPVBUAQN2C/dVZTvEXCp80kfQ1FFZPrwykQ==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.12.16"
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-create-class-features-plugin" "^7.14.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-typescript" "^7.12.13"
 
 "@babel/plugin-transform-unicode-escapes@^7.12.13":
@@ -927,78 +1025,85 @@
     "@babel/helper-plugin-utils" "^7.12.13"
 
 "@babel/preset-env@^7.12.1":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.16.tgz#16710e3490e37764b2f41886de0a33bc4ae91082"
-  integrity sha512-BXCAXy8RE/TzX416pD2hsVdkWo0G+tYd16pwnRV4Sc0fRwTLRS/Ssv8G5RLXUGQv7g4FG7TXkdDJxCjQ5I+Zjg==
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.4.tgz#73fc3228c59727e5e974319156f304f0d6685a2d"
+  integrity sha512-GwMMsuAnDtULyOtuxHhzzuSRxFeP0aR/LNzrHRzP8y6AgDNgqnrfCCBm/1cRdTU75tRs28Eh76poHLcg9VF0LA==
   dependencies:
-    "@babel/compat-data" "^7.12.13"
-    "@babel/helper-compilation-targets" "^7.12.16"
-    "@babel/helper-module-imports" "^7.12.13"
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-validator-option" "^7.12.16"
-    "@babel/plugin-proposal-async-generator-functions" "^7.12.13"
-    "@babel/plugin-proposal-class-properties" "^7.12.13"
-    "@babel/plugin-proposal-dynamic-import" "^7.12.16"
-    "@babel/plugin-proposal-export-namespace-from" "^7.12.13"
-    "@babel/plugin-proposal-json-strings" "^7.12.13"
-    "@babel/plugin-proposal-logical-assignment-operators" "^7.12.13"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.13"
-    "@babel/plugin-proposal-numeric-separator" "^7.12.13"
-    "@babel/plugin-proposal-object-rest-spread" "^7.12.13"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.12.13"
-    "@babel/plugin-proposal-optional-chaining" "^7.12.16"
-    "@babel/plugin-proposal-private-methods" "^7.12.13"
+    "@babel/compat-data" "^7.14.4"
+    "@babel/helper-compilation-targets" "^7.14.4"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-option" "^7.12.17"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.13.12"
+    "@babel/plugin-proposal-async-generator-functions" "^7.14.2"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-class-static-block" "^7.14.3"
+    "@babel/plugin-proposal-dynamic-import" "^7.14.2"
+    "@babel/plugin-proposal-export-namespace-from" "^7.14.2"
+    "@babel/plugin-proposal-json-strings" "^7.14.2"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.14.2"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.14.2"
+    "@babel/plugin-proposal-numeric-separator" "^7.14.2"
+    "@babel/plugin-proposal-object-rest-spread" "^7.14.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.14.2"
+    "@babel/plugin-proposal-optional-chaining" "^7.14.2"
+    "@babel/plugin-proposal-private-methods" "^7.13.0"
+    "@babel/plugin-proposal-private-property-in-object" "^7.14.0"
     "@babel/plugin-proposal-unicode-property-regex" "^7.12.13"
-    "@babel/plugin-syntax-async-generators" "^7.8.0"
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
     "@babel/plugin-syntax-class-properties" "^7.12.13"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
+    "@babel/plugin-syntax-class-static-block" "^7.12.13"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
-    "@babel/plugin-syntax-json-strings" "^7.8.0"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
-    "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.0"
     "@babel/plugin-syntax-top-level-await" "^7.12.13"
-    "@babel/plugin-transform-arrow-functions" "^7.12.13"
-    "@babel/plugin-transform-async-to-generator" "^7.12.13"
+    "@babel/plugin-transform-arrow-functions" "^7.13.0"
+    "@babel/plugin-transform-async-to-generator" "^7.13.0"
     "@babel/plugin-transform-block-scoped-functions" "^7.12.13"
-    "@babel/plugin-transform-block-scoping" "^7.12.13"
-    "@babel/plugin-transform-classes" "^7.12.13"
-    "@babel/plugin-transform-computed-properties" "^7.12.13"
-    "@babel/plugin-transform-destructuring" "^7.12.13"
+    "@babel/plugin-transform-block-scoping" "^7.14.4"
+    "@babel/plugin-transform-classes" "^7.14.4"
+    "@babel/plugin-transform-computed-properties" "^7.13.0"
+    "@babel/plugin-transform-destructuring" "^7.14.4"
     "@babel/plugin-transform-dotall-regex" "^7.12.13"
     "@babel/plugin-transform-duplicate-keys" "^7.12.13"
     "@babel/plugin-transform-exponentiation-operator" "^7.12.13"
-    "@babel/plugin-transform-for-of" "^7.12.13"
+    "@babel/plugin-transform-for-of" "^7.13.0"
     "@babel/plugin-transform-function-name" "^7.12.13"
     "@babel/plugin-transform-literals" "^7.12.13"
     "@babel/plugin-transform-member-expression-literals" "^7.12.13"
-    "@babel/plugin-transform-modules-amd" "^7.12.13"
-    "@babel/plugin-transform-modules-commonjs" "^7.12.13"
-    "@babel/plugin-transform-modules-systemjs" "^7.12.13"
-    "@babel/plugin-transform-modules-umd" "^7.12.13"
+    "@babel/plugin-transform-modules-amd" "^7.14.2"
+    "@babel/plugin-transform-modules-commonjs" "^7.14.0"
+    "@babel/plugin-transform-modules-systemjs" "^7.13.8"
+    "@babel/plugin-transform-modules-umd" "^7.14.0"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.12.13"
     "@babel/plugin-transform-new-target" "^7.12.13"
     "@babel/plugin-transform-object-super" "^7.12.13"
-    "@babel/plugin-transform-parameters" "^7.12.13"
+    "@babel/plugin-transform-parameters" "^7.14.2"
     "@babel/plugin-transform-property-literals" "^7.12.13"
-    "@babel/plugin-transform-regenerator" "^7.12.13"
+    "@babel/plugin-transform-regenerator" "^7.13.15"
     "@babel/plugin-transform-reserved-words" "^7.12.13"
     "@babel/plugin-transform-shorthand-properties" "^7.12.13"
-    "@babel/plugin-transform-spread" "^7.12.13"
+    "@babel/plugin-transform-spread" "^7.13.0"
     "@babel/plugin-transform-sticky-regex" "^7.12.13"
-    "@babel/plugin-transform-template-literals" "^7.12.13"
+    "@babel/plugin-transform-template-literals" "^7.13.0"
     "@babel/plugin-transform-typeof-symbol" "^7.12.13"
     "@babel/plugin-transform-unicode-escapes" "^7.12.13"
     "@babel/plugin-transform-unicode-regex" "^7.12.13"
-    "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.12.13"
-    core-js-compat "^3.8.0"
-    semver "^5.5.0"
+    "@babel/preset-modules" "^0.1.4"
+    "@babel/types" "^7.14.4"
+    babel-plugin-polyfill-corejs2 "^0.2.0"
+    babel-plugin-polyfill-corejs3 "^0.2.0"
+    babel-plugin-polyfill-regenerator "^0.2.0"
+    core-js-compat "^3.9.0"
+    semver "^6.3.0"
 
-"@babel/preset-modules@^0.1.3":
+"@babel/preset-modules@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.4.tgz#362f2b68c662842970fdb5e254ffc8fc1c2e415e"
   integrity sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
@@ -1010,37 +1115,38 @@
     esutils "^2.0.2"
 
 "@babel/preset-react@^7.12.5":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.12.13.tgz#5f911b2eb24277fa686820d5bd81cad9a0602a0a"
-  integrity sha512-TYM0V9z6Abb6dj1K7i5NrEhA13oS5ujUYQYDfqIBXYHOc2c2VkFgc+q9kyssIyUfy4/hEwqrgSlJ/Qgv8zJLsA==
+  version "7.13.13"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.13.13.tgz#fa6895a96c50763fe693f9148568458d5a839761"
+  integrity sha512-gx+tDLIE06sRjKJkVtpZ/t3mzCDOnPG+ggHZG9lffUbX8+wC739x20YQc9V35Do6ZAxaUc/HhVHIiOzz5MvDmA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-option" "^7.12.17"
     "@babel/plugin-transform-react-display-name" "^7.12.13"
-    "@babel/plugin-transform-react-jsx" "^7.12.13"
-    "@babel/plugin-transform-react-jsx-development" "^7.12.12"
+    "@babel/plugin-transform-react-jsx" "^7.13.12"
+    "@babel/plugin-transform-react-jsx-development" "^7.12.17"
     "@babel/plugin-transform-react-pure-annotations" "^7.12.1"
 
 "@babel/preset-typescript@^7.12.1":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.16.tgz#b2080ce20b7095c049db2a0410f1e39bc892f7ca"
-  integrity sha512-IrYNrpDSuQfNHeqh7gsJsO35xTGyAyGkI1VxOpBEADFtxCqZ77a1RHbJqM3YJhroj7qMkNMkNtcw0lqeZUrzow==
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.13.0.tgz#ab107e5f050609d806fbb039bec553b33462c60a"
+  integrity sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.12.13"
-    "@babel/helper-validator-option" "^7.12.16"
-    "@babel/plugin-transform-typescript" "^7.12.16"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    "@babel/helper-validator-option" "^7.12.17"
+    "@babel/plugin-transform-typescript" "^7.13.0"
 
 "@babel/runtime-corejs3@^7.12.5":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz#53d09813b7c20d616caf258e9325550ff701c039"
-  integrity sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz#6bf5fbc0b961f8e3202888cb2cd0fb7a0a9a3f66"
+  integrity sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==
   dependencies:
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
-  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1053,7 +1159,21 @@
     "@babel/parser" "^7.12.13"
     "@babel/types" "^7.12.13"
 
-"@babel/traverse@^7.12.13", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.9":
+"@babel/traverse@^7.12.13", "@babel/traverse@^7.12.5", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.15", "@babel/traverse@^7.14.0", "@babel/traverse@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.2.tgz#9201a8d912723a831c2679c7ebbf2fe1416d765b"
+  integrity sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/generator" "^7.14.2"
+    "@babel/helper-function-name" "^7.14.2"
+    "@babel/helper-split-export-declaration" "^7.12.13"
+    "@babel/parser" "^7.14.2"
+    "@babel/types" "^7.14.2"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.12.9":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.13.tgz#689f0e4b4c08587ad26622832632735fb8c4e0c0"
   integrity sha512-3Zb4w7eE/OslI0fTp8c7b286/cQps3+vdLW3UcwC8VSJC6GbKn55aeVVu2QJNuCDoeKyptLOFrPq8WqZZBodyA==
@@ -1068,7 +1188,15 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.6", "@babel/types@^7.12.7", "@babel/types@^7.4.4":
+"@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.6", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.16", "@babel/types@^7.14.0", "@babel/types@^7.14.2", "@babel/types@^7.14.4", "@babel/types@^7.4.4":
+  version "7.14.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.4.tgz#bfd6980108168593b38b3eb48a24aa026b919bc0"
+  integrity sha512-lCj4aIs0xUefJFQnwwQv2Bxg7Omd6bgquZ6LGC+gGMh6/s5qDVfjuCMlDmYQ15SLsWHd9n+X3E75lKIhl5Lkiw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.7":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
   integrity sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
@@ -1434,9 +1562,9 @@
     webpack-sources "^1.4.3"
 
 "@hapi/hoek@^9.0.0":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
-  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
 
 "@hapi/topo@^5.0.0":
   version "5.0.0"
@@ -1523,9 +1651,9 @@
     rimraf "^3.0.2"
 
 "@sideway/address@^4.1.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d"
-  integrity sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
+  integrity sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
@@ -1654,11 +1782,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/anymatch@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
-  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
-
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -1684,6 +1807,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/katex@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.11.0.tgz#b16c54ee670925ffef0616beae9e90c557e17334"
+  integrity sha512-27BfE8zASRLYfSBNMk5/+KIjr2CBBrH0i5lhsO04fca4TGirIIMay73v3zNkzqmsaeIa/Mi5kejWDcxPLAmkvA==
+
 "@types/mdast@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
@@ -1692,14 +1820,14 @@
     "@types/unist" "*"
 
 "@types/minimatch@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
-  integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
+  integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
 "@types/node@*":
-  version "14.14.28"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"
-  integrity sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.0.tgz#6a459d261450a300e6865faeddb5af01c3389bb3"
+  integrity sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -1741,15 +1869,15 @@
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
-"@types/tapable@*", "@types/tapable@^1.0.5":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
-  integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+"@types/tapable@^1", "@types/tapable@^1.0.5":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
+  integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
 
 "@types/uglify-js@*":
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.12.0.tgz#2bb061c269441620d46b946350c8f16d52ef37c5"
-  integrity sha512-sYAF+CF9XZ5cvEBkI7RtrG9g2GtMBkviTnBxYYyq+8BWvO4QtXfwwR6a2LFwCi4evMKZfpv6U43ViYvv17Wz3Q==
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.0.tgz#1cad8df1fb0b143c5aba08de5712ea9d1ff71124"
+  integrity sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==
   dependencies:
     source-map "^0.6.1"
 
@@ -1768,15 +1896,15 @@
     source-map "^0.7.3"
 
 "@types/webpack@^4.41.0", "@types/webpack@^4.41.8":
-  version "4.41.26"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
-  integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
+  version "4.41.29"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.29.tgz#2e66c1de8223c440366469415c50a47d97625773"
+  integrity sha512-6pLaORaVNZxiB3FSHbyBiWM7QdazAWda1zvAq4SbZObZqHSDbWLi62iFdblVea6SK9eyBIVp5yHhKt/yNQdR7Q==
   dependencies:
-    "@types/anymatch" "*"
     "@types/node" "*"
-    "@types/tapable" "*"
+    "@types/tapable" "^1"
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
     source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -2035,11 +2163,11 @@ ansi-colors@^3.0.0:
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^4.2.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
-  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
-    type-fest "^0.11.0"
+    type-fest "^0.21.3"
 
 ansi-html@0.0.7:
   version "0.0.7"
@@ -2088,10 +2216,10 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
-  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+anymatch@^3.0.0, anymatch@~3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
@@ -2283,15 +2411,39 @@ babel-plugin-extract-import-names@1.6.22:
   dependencies:
     "@babel/helper-plugin-utils" "7.10.4"
 
+babel-plugin-polyfill-corejs2@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz#e9124785e6fd94f94b618a7954e5693053bf5327"
+  integrity sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==
+  dependencies:
+    "@babel/compat-data" "^7.13.11"
+    "@babel/helper-define-polyfill-provider" "^0.2.2"
+    semver "^6.1.1"
+
+babel-plugin-polyfill-corejs3@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.2.tgz#7424a1682ee44baec817327710b1b094e5f8f7f5"
+  integrity sha512-l1Cf8PKk12eEk5QP/NQ6TH8A1pee6wWDJ96WjxrMXFLHLOBFzYM4moG80HFgduVhTqAFez4alnZKEhP/bYHg0A==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.2.2"
+    core-js-compat "^3.9.1"
+
+babel-plugin-polyfill-regenerator@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz#b310c8d642acada348c1fa3b3e6ce0e851bee077"
+  integrity sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.2.2"
+
 bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
   integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base16@^1.0.0:
   version "1.0.0"
@@ -2359,14 +2511,14 @@ bluebird@^3.5.5, bluebird@^3.7.1:
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
-  version "4.11.9"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
-  integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bn.js@^5.0.0, bn.js@^5.1.1:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
-  integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -2522,16 +2674,16 @@ browserslist@4.10.0:
     node-releases "^1.1.52"
     pkg-up "^3.1.0"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.1, browserslist@^4.6.4:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
-  integrity sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4.6.4:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
   dependencies:
-    caniuse-lite "^1.0.30001181"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.649"
+    caniuse-lite "^1.0.30001219"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.723"
     escalade "^3.1.1"
-    node-releases "^1.1.70"
+    node-releases "^1.1.71"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2599,9 +2751,9 @@ cacache@^12.0.2:
     y18n "^4.0.0"
 
 cacache@^15.0.5:
-  version "15.0.5"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
-  integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
+  version "15.2.0"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.2.0.tgz#73af75f77c58e72d8c630a7a2858cb18ef523389"
+  integrity sha512-uKoJSHmnrqXgthDFx/IU6ED/5xd+NNGe+Bb+kLZy7Ku4P+BaiWEUflAKPZ7eAzsYGcsAGASJZsybXp+quEcHTw==
   dependencies:
     "@npmcli/move-file" "^1.0.1"
     chownr "^2.0.0"
@@ -2617,7 +2769,7 @@ cacache@^15.0.5:
     p-map "^4.0.0"
     promise-inflight "^1.0.1"
     rimraf "^3.0.2"
-    ssri "^8.0.0"
+    ssri "^8.0.1"
     tar "^6.0.2"
     unique-filename "^1.1.1"
 
@@ -2731,10 +2883,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
-  version "1.0.30001187"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001187.tgz#5706942631f83baa5a0218b7dfa6ced29f845438"
-  integrity sha512-w7/EP1JRZ9552CyrThUnay2RkZ1DXxKe/Q2swTC4+LElLh9RRYrL1Z+27LlakB8kzY0fSmHw9mc7XYDUKAKWMA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
+  version "1.0.30001233"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz#b7cb4a377a4b12ed240d2fa5c792951a06e5f2c4"
+  integrity sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg==
 
 ccount@^1.0.0, ccount@^1.0.3:
   version "1.1.0"
@@ -2770,9 +2922,9 @@ chalk@^3.0.0:
     supports-color "^7.1.0"
 
 chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2869,21 +3021,19 @@ chownr@^2.0.0:
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
-  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
-  dependencies:
-    tslib "^1.9.0"
-
-ci-info@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
-  integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
+  integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
+  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -3019,9 +3169,9 @@ color-name@^1.0.0, color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
-  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
+  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
@@ -3034,17 +3184,17 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.4"
 
-colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+colorette@^1.2.1, colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 comma-separated-tokens@^1.0.0:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^2.18.0, commander@^2.20.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -3204,18 +3354,18 @@ copy-webpack-plugin@^6.3.0:
     serialize-javascript "^5.0.1"
     webpack-sources "^1.4.3"
 
-core-js-compat@^3.8.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.3.tgz#9123fb6b9cad30f0651332dc77deba48ef9b0b3f"
-  integrity sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==
+core-js-compat@^3.9.0, core-js-compat@^3.9.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.13.1.tgz#05444caa8f153be0c67db03cf8adb8ec0964e58e"
+  integrity sha512-mdrcxc0WznfRd8ZicEZh1qVeJ2mu6bwQFh8YVUK48friy/FOwFV5EJj9/dlh+nMQ74YusdVfBFDuomKgUspxWQ==
   dependencies:
-    browserslist "^4.16.1"
+    browserslist "^4.16.6"
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.3.tgz#10e9e3b2592ecaede4283e8f3ad7020811587c02"
-  integrity sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.13.1.tgz#5d139d346780f015f67225f45ee2362a6bed6ba1"
+  integrity sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==
 
 core-js@^2.6.5:
   version "2.6.12"
@@ -3425,9 +3575,9 @@ css-tree@1.0.0-alpha.37:
     source-map "^0.6.1"
 
 css-tree@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
-  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
@@ -3458,21 +3608,21 @@ cssesc@^3.0.0:
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssnano-preset-advanced@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-advanced/-/cssnano-preset-advanced-4.0.7.tgz#d981527b77712e2f3f3f09c73313e9b71b278b88"
-  integrity sha512-j1O5/DQnaAqEyFFQfC+Z/vRlLXL3LxJHN+lvsfYqr7KgPH74t69+Rsy2yXkovWNaJjZYBpdz2Fj8ab2nH7pZXw==
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-advanced/-/cssnano-preset-advanced-4.0.8.tgz#076f7c0818619e7385036c9927fd67e0f626ac30"
+  integrity sha512-DlZ5+XNKwB3ZnrtJ7jdj8WxT5Zgt1WIr4gdP9v1Sdn3SObqcLwbBobQaM7BqLIVHS74TE5iWn2TSYmOVSsmozQ==
   dependencies:
     autoprefixer "^9.4.7"
-    cssnano-preset-default "^4.0.7"
+    cssnano-preset-default "^4.0.8"
     postcss-discard-unused "^4.0.1"
     postcss-merge-idents "^4.0.1"
     postcss-reduce-idents "^4.0.2"
     postcss-zindex "^4.0.1"
 
-cssnano-preset-default@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz#51ec662ccfca0f88b396dcd9679cdb931be17f76"
-  integrity sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==
+cssnano-preset-default@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz#920622b1fc1e95a34e8838203f1397a504f2d3ff"
+  integrity sha512-LdAyHuq+VRyeVREFmuxUZR1TXjQm8QQU/ktoo/x7bz+SdOge1YKc5eMN6pRW7YWBmyq59CqYba1dJ5cUukEjLQ==
   dependencies:
     css-declaration-sorter "^4.0.1"
     cssnano-util-raw-cache "^4.0.1"
@@ -3502,7 +3652,7 @@ cssnano-preset-default@^4.0.7:
     postcss-ordered-values "^4.1.2"
     postcss-reduce-initial "^4.0.3"
     postcss-reduce-transforms "^4.0.2"
-    postcss-svgo "^4.0.2"
+    postcss-svgo "^4.0.3"
     postcss-unique-selectors "^4.0.1"
 
 cssnano-util-get-arguments@^4.0.0:
@@ -3528,12 +3678,12 @@ cssnano-util-same-parent@^4.0.0:
   integrity sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==
 
 cssnano@^4.1.10:
-  version "4.1.10"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.10.tgz#0ac41f0b13d13d465487e111b778d42da631b8b2"
-  integrity sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.11.tgz#c7b5f5b81da269cb1fd982cb960c1200910c9a99"
+  integrity sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==
   dependencies:
     cosmiconfig "^5.0.0"
-    cssnano-preset-default "^4.0.7"
+    cssnano-preset-default "^4.0.8"
     is-resolvable "^1.0.0"
     postcss "^7.0.0"
 
@@ -3714,9 +3864,9 @@ detab@2.0.4:
     repeat-string "^1.5.4"
 
 detect-node@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
-  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detect-port-alt@1.1.6:
   version "1.1.6"
@@ -3764,9 +3914,9 @@ dns-equal@^1.0.0:
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
 dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"
@@ -3812,9 +3962,9 @@ domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
-  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domhandler@^2.3.0:
   version "2.4.2"
@@ -3884,10 +4034,10 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.649:
-  version "1.3.666"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.666.tgz#59f3ce1e45b860a0ebe439b72664354efbb8bc62"
-  integrity sha512-/mP4HFQ0fKIX4sXltG6kfcoGrfNDZwCIyWbH2SIcVaa9u7Rm0HKjambiHNg5OEruicTl9s1EwbERLwxZwk19aw==
+electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.723:
+  version "1.3.746"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.746.tgz#4ff1251986d751ba6e0acee516e04bc205511463"
+  integrity sha512-3ffyGODL38apwSsIgXaWnAKNXChsjXhAmBTjbqCbrv1fBbVltuNLWh0zdrQbwK/oxPQ/Gss/kYfFAPPGu9mszQ==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -3977,42 +4127,27 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.2:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
-  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
-  dependencies:
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.2.2"
-    is-regex "^1.1.1"
-    object-inspect "^1.8.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.1"
-    string.prototype.trimend "^1.0.1"
-    string.prototype.trimstart "^1.0.1"
-
-es-abstract@^1.18.0-next.1:
-  version "1.18.0-next.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.2.tgz#088101a55f0541f595e7e057199e27ddc8f3a5c2"
-  integrity sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
+es-abstract@^1.17.2, es-abstract@^1.18.0-next.2, es-abstract@^1.18.2:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.3.tgz#25c4c3380a27aa203c44b2b685bba94da31b63e0"
+  integrity sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
+    get-intrinsic "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.2.2"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
     is-negative-zero "^2.0.1"
-    is-regex "^1.1.1"
-    object-inspect "^1.9.0"
+    is-regex "^1.1.3"
+    is-string "^1.0.6"
+    object-inspect "^1.10.3"
     object-keys "^1.1.1"
     object.assign "^4.1.2"
-    string.prototype.trimend "^1.0.3"
-    string.prototype.trimstart "^1.0.3"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -4094,9 +4229,9 @@ etag@~1.8.1:
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
 eval@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/eval/-/eval-0.1.4.tgz#e05dbe0dab4b9330215cbb7bf4886eb24bd58700"
-  integrity sha512-npGsebJejyjMRnLdFu+T/97dnigqIU0Ov3IGrZ8ygd1v7RL1vGkEKtvyWZobqUH1AQgKlg0Yqqe2BtMA9/QZLw==
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/eval/-/eval-0.1.6.tgz#9620d7d8c85515e97e6b47c5814f46ae381cb3cc"
+  integrity sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==
   dependencies:
     require-like ">= 0.1.1"
 
@@ -4111,14 +4246,14 @@ events@^1.1.1:
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 events@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
-  integrity sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 eventsource@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.0.7.tgz#8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0"
-  integrity sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.0.tgz#00e8ca7c92109e94b0ddf32dac677d841028cfaf"
+  integrity sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==
   dependencies:
     original "^1.0.0"
 
@@ -4293,16 +4428,16 @@ fast-url-parser@1.1.3:
     punycode "^1.3.2"
 
 fastq@^1.6.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.10.1.tgz#8b8f2ac8bf3632d67afcd65dac248d5fdc45385e"
-  integrity sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
+  integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
   dependencies:
     reusify "^1.0.4"
 
 faye-websocket@^0.11.3:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
-  integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
+  integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -4458,9 +4593,9 @@ flux@^4.0.1:
     fbjs "^3.0.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
-  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -4481,10 +4616,10 @@ fork-ts-checker-webpack-plugin@3.1.1:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-forwarded@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
-  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -4556,7 +4691,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-gensync@^1.0.0-beta.1:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -4566,7 +4701,7 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -4615,9 +4750,9 @@ glob-parent@^3.1.0:
     path-dirname "^1.0.0"
 
 glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
@@ -4627,9 +4762,9 @@ glob-to-regexp@^0.3.0:
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4694,9 +4829,9 @@ globby@^10.0.1:
     slash "^3.0.0"
 
 globby@^11.0.1:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
-  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -4746,11 +4881,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 gray-matter@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.2.tgz#9aa379e3acaf421193fce7d2a28cebd4518ac454"
-  integrity sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.3.tgz#e893c064825de73ea1f5f7d88c7a9f7274288798"
+  integrity sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==
   dependencies:
-    js-yaml "^3.11.0"
+    js-yaml "^3.13.1"
     kind-of "^6.0.2"
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
@@ -4775,6 +4910,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -4785,10 +4925,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
-  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -4886,6 +5026,11 @@ hast-util-from-parse5@^6.0.0:
     vfile-location "^3.2.0"
     web-namespaces "^1.0.0"
 
+hast-util-is-element@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
+  integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
@@ -4917,6 +5062,15 @@ hast-util-to-parse5@^6.0.0:
     web-namespaces "^1.0.0"
     xtend "^4.0.0"
     zwitch "^1.0.0"
+
+hast-util-to-text@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz#04f2e065642a0edb08341976084aa217624a0f8b"
+  integrity sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==
+  dependencies:
+    hast-util-is-element "^1.0.0"
+    repeat-string "^1.0.0"
+    unist-util-find-after "^3.0.0"
 
 hastscript@^5.0.0:
   version "5.1.2"
@@ -5002,11 +5156,6 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
-html-comment-regex@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
-  integrity sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==
-
 html-entities@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.4.0.tgz#cfbd1b01d2afaf9adca1b10ae7dffab98c71d2dc"
@@ -5036,9 +5185,9 @@ html-void-elements@^1.0.0:
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
 html-webpack-plugin@^4.5.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.1.tgz#40aaf1b5cb78f2f23a83333999625c20929cda65"
-  integrity sha512-yzK7RQZwv9xB+pcdHNTjcqbaaDZ+5L0zJHXfi89iWIZmb/FtzxhLk0635rmJihcQbs3ZUF27Xp4oWGx6EK56zg==
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
+  integrity sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==
   dependencies:
     "@types/html-minifier-terser" "^5.0.0"
     "@types/tapable" "^1.0.5"
@@ -5403,6 +5552,11 @@ is-arrayish@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
+is-bigint@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
+  integrity sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -5417,6 +5571,13 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.1.tgz#3c0878f035cb821228d350d2e1e36719716a3de8"
+  integrity sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -5427,7 +5588,7 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-callable@^1.1.4, is-callable@^1.2.2:
+is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
@@ -5452,9 +5613,9 @@ is-color-stop@^1.0.0:
     rgba-regex "^1.0.0"
 
 is-core-module@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
-  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
+  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
   dependencies:
     has "^1.0.3"
 
@@ -5473,9 +5634,9 @@ is-data-descriptor@^1.0.0:
     kind-of "^6.0.0"
 
 is-date-object@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
-  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
+  integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
 
 is-decimal@^1.0.0:
   version "1.0.4"
@@ -5506,9 +5667,9 @@ is-directory@^0.3.1:
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-docker@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
-  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -5574,6 +5735,11 @@ is-npm@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
   integrity sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
 
+is-number-object@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.5.tgz#6edfaeed7950cff19afedce9fbfca9ee6dd289eb"
+  integrity sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -5616,9 +5782,9 @@ is-path-inside@^2.1.0:
     path-is-inside "^1.0.2"
 
 is-path-inside@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.2.tgz#f5220fc82a3e233757291dddc9c5877f2a1f3017"
-  integrity sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^1.0.0:
   version "1.1.0"
@@ -5637,13 +5803,13 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.0.4, is-regex@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.2.tgz#81c8ebde4db142f2cf1c53fc86d6a45788266251"
-  integrity sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==
+is-regex@^1.0.4, is-regex@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
+  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
   dependencies:
     call-bind "^1.0.2"
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.2"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -5670,19 +5836,17 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
-is-svg@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-3.0.0.tgz#9321dbd29c212e5ca99c4fa9794c714bcafa2f75"
-  integrity sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
-  dependencies:
-    html-comment-regex "^1.1.0"
+is-string@^1.0.5, is-string@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
+  integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
 
-is-symbol@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
-  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.2"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -5778,7 +5942,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.11.0, js-yaml@^3.13.1:
+js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -5843,6 +6007,13 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+katex@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.12.0.tgz#2fb1c665dbd2b043edcf8a1f5c555f46beaa0cb9"
+  integrity sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==
+  dependencies:
+    commander "^2.19.0"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -5952,11 +6123,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -5981,6 +6147,11 @@ lodash.curry@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
   integrity sha1-JI42By7ekGUB11lmIAqG2riyMXA=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 lodash.defaults@^4.0.1:
   version "4.2.0"
@@ -6087,21 +6258,6 @@ lodash.sortby@^4.6.0, lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -6112,10 +6268,10 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loglevel@^1.6.8:
   version "1.7.1"
@@ -6315,12 +6471,12 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     to-regex "^3.0.2"
 
 micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.3"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -6330,15 +6486,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.45.0:
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
-  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
-
-"mime-db@>= 1.43.0 < 2":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
-  integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
+mime-db@1.48.0, "mime-db@>= 1.43.0 < 2":
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
 mime-db@~1.33.0:
   version "1.33.0"
@@ -6353,11 +6504,11 @@ mime-types@2.1.18:
     mime-db "~1.33.0"
 
 mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
-  version "2.1.28"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
-  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.45.0"
+    mime-db "1.48.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -6365,9 +6516,9 @@ mime@1.6.0:
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.4.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.0.tgz#2b4af934401779806ee98026bb42e8c1ae1876b1"
-  integrity sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
+  integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -6632,10 +6783,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-releases@^1.1.52, node-releases@^1.1.70:
-  version "1.1.70"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
-  integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
+node-releases@^1.1.52, node-releases@^1.1.71:
+  version "1.1.72"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
+  integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -6670,9 +6821,9 @@ normalize-url@^3.0.0:
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
 normalize-url@^4.1.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
-  integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -6727,17 +6878,17 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.8.0, object-inspect@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
-  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+object-inspect@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
+  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
 object-is@^1.0.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
-  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
+  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
 
 object-keys@^1.0.12, object-keys@^1.1.1:
@@ -6752,7 +6903,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0, object.assign@^4.1.1, object.assign@^4.1.2:
+object.assign@^4.1.0, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -6763,13 +6914,13 @@ object.assign@^4.1.0, object.assign@^4.1.1, object.assign@^4.1.2:
     object-keys "^1.1.1"
 
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
-  integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
+  integrity sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
+    es-abstract "^1.18.0-next.2"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -6779,14 +6930,13 @@ object.pick@^1.3.0:
     isobject "^3.0.1"
 
 object.values@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
-  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.4.tgz#0d273762833e816b693a637d30073e7051535b30"
+  integrity sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
-    has "^1.0.3"
+    es-abstract "^1.18.2"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -6840,9 +6990,9 @@ opn@^5.5.0:
     is-wsl "^1.1.0"
 
 optimize-css-assets-webpack-plugin@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz#85883c6528aaa02e30bbad9908c92926bb52dc90"
-  integrity sha512-wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.6.tgz#abad0c6c11a632201794f75ddba3ce13e32ae80e"
+  integrity sha512-JAYw7WrIAIuHWoKeSBB3lJ6ZG9PSDK3JJduv/FMpIY060wvbA8Lqn/TCtxNGICNlg0X5AGshLzIhpYrkltdq+A==
   dependencies:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
@@ -7092,9 +7242,9 @@ path-key@^3.0.0, path-key@^3.1.0:
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -7126,9 +7276,9 @@ path-type@^4.0.0:
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 pbkdf2@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
-  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -7136,10 +7286,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -7417,11 +7567,10 @@ postcss-image-set-function@^3.0.1:
     postcss-values-parser "^2.0.0"
 
 postcss-initial@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.2.tgz#f018563694b3c16ae8eaabe3c585ac6319637b2d"
-  integrity sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.4.tgz#9d32069a10531fe2ecafa0b6ac750ee0bc7efc53"
+  integrity sha512-3RLn6DIpMsK1l5UUy9jxQvoDeUN4gP939tDcKUHD/kM8SGSKbFAnvkpFpj3Bhtz3HGk1jWY5ZNWX6mPta5M9fg==
   dependencies:
-    lodash.template "^4.5.0"
     postcss "^7.0.2"
 
 postcss-lab-function@^2.0.1:
@@ -7810,13 +7959,11 @@ postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
     uniq "^1.0.1"
 
 postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
-  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
+  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
   dependencies:
     cssesc "^3.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
 postcss-sort-media-queries@^1.7.26:
@@ -7827,12 +7974,11 @@ postcss-sort-media-queries@^1.7.26:
     postcss "^7.0.27"
     sort-css-media-queries "1.5.0"
 
-postcss-svgo@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
-  integrity sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==
+postcss-svgo@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.3.tgz#343a2cdbac9505d416243d496f724f38894c941e"
+  integrity sha512-NoRbrcMWTtUghzuKSoIm6XV+sJdvZ7GZSc3wdBN0W19FTtp2ko8NqLsgoh/m9CzNhU3KLPvQmjIwtaNFkaFTvw==
   dependencies:
-    is-svg "^3.0.0"
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
     svgo "^1.0.0"
@@ -7957,11 +8103,11 @@ property-information@^5.0.0, property-information@^5.3.0:
     xtend "^4.0.0"
 
 proxy-addr@~2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
-  integrity sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
   dependencies:
-    forwarded "~0.1.2"
+    forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
 prr@~1.0.1:
@@ -8067,9 +8213,9 @@ querystringify@^2.1.1:
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
-  integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -8413,11 +8559,23 @@ regjsgen@^0.5.1:
   integrity sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
 
 regjsparser@^0.6.4:
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.7.tgz#c00164e1e6713c2e3ee641f1701c4b7aa0a7f86c"
-  integrity sha512-ib77G0uxsA2ovgiYbCVGx4Pv3PSttAx2vIwidqQzbL2U5S4Q+j00HdSAneSBuyVcMvEnTXMjiGgB+DlXozVhpQ==
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.6.9.tgz#b489eef7c9a2ce43727627011429cf833a7183e6"
+  integrity sha512-ZqbNRz1SNjLAiYuwY0zoXW8Ne675IX5q+YHioAGbCw4X96Mjl2+dcX9B2ciaeyYjViDAfvIjFpQjJgLttTEERQ==
   dependencies:
     jsesc "~0.5.0"
+
+rehype-katex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-katex/-/rehype-katex-4.0.0.tgz#ce11a5db0bff014350e7a9cfd30147d314b14330"
+  integrity sha512-0mgBqYugQyIW0eUl6RDOZ28Cat2YzrnWGaYgKCMQnJw6ClmKgLqXBnkDAPGh2mwxvkkKwQOUMUpSLpA5rt7rzA==
+  dependencies:
+    "@types/katex" "^0.11.0"
+    hast-util-to-text "^2.0.0"
+    katex "^0.12.0"
+    rehype-parse "^7.0.0"
+    unified "^9.0.0"
+    unist-util-visit "^2.0.0"
 
 rehype-parse@^6.0.2:
   version "6.0.2"
@@ -8427,6 +8585,14 @@ rehype-parse@^6.0.2:
     hast-util-from-parse5 "^5.0.0"
     parse5 "^5.0.0"
     xtend "^4.0.0"
+
+rehype-parse@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-7.0.1.tgz#58900f6702b56767814afc2a9efa2d42b1c90c57"
+  integrity sha512-fOiR9a9xH+Le19i4fGzIEowAbwG7idy2Jzs4mOrFWBSJ0sNUgy0ev871dwWnbOo371SjgjG4pwzrbgSVrKxecw==
+  dependencies:
+    hast-util-from-parse5 "^6.0.0"
+    parse5 "^6.0.0"
 
 relateurl@^0.2.7:
   version "0.2.7"
@@ -8455,6 +8621,11 @@ remark-footnotes@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-2.0.0.tgz#9001c4c2ffebba55695d2dd80ffb8b82f7e6303f"
   integrity sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==
+
+remark-math@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-3.0.1.tgz#85a02a15b15cad34b89a27244d4887b3a95185bb"
+  integrity sha512-epT77R/HK0x7NqrWHdSV75uNLwn8g9qTyMqCRCDujL0vj/6T6+yhdrR7mjELWtkse+Fw02kijAaBuVcHBor1+Q==
 
 remark-mdx@1.6.22:
   version "1.6.22"
@@ -8516,11 +8687,11 @@ renderkid@^2.0.4:
     strip-ansi "^3.0.0"
 
 repeat-element@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
-  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
+  integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
-repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -8572,7 +8743,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.14.2, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -8662,9 +8833,9 @@ run-queue@^1.0.0, run-queue@^1.0.3:
     aproba "^1.1.1"
 
 rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -8749,9 +8920,9 @@ select@^1.1.2:
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 selfsigned@^1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
-  integrity sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==
+  version "1.10.11"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.11.tgz#24929cd906fe0f44b6d01fb23999a739537acbe9"
+  integrity sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==
   dependencies:
     node-forge "^0.10.0"
 
@@ -8767,12 +8938,12 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -8986,16 +9157,16 @@ snapdragon@^0.8.1:
     use "^3.1.0"
 
 sockjs-client@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.0.tgz#2f8ff5d4b659e0d092f7aba0b7c386bd2aa20add"
-  integrity sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.5.1.tgz#256908f6d5adfb94dabbdbd02c66362cca0f9ea6"
+  integrity sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==
   dependencies:
     debug "^3.2.6"
     eventsource "^1.0.7"
     faye-websocket "^0.11.3"
     inherits "^2.0.4"
     json3 "^3.3.3"
-    url-parse "^1.4.7"
+    url-parse "^1.5.1"
 
 sockjs@^0.3.21:
   version "0.3.21"
@@ -9103,13 +9274,13 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 
-ssri@^8.0.0:
+ssri@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
@@ -9140,11 +9311,11 @@ static-extend@^0.1.1:
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 std-env@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/std-env/-/std-env-2.2.1.tgz#2ffa0fdc9e2263e0004c1211966e960948a40f6b"
-  integrity sha512-IjYQUinA3lg5re/YMlwlfhqNRTzMZMqE+pezevdcTaHceqx8ngEi1alX9nNCk9Sc81fy1fLDeQoaCzeiW1yBOQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-2.3.0.tgz#66d4a4a4d5224242ed8e43f5d65cfa9095216eee"
+  integrity sha512-4qT5B45+Kjef2Z6pE0BkskzsH0GO7GrND0wGlTM1ioUe3v0dGYx9ZJH0Aro/YyA8fqQ5EyIKDRjZojJYMFTflw==
   dependencies:
-    ci-info "^1.6.0"
+    ci-info "^3.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -9193,28 +9364,28 @@ string-width@^3.0.0, string-width@^3.1.0:
     strip-ansi "^5.1.0"
 
 string-width@^4.0.0, string-width@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimend@^1.0.1, string.prototype.trimend@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
-  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-string.prototype.trimstart@^1.0.1, string.prototype.trimstart@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
-  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
@@ -9409,9 +9580,9 @@ terser@^4.1.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.0.tgz#138cdf21c5e3100b1b3ddfddf720962f88badcd2"
-  integrity sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.0.tgz#a761eeec206bc87b605ab13029876ead938ae693"
+  integrity sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==
   dependencies:
     commander "^2.20.0"
     source-map "~0.7.2"
@@ -9564,19 +9735,19 @@ tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
-type-fest@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
-  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.8.1:
   version "0.8.1"
@@ -9607,6 +9778,16 @@ ua-parser-js@^0.7.18:
   version "0.7.24"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.24.tgz#8d3ecea46ed4f1f1d63ec25f17d8568105dc027c"
   integrity sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==
+
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
 
 unherit@^1.0.4:
   version "1.1.3"
@@ -9662,6 +9843,18 @@ unified@^8.4.2:
     trough "^1.0.0"
     vfile "^4.0.0"
 
+unified@^9.0.0:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
+  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"
@@ -9707,6 +9900,13 @@ unist-builder@2.0.3, unist-builder@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
+
+unist-util-find-after@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz#5c65fcebf64d4f8f496db46fa8fd0fbf354b43e6"
+  integrity sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==
+  dependencies:
+    unist-util-is "^4.0.0"
 
 unist-util-generated@^1.0.0:
   version "1.1.6"
@@ -9836,10 +10036,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3, url-parse@^1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+url-parse@^1.4.3, url-parse@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
+  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
@@ -9958,13 +10158,13 @@ vm-browserify@^1.0.1:
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
 wait-on@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.2.1.tgz#05b66fcb4d7f5da01537f03e7cf96e8836422996"
-  integrity sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
+  integrity sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==
   dependencies:
     axios "^0.21.1"
     joi "^17.3.0"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     minimist "^1.2.5"
     rxjs "^6.6.3"
 
@@ -10161,6 +10361,17 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -10235,9 +10446,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^6.0.0, ws@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 
@@ -10264,9 +10475,9 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
-  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yallist@^3.0.2:
   version "3.1.1"
@@ -10279,9 +10490,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
-  integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@^13.1.2:
   version "13.1.2"

--- a/docs/language-reference/rise-types.md
+++ b/docs/language-reference/rise-types.md
@@ -1,0 +1,72 @@
+---
+title: RISE Type System
+sidebar_label: RISE Type System
+---
+
+## Well-formed Types
+
+
+```scala mdoc:passthrough
+println(s"""
+### Kinds
+$$
+${rise.core.types.latex.wellFormedTypes.kinds}
+$$
+
+### Kinding Structural Rule
+$$
+${rise.core.types.latex.wellFormedTypes.structuralRules}
+$$
+
+### Type Equality
+$$
+${rise.core.types.latex.wellFormedTypes.typeEquality}
+$$
+
+### Address Spaces
+$$
+${rise.core.types.latex.wellFormedTypes.addressSpaces}
+$$
+
+### Nat to Nat Type Level Functions
+$$
+${rise.core.types.latex.wellFormedTypes.natToNatTypeLevelFunctions}
+$$
+
+### Nat to Data Type Level Functions
+$$
+${rise.core.types.latex.wellFormedTypes.natToDataTypeLevelFunctions}
+$$
+
+### Natural numbers
+$$
+${rise.core.types.latex.wellFormedTypes.naturalNumbers}
+$$
+
+### Data Types
+$$
+${rise.core.types.latex.wellFormedTypes.dataTypes}
+$$
+
+### Types
+$$
+${rise.core.types.latex.wellFormedTypes.types}
+$$
+""")
+```
+
+## Typing Rules
+
+```scala mdoc:passthrough
+println(s"""
+### Structural Rules
+$$
+${rise.core.types.latex.typingRules.structural}
+$$
+
+### Introduction and Elimination Rules
+$$
+${rise.core.types.latex.typingRules.introAndElim}
+$$
+""")
+```

--- a/meta/src/main/scala/meta/generator/DPIAPrimitives.scala
+++ b/meta/src/main/scala/meta/generator/DPIAPrimitives.scala
@@ -140,23 +140,22 @@ ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), param
     case DPIA.Type.AST.CommType               => t"CommType"
     case DPIA.Type.AST.PairType(lhs, rhs) => t"PhrasePairType[${generatePhraseType(lhs)}, ${generatePhraseType(rhs)}]"
     case DPIA.Type.AST.FunType(inT, outT) => t"FunType[${generatePhraseType(inT)}, ${generatePhraseType(outT)}]"
-    case DPIA.Type.AST.DepFunType(id, kind, t) => t"DepFunType[${generateKindType(kind)}, ${generatePhraseType(t)}]"
+    case DPIA.Type.AST.DepFunType(id, kind, t) => t"DepFunType[${generateKindIdentifierType(kind)}, ${generatePhraseType(t)}]"
     case DPIA.Type.AST.Identifier(name) => Type.Name(name)
     case DPIA.Type.AST.VariadicType(_, _) => throw new Exception("Can not generate Phrase Type for Variadic Type")
   }
 
-  // generate Scala type for representing the DPIA/rise kinds themselves
-  def generateKindType(kindAST: DPIA.Kind.AST): scala.meta.Type = kindAST match {
+  def generateKindIdentifierType(kindAST: DPIA.Kind.AST): scala.meta.Type = kindAST match {
     case DPIA.Kind.AST.RiseKind(riseKind) => riseKind match {
-        case rise.Kind.AST.Data =>      Type.Name("DataKind")
-        case rise.Kind.AST.Address =>   Type.Name("AddressSpaceKind")
-        case rise.Kind.AST.Nat2Nat =>   Type.Name("NatToNatKind")
-        case rise.Kind.AST.Nat2Data =>  Type.Name("NatToDataKind")
-        case rise.Kind.AST.Nat =>       Type.Name("NatKind")
-        case rise.Kind.AST.Fragment => throw new Exception("Can not generate Kind for Fragment")
-        case rise.Kind.AST.MatrixLayout => throw new Exception("Can not generate Kind for Matrix Layout")
-      }
-    case DPIA.Kind.AST.Access =>        Type.Name("AccessKind")
+      case rise.Kind.AST.Data =>      Type.Name("DataTypeIdentifier")
+      case rise.Kind.AST.Address =>   Type.Name("AddressSpaceIdentifier")
+      case rise.Kind.AST.Nat2Nat =>   Type.Name("NatToNatIdentifier")
+      case rise.Kind.AST.Nat2Data =>  Type.Name("NatToDataIdentifier")
+      case rise.Kind.AST.Nat =>       Type.Name("NatIdentifier")
+      case rise.Kind.AST.Fragment => throw new Exception("Can not generate Kind for Fragment")
+      case rise.Kind.AST.MatrixLayout => throw new Exception("Can not generate Kind for Matrix Layout")
+    }
+    case DPIA.Kind.AST.Access =>        Type.Name("AccessTypeIdentifier")
     case DPIA.Kind.AST.VariadicKind(_, _) => throw new Exception("Can not generate Kind for Variadic Kind")
   }
 
@@ -287,7 +286,7 @@ ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), param
     case DPIA.Type.AST.FunType(inT, outT) =>
       q"FunType(${generateTerm(inT)}, ${generateTerm(outT)})"
     case DPIA.Type.AST.DepFunType(id, kind, t) =>
-      q"DepFunType[${generateKindType(kind)}, PhraseType](${Term.Name(id.name)}, ${generateTerm(t)})"
+      q"DepFunType(${generateKindType(kind)}, ${Term.Name(id.name)}, ${generateTerm(t)})"
     case DPIA.Type.AST.VariadicType(_, _) => throw new Exception("Can not generate Term for Variadic Type")
   }
 
@@ -295,6 +294,21 @@ ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), param
     case DPIA.Type.Access.AST.Identifier(name) => Term.Name(name)
     case DPIA.Type.Access.AST.Read => Term.Name("read")
     case DPIA.Type.Access.AST.Write =>Term.Name("write")
+  }
+
+  // generate Scala type for representing the DPIA/rise kinds themselves
+  def generateKindType(kindAST: DPIA.Kind.AST): scala.meta.Term = kindAST match {
+    case DPIA.Kind.AST.RiseKind(riseKind) => riseKind match {
+      case rise.Kind.AST.Data =>      Term.Name("DataKind")
+      case rise.Kind.AST.Address =>   Term.Name("AddressSpaceKind")
+      case rise.Kind.AST.Nat2Nat =>   Term.Name("NatToNatKind")
+      case rise.Kind.AST.Nat2Data =>  Term.Name("NatToDataKind")
+      case rise.Kind.AST.Nat =>       Term.Name("NatKind")
+      case rise.Kind.AST.Fragment => throw new Exception("Can not generate Kind for Fragment")
+      case rise.Kind.AST.MatrixLayout => throw new Exception("Can not generate Kind for Matrix Layout")
+    }
+    case DPIA.Kind.AST.Access =>        Term.Name("AccessKind")
+    case DPIA.Kind.AST.VariadicKind(_, _) => throw new Exception("Can not generate Kind for Variadic Kind")
   }
 
   def generateVisitAndRebuild(name: scala.meta.Type.Name,

--- a/meta/src/main/scala/meta/generator/RisePrimitives.scala
+++ b/meta/src/main/scala/meta/generator/RisePrimitives.scala
@@ -177,27 +177,27 @@ import arithexpr.arithmetic._
       case rise.Type.AST.VariadicDepFunType(n, ids, kind, t) =>
         // variadic dependent function type, e.g.:  n*((ids: kind) ->) t
         // generates:
-        //    val ids = Seq.fill(n)(DataTypeIdentifier(freshName("dt"), isExplicit = true))
+        //    val ids = Seq.fill(n)(DataTypeIdentifier(freshName("dt")))
         //    ids.foldRight(t){ case (id, t) => DepFunType[DataKind](id, t) }
         // to represent n-many dependent function types: (id0: kind) -> (id1: kind) -> ... -> t
-        val (createIds, typeName) = kind match {
+        val (createIds, kindName) = kind match {
           case AST.Data =>
-            (q"""DataTypeIdentifier(freshName("dt"), isExplicit = true)""", Type.Name("DataKind"))
+            (q"""DataTypeIdentifier(freshName("dt"))""", Term.Name("DataKind"))
           case AST.Address =>
-            (q"""AddressSpaceIdentifier(freshName("a"), isExplicit = true)""", Type.Name("AddressSpaceKind"))
+            (q"""AddressSpaceIdentifier(freshName("a"))""", Term.Name("AddressSpaceKind"))
           case AST.Nat2Nat =>
-            (q"""NatToNatIdentifier(freshName("n2n"), isExplicit = true)""", Type.Name("NatToNatKind"))
+            (q"""NatToNatIdentifier(freshName("n2n"))""", Term.Name("NatToNatKind"))
           case AST.Nat2Data =>
-            (q"""NatToDataIdentifier(freshName("n2d"), isExplicit = true)""", Type.Name("NatToDataKind"))
+            (q"""NatToDataIdentifier(freshName("n2d"))""", Term.Name("NatToDataKind"))
           case AST.Nat =>
-            (q"""NatIdentifier(freshName("n"), isExplicit = true)""", Type.Name("NatKind"))
+            (q"""NatIdentifier(freshName("n"))""", Term.Name("NatKind"))
           case AST.Fragment => throw new Exception("No support for Fragment Kind yet")
           case AST.MatrixLayout => throw new Exception("No support for Matrix Layout Kind yet")
         }
         q"""{
             val ${Pat.Var(Term.Name(ids.name))} = Seq.fill(${Term.Name(n.name)})($createIds)
             ${Term.Name(ids.name)}.foldRight(${generateTypeScheme(t)}: Type) {
-              case (id, t) =>   DepFunType[$typeName, Type](id, t)
+              case (id, t) =>   DepFunType($kindName, id, t)
             }
          }"""
       case _ => generateDataType(typeAST)

--- a/src/main/scala/apps/cameraPipelineRewrite.scala
+++ b/src/main/scala/apps/cameraPipelineRewrite.scala
@@ -29,7 +29,7 @@ object cameraPipelineRewrite {
 
   case class depFunction(s: Strategy[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
-      case ap @ DepApp(f, x) => s(f).mapSuccess(DepApp(_, x)(ap.t))
+      case ap @ DepApp(kind, f, x) => s(f).mapSuccess(DepApp(kind, _, x)(ap.t))
       case _ => Failure(s)
     }
     override def toString: String = s"depFunction($s)"

--- a/src/main/scala/apps/mmTuning.scala
+++ b/src/main/scala/apps/mmTuning.scala
@@ -143,7 +143,8 @@ object mmTuning {
     // generate kernel
     println("timestamp")
     val genExprStart = System.currentTimeMillis()
-    val kernel = genMMKernel(v3, v4, v5, v6, v7, v8)
+    // FIXME: delete this file entirely?
+    val kernel = ??? // genMMKernel(v3, v4, v5, v6, v7, v8)
     val genExpr = System.currentTimeMillis() - genExprStart
 
     // run kernel

--- a/src/main/scala/rise/core/Builder.scala
+++ b/src/main/scala/rise/core/Builder.scala
@@ -7,12 +7,12 @@ trait Builder {
     throw new Exception("apply method must be overridden")
   def apply(e: DSL.ToBeTyped[Expr]): DSL.ToBeTyped[App] =
     DSL.app(DSL.toBeTyped(apply), e)
-  def apply(n: Nat): DSL.ToBeTyped[DepApp[NatKind]] =
-    DSL.depApp[NatKind](DSL.toBeTyped(apply), n)
-  def apply(dt: DataType): DSL.ToBeTyped[DepApp[DataKind]] =
-    DSL.depApp[DataKind](DSL.toBeTyped(apply), dt)
-  def apply(a: AddressSpace): DSL.ToBeTyped[DepApp[AddressSpaceKind]] =
-    DSL.depApp[AddressSpaceKind](DSL.toBeTyped(apply), a)
+  def apply(n: Nat): DSL.ToBeTyped[DepApp[Nat, _]] =
+    DSL.depApp(NatKind, DSL.toBeTyped(apply), n)
+  def apply(dt: DataType): DSL.ToBeTyped[DepApp[DataType, _]] =
+    DSL.depApp(DataKind, DSL.toBeTyped(apply), dt)
+  def apply(a: AddressSpace): DSL.ToBeTyped[DepApp[AddressSpace, _]] =
+    DSL.depApp(AddressSpaceKind, DSL.toBeTyped(apply), a)
 
   def unapply(arg: Expr): Boolean =
     throw new Exception("unapply method must be overridden")

--- a/src/main/scala/rise/core/DSL/TopLevel.scala
+++ b/src/main/scala/rise/core/DSL/TopLevel.scala
@@ -3,8 +3,9 @@ package rise.core.DSL
 import Type.impl
 import util.monads._
 import rise.core.traverse._
+import rise.core.types.Kind._
 import rise.core.types._
-import rise.core.{DSL, Expr, Primitive}
+import rise.core.{DSL, Expr, IsClosedForm, Primitive}
 
 final case class TopLevel(e: Expr, inst: Solution = Solution())(
   override val t: Type = e.t
@@ -23,30 +24,28 @@ final case class TopLevel(e: Expr, inst: Solution = Solution())(
 object TopLevel {
   private def instantiate(t: Type): Solution = {
     import scala.collection.immutable.Map
-    infer.getFTVs(t).foldLeft(Solution())((subs, ftv) =>
+    IsClosedForm.varsToClose(t).foldLeft(Solution())((subs, ftv) =>
       subs match {
         case s@Solution(ts, ns, as, ms, fs, n2ds, n2ns, natColls) =>
           ftv match {
-            case i: TypeIdentifier =>
+            case IType(i) =>
               s.copy(ts = ts ++ Map(i -> impl{ x: TypeIdentifier => x }))
-            case i: DataTypeIdentifier =>
+            case IDataType(i) =>
               s.copy(ts = ts ++ Map(i -> impl{ x: DataType => x }))
-            case i: NatIdentifier =>
+            case INat(i) =>
               s.copy(ns = ns ++ Map(i -> impl{ x: Nat => x }))
-            case i: AddressSpaceIdentifier =>
+            case IAddressSpace(i) =>
               s.copy(as = as ++ Map(i -> impl{ x: AddressSpace => x }))
-            case i: MatrixLayoutIdentifier =>
+            case IMatrixLayout(i) =>
               s.copy(ms = ms ++ Map(i -> impl{ x: MatrixLayout => x }))
-            case i: FragmentKindIdentifier =>
+            case IFragmentKind(i) =>
               s.copy(fs = fs ++ Map(i -> impl{ x: FragmentKind => x }))
-            case i: NatToDataIdentifier =>
+            case INatToData(i) =>
               s.copy(n2ds = n2ds ++ Map(i -> impl{ x: NatToData => x }))
-            case i: NatToNatIdentifier =>
+            case INatToNat(i) =>
               s.copy(n2ns = n2ns ++ Map(i -> impl{ x: NatToNat => x }))
-            case i: NatCollectionIdentifier =>
+            case INatCollection(i) =>
               s.copy(natColls = natColls ++ Map(i -> impl{ x: NatCollection => x }))
-            case i =>
-              throw TypeException(s"${i.getClass} is not supported yet")
           }
       }
     )

--- a/src/main/scala/rise/core/DSL/Type.scala
+++ b/src/main/scala/rise/core/DSL/Type.scala
@@ -117,7 +117,7 @@ object Type {
 
   object impl {
     def apply[A](w: NatFunctionWrapper[A]): A = {
-      w.f(NatIdentifier(freshName("n"), isExplicit = false))
+      w.f(NatIdentifier(freshName("n")))
     }
 
     def apply[A](w: DataTypeFunctionWrapper[A]): A = {

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -34,29 +34,17 @@ object infer {
     traverse(e, Traversal(Set()))._1
   }
 
-  def preservingWithEnv(e: Expr, env: Map[String, Type], preserve: Set[Kind.Identifier]): Expr = {
-    val (typed_e, constraints) = constrainTypes(env)(e)
-    val solution = Constraint.solve(constraints, preserve, Seq())(
-      Flags.ExplicitDependence.Off)
-    solution(typed_e)
-  }
+  type ExprEnv = Map[String, Type]
 
-  // TODO: Get rid of TypeAssertion and deprecate, instead evaluate !: in place and use `preserving` directly
-  private [DSL] def apply(e: Expr,
-                          printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off,
-                          explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off): Expr = {
+  def apply(e: Expr, exprEnv: ExprEnv = Map(), typeEnv : Set[Kind.Identifier] = Set(),
+            printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off): Expr = {
+    // TODO: Get rid of TypeAssertion and deprecate, instead evaluate !: in place and use `preserving` directly
     // Collect FTVs in assertions and opaques; transform assertions into annotations
-    val (preserve, e_wo_assertions) = traverse(e, collectPreserve)
-    infer.preserving(e_wo_assertions, preserve, printFlag, explDep)
-  }
-
-  private [DSL] def preserving(wo_assertions: Expr, preserve : Set[Kind.Identifier],
-                               printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off,
-                               explDep: Flags.ExplicitDependence = Flags.ExplicitDependence.Off): Expr = {
+    val (e_preserve, e_wo_assertions) = traverse(e, collectPreserve)
     // Collect constraints
-    val (typed_e, constraints) = constrainTypes(Map())(wo_assertions)
+    val (typed_e, constraints) = constrainTypes(exprEnv)(e_wo_assertions)
     // Solve constraints while preserving the FTVs in preserve
-    val solution = Constraint.solve(constraints, preserve, Seq())(explDep)
+    val solution = Constraint.solve(constraints, e_preserve ++ typeEnv, Seq())
     // Apply the solution
     val res = traverse(typed_e, Visitor(solution))
     if (printFlag == Flags.PrintTypesAndTypeHoles.On) {
@@ -83,100 +71,72 @@ object infer {
     }
   }
 
-  val FTVGathering = new PureAccumulatorTraversal[Seq[Kind.Identifier]] {
-    override val accumulator = SeqMonoid
-    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = _ => {
-      case i: Kind.Explicitness => accumulate(if (!i.isExplicit) Seq(i) else Seq())(i.asInstanceOf[I])
-      case i => accumulate(Seq(i))(i)
-    }
-    override def nat: Nat => Pair[Nat] = ae => {
-      val ftvs = mutable.ListBuffer[Kind.Identifier]()
-      val r = ae.visitAndRebuild({
-        case i: NatIdentifier if !i.isExplicit => ftvs += i; i
-        case n => n
-      })
-      accumulate(ftvs.toSeq)(r)
-    }
-  }
-
-  def getFTVs(t: Type): Seq[Kind.Identifier] = {
-    traverse(t, FTVGathering)._1.distinct
-  }
-
-  def getFTVsRec(e: Expr): Seq[Kind.Identifier] = {
-    traverse(e, FTVGathering)._1.distinct
-  }
-
   private val collectPreserve = new PureAccumulatorTraversal[Set[Kind.Identifier]] {
     override val accumulator = SetMonoid
+
+    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
+      case Binding => i => accumulate(Set(i))(i)
+      case _ => return_
+    }
+
     override def expr: Expr => Pair[Expr] = {
       // Transform assertions into annotations, collect FTVs
       case TypeAssertion(e, t) =>
-        val (s, e1) = expr(e).unwrap
-        accumulate(s ++ getFTVs(t))(TypeAnnotation(e1, t) : Expr)
+        val (s1, e1) = expr(e).unwrap
+        accumulate(s1 ++ IsClosedForm.freeVars(t).set)(TypeAnnotation(e1, t) : Expr)
       // Collect FTVs
       case Opaque(e, t) =>
-        accumulate(getFTVs(t).toSet)(Opaque(e, t) : Expr)
+        accumulate(IsClosedForm.freeVars(t).set)(Opaque(e, t) : Expr)
       case e => super.expr(e)
     }
   }
 
   private val genType : Expr => Type =
     e => if (e.t == TypePlaceholder) freshTypeIdentifier else e.t
-  private val constrIfTyped : Type => Constraint => Seq[Constraint] =
+  private def ifTyped[T] : Type => T => Seq[T] =
     t => c => if (t == TypePlaceholder) Nil else Seq(c)
 
-  private val constrainTypes : Map[String, Type] => Expr => (Expr, Seq[Constraint]) = env => {
+  def constrainTypes(exprEnv : ExprEnv) : Expr => (Expr, Seq[Constraint]) = {
     case i: Identifier =>
-      val t = env.getOrElse(i.name,
+      val t = exprEnv.getOrElse(i.name,
         if (i.t == TypePlaceholder) error(s"$i has no type")(Seq()) else i.t )
       val c = TypeConstraint(t, i.t)
       (i.setType(t), Nil :+ c)
 
     case expr@Lambda(x, e) =>
       val tx = x.setType(genType(x))
-      val env1 : Map[String, Type] = env + (tx.name -> tx.t)
-      val (te, cs) = constrainTypes(env1)(e)
+      val exprEnv1 = exprEnv + (tx.name -> tx.t)
+      val (te, cs) = constrainTypes(exprEnv1)(e)
       val ft = FunType(tx.t, te.t)
-      val cs1 = constrIfTyped(expr.t)(TypeConstraint(expr.t, ft))
+      val cs1 = ifTyped(expr.t)(TypeConstraint(expr.t, ft))
       (Lambda(tx, te)(ft), cs ++ cs1)
 
     case expr@App(f, e) =>
-      val (tf, csF) = constrainTypes(env)(f)
-      val (te, csE) = constrainTypes(env)(e)
+      val (tf, csF) = constrainTypes(exprEnv)(f)
+      val (te, csE) = constrainTypes(exprEnv)(e)
       val exprT = genType(expr)
       val c = TypeConstraint(tf.t, FunType(te.t, exprT))
       (App(tf, te)(exprT), csF ++ csE :+ c)
 
-    case expr@DepLambda(x, e) =>
-      val (te, csE) = constrainTypes(env)(e)
-      val exprT = genType(expr)
-      val tf = x match {
-        case n: NatIdentifier =>
-          DepLambda[NatKind](n, te)(DepFunType[NatKind, Type](n, te.t))
-        case dt: DataTypeIdentifier =>
-          DepLambda[DataKind](dt, te)(DepFunType[DataKind, Type](dt, te.t))
-        case ad: AddressSpaceIdentifier =>
-          DepLambda[AddressSpaceKind](ad, te)(DepFunType[AddressSpaceKind, Type](ad, te.t))
-        case n2n: NatToNatIdentifier =>
-          DepLambda[NatToNatKind](n2n, te)(DepFunType[NatToNatKind, Type](n2n, te.t))
-      }
-      val csE1 = constrIfTyped(expr.t)(TypeConstraint(expr.t, tf.t))
+    case expr@DepLambda(kind, x, e) =>
+      val (te, csE) = constrainTypes(exprEnv)(e)
+      val tf = DepLambda(kind, x, te)(DepFunType(kind, x, te.t))
+      val csE1 = ifTyped(expr.t)(TypeConstraint(expr.t, tf.t))
       (tf, csE ++ csE1)
 
-    case expr@DepApp(f, x) =>
-      val (tf, csF) = constrainTypes(env)(f)
+    case expr@DepApp(kind, f, x) =>
+      val (tf, csF) = constrainTypes(exprEnv)(f)
       val exprT = genType(expr)
-      val c = DepConstraint(tf.t, x, exprT)
-      (DepApp(tf, x)(exprT), csF :+ c)
+      val c = DepConstraint(kind, tf.t, x, exprT)
+      (DepApp(kind, tf, x)(exprT), csF :+ c)
 
     case TypeAnnotation(e, t) =>
-      val (te, csE) = constrainTypes(env)(e)
+      val (te, csE) = constrainTypes(exprEnv)(e)
       val c = TypeConstraint(te.t, t)
       (te, csE :+ c)
 
     case TypeAssertion(e, t) =>
-      val (te, csE) = constrainTypes(env)(e)
+      val (te, csE) = constrainTypes(exprEnv)(e)
       val c = TypeConstraint(te.t, t)
       (te, csE :+ c)
 
@@ -197,11 +157,4 @@ object infer {
     override def natToData : NatToData => Pure[NatToData] = n2d => return_(sol(n2d))
     override def natToNat : NatToNat => Pure[NatToNat] = n2n => return_(sol(n2n))
   }
-}
-
-object inferDependent {
-  def apply(e: ToBeTyped[Expr],
-            printFlag: Flags.PrintTypesAndTypeHoles = Flags.PrintTypesAndTypeHoles.Off): Expr = infer(e match {
-    case ToBeTyped(e) => e
-  }, printFlag, Flags.ExplicitDependence.On)
 }

--- a/src/main/scala/rise/core/DSL/infer.scala
+++ b/src/main/scala/rise/core/DSL/infer.scala
@@ -74,8 +74,14 @@ object infer {
   private val collectPreserve = new PureAccumulatorTraversal[Set[Kind.Identifier]] {
     override val accumulator = SetMonoid
 
+    override def nat: Nat => Pair[Nat] = n => n match {
+      case p@TuningParameter() => accumulate(Set(Kind.INat(p)))(n)
+      case n => return_(n)
+    }
+
     override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
       case Binding => i => accumulate(Set(i))(i)
+      // FIXME? nat identifiers don't seem to be traversed here
       case _ => return_
     }
 

--- a/src/main/scala/rise/core/Expr.scala
+++ b/src/main/scala/rise/core/Expr.scala
@@ -30,19 +30,13 @@ final case class App(f: Expr, e: Expr)(override val t: Type)
   override def setType(t: Type): App = this.copy(f, e)(t)
 }
 
-final case class DepLambda[K <: Kind: KindName](
-    x: K#I with Kind.Explicitness,
-    e: Expr
-)(override val t: Type)
-    extends Expr {
-  val kindName: String = implicitly[KindName[K]].get
-  override def setType(t: Type): DepLambda[K] = this.copy(x, e)(t)
+final case class DepLambda[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI],x: I, e: Expr)(override val t: Type) extends Expr {
+  val kindName: String = kind.name
+  override def setType(t: Type): DepLambda[T, I, KI] = this.copy(kind, x, e)(t)
 }
 
-final case class DepApp[K <: Kind](f: Expr, x: K#T)(
-    override val t: Type
-) extends Expr {
-  override def setType(t: Type): DepApp[K] = this.copy(f, x)(t)
+final case class DepApp[T, KI <: Kind.Identifier](kind: Kind[T, _, KI], f: Expr, x: T)(override val t: Type) extends Expr {
+  override def setType(t: Type): DepApp[T, KI] = this.copy(kind, f, x)(t)
 }
 
 final case class Literal(d: semantics.Data) extends Expr {

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -46,13 +46,8 @@ object IsClosedForm {
     }
 
     override def nat: Nat => Pair[Nat] = n => {
-<<<<<<< HEAD
-      val free = n.varList.foldLeft(Set[Kind.Identifier]()) {
-        case (free, v: NamedVar) if !boundT(NatIdentifier(v, isExplicit = false, isTuningParam = false)) => free + NatIdentifier(v, isExplicit = false, isTuningParam = false)
-=======
       val free = n.varList.foldLeft(OrderedSet.empty[Kind.Identifier]) {
         case (free, v: NamedVar) if !boundT(INat(v)) => OrderedSet.add(INat(v) : Kind.Identifier)(free)
->>>>>>> master
         case (free, _) => free
       }
       accumulate((OrderedSet.empty, free))(n)

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -3,18 +3,36 @@ package rise.core
 import util.monads._
 import arithexpr.arithmetic.NamedVar
 import rise.core.traverse._
+import rise.core.types.Kind.{IFragmentKind, IMatrixLayout, INat, INatToData}
 import rise.core.types._
 
 object IsClosedForm {
+  case class OrderedSet[T](seq : Seq[T], set : Set[T])
+  object OrderedSet {
+    def empty[T] : OrderedSet[T] = OrderedSet(Seq(), Set())
+    def add[T] : T => OrderedSet[T] => OrderedSet[T] = t => ts =>
+      if (ts.set.contains(t)) ts else OrderedSet(t +: ts.seq, ts.set + t)
+    def one[T] : T => OrderedSet[T] = add(_)(empty)
+    def append[T] : OrderedSet[T] => OrderedSet[T] => OrderedSet[T] = x => y => {
+      val ordered = x.seq.filter(!y.set.contains(_)) ++ y.seq
+      val unique = x.set ++ y.set
+      OrderedSet(ordered, unique)
+    }
+  }
+  implicit def OrderedSetMonoid[T] : Monoid[OrderedSet[T]] = new Monoid[OrderedSet[T]] {
+    def empty : OrderedSet[T] = OrderedSet.empty
+    def append : OrderedSet[T] => OrderedSet[T] => OrderedSet[T] = OrderedSet.append
+  }
+
   case class Visitor(boundV: Set[Identifier], boundT: Set[Kind.Identifier])
-    extends PureAccumulatorTraversal[(Set[Identifier], Set[Kind.Identifier])]
+    extends PureAccumulatorTraversal[(OrderedSet[Identifier], OrderedSet[Kind.Identifier])]
   {
-    override val accumulator = PairMonoid(SetMonoid, SetMonoid)
+    override val accumulator = PairMonoid(OrderedSetMonoid, OrderedSetMonoid)
 
     override def identifier[I <: Identifier]: VarType => I => Pair[I] = vt => i => {
       for { t2 <- `type`(i.t);
             i2 <- if (vt == Reference && !boundV(i)) {
-                    accumulate((Set(i), Set()))(i)
+                    accumulate((OrderedSet.one(i : Identifier), OrderedSet.empty))(i)
                   } else {
                     return_(i)
                   }}
@@ -23,54 +41,87 @@ object IsClosedForm {
 
     override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] = {
       case Reference => i =>
-        if (boundT(i)) return_(i) else accumulate((Set(), Set(i)))(i)
+        if (boundT(i)) return_(i) else accumulate((OrderedSet.empty, OrderedSet.one(i : Kind.Identifier)))(i)
       case _ => return_
     }
 
     override def nat: Nat => Pair[Nat] = n => {
+<<<<<<< HEAD
       val free = n.varList.foldLeft(Set[Kind.Identifier]()) {
         case (free, v: NamedVar) if !boundT(NatIdentifier(v, isExplicit = false, isTuningParam = false)) => free + NatIdentifier(v, isExplicit = false, isTuningParam = false)
+=======
+      val free = n.varList.foldLeft(OrderedSet.empty[Kind.Identifier]) {
+        case (free, v: NamedVar) if !boundT(INat(v)) => OrderedSet.add(INat(v) : Kind.Identifier)(free)
+>>>>>>> master
         case (free, _) => free
       }
-      accumulate((Set(), free))(n)
+      accumulate((OrderedSet.empty, free))(n)
     }
 
     override def expr: Expr => Pair[Expr] = {
-      case Lambda(x, b) => this.copy(boundV = boundV + x).expr(b)
-      case DepLambda(x, b) => this.copy(boundT = boundT + x).expr(b)
+      case l@Lambda(x, e) =>
+        // The binder's type itself might contain free type variables
+        val ((fVx, fTx), x1) = identifier(Binding)(x).unwrap
+        val ((fVe, fTe), e1) = this.copy(boundV = boundV + x1).expr(e).unwrap
+        val ((fVt, fTt), t1) = `type`(l.t).unwrap
+        val fV = OrderedSet.append(OrderedSet.append(fVx)(fVe))(fVt)
+        val fT = OrderedSet.append(OrderedSet.append(fTx)(fTe))(fTt)
+        accumulate((fV, fT))(Lambda(x1, e1)(t1): Expr)
+      case DepLambda(k, x, b) => this.copy(boundT = boundT + Kind.toIdentifier(k, x)).expr(b)
       case e => super.expr(e)
     }
 
     override def natToData: NatToData => Pair[NatToData] = {
       case NatToDataLambda(x, e) =>
-        for { p <- this.copy(boundT = boundT + x).`type`(e) }
+        for { p <- this.copy(boundT = boundT + INat(x)).`type`(e) }
           yield (p._1, NatToDataLambda(x, e))
       case t => super.natToData(t)
     }
 
     override def natToNat: NatToNat => Pair[NatToNat] = {
       case NatToNatLambda(x, n) =>
-        for { p <- this.copy(boundT = boundT + x).nat(n) }
+        for { p <- this.copy(boundT = boundT + INat(x)).nat(n) }
           yield (p._1, NatToNatLambda(x, n))
       case n => super.natToNat(n)
     }
 
     override def `type`[T <: Type]: T => Pair[T] = {
-      case d@DepFunType(x, t) =>
-        for { p <- this.copy(boundT = boundT + x).`type`(t) }
+      case d@DepFunType(k, x, t) =>
+        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).`type`(t) }
           yield (p._1, d.asInstanceOf[T])
-      case d@DepPairType(x, dt) =>
-        for { p <- this.copy(boundT = boundT + x).datatype(dt) }
+      case d@DepPairType(k, x, dt) =>
+        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).datatype(dt) }
           yield (p._1, d.asInstanceOf[T])
       case t => super.`type`(t)
     }
   }
 
-  def freeVars(expr: Expr): (Set[Identifier], Set[Kind.Identifier]) =
-    traverse(expr, Visitor(Set(), Set()))._1
+  def freeVars(expr: Expr): (OrderedSet[Identifier], OrderedSet[Kind.Identifier]) = {
+    val ((fV, fT), _) = traverse(expr, Visitor(Set(), Set()))
+    (fV, fT)
+  }
+
+  def freeVars(t: Type): OrderedSet[Kind.Identifier] = {
+    val ((_, ftv), _) = traverse(t, Visitor(Set(), Set()))
+    ftv
+  }
+
+  // Exclude matrix layout and fragment kind identifiers, since they cannot currently be bound
+  def needsClosing : Seq[Kind.Identifier] => Seq[Kind.Identifier] = _.flatMap {
+    case IMatrixLayout(i) => Seq()
+    case IFragmentKind(i) => Seq()
+    case e => Seq(e)
+  }
+
+  def varsToClose(expr : Expr): (Seq[Identifier], Seq[Kind.Identifier]) = {
+    val (fV, fT) = freeVars(expr)
+    (fV.seq, needsClosing(fT.seq))
+  }
+
+  def varsToClose(t : Type): Seq[Kind.Identifier] = needsClosing(freeVars(t).seq)
 
   def apply(expr: Expr): Boolean = {
-    val (freeV, freeT) = freeVars(expr)
+    val (freeV, freeT) = varsToClose(expr)
     freeV.isEmpty && freeT.isEmpty
   }
 }

--- a/src/main/scala/rise/core/dotPrinter.scala
+++ b/src/main/scala/rise/core/dotPrinter.scala
@@ -1,6 +1,6 @@
 package rise.core
 
-import rise.core.types.Type
+import rise.core.types.{Kind, Type}
 
 // scalastyle:off indentation multiple.string.literals method.length
 case object dotPrinter {
@@ -114,22 +114,22 @@ case object dotPrinter {
             |${recurse(e, eID)}
             |$parent -> $eID ${edgeLabel("arg")};""".stripMargin
 
-        case DepLambda(x, e) if !inlineLambdaIdentifier =>
+        case DepLambda(kind, x, e) if !inlineLambdaIdentifier =>
           val id = getID(x)
           val expr = getID(e)
           s"""$parent ${attr(fillWhite + Label("Λ").bold.toString)}
             |$parent -> $id ${edgeLabel("id")};
             |$parent -> $expr ${edgeLabel("body")};
-            |$id ${attr(fillWhite + Label(x.name).orange.toString)}
+            |$id ${attr(fillWhite + Label(Kind.idName(kind, x)).orange.toString)}
             |${recurse(e, expr)}""".stripMargin
 
-        case DepLambda(x, e) if inlineLambdaIdentifier =>
+        case DepLambda(kind, x, e) if inlineLambdaIdentifier =>
           val expr = getID(e)
-          s"""$parent ${attr(fillWhite + Label(s"Λ.${x.name}").toString)}
+          s"""$parent ${attr(fillWhite + Label(s"Λ.${Kind.idName(kind, x)}").toString)}
             |$parent -> $expr ${edgeLabel("body")};
             |${recurse(e, expr)}""".stripMargin
 
-        case DepApp(f, e) if applyNodes =>
+        case DepApp(_, f, e) if applyNodes =>
           val fun = getID(f)
           val arg = getID(e)
           s"""
@@ -139,7 +139,7 @@ case object dotPrinter {
             |$arg ${attr(fillWhite + Label(e.toString).toString)}
             |${recurse(f, fun)}""".stripMargin
 
-        case DepApp(f, e) if !applyNodes =>
+        case DepApp(_, f, e) if !applyNodes =>
           val eID = getID(e)
           s"""
             |${recurse(f, parent)}

--- a/src/main/scala/rise/core/lifting.scala
+++ b/src/main/scala/rise/core/lifting.scala
@@ -37,50 +37,28 @@ object lifting {
       case Lambda(x, body) =>
         Reducing((e: Expr) => substitute.exprInExpr(e, `for` = x, in = body))
       case App(f, e) => chain(liftFunExpr(f).map(lf => lf(e)))
-      case DepApp(f, x) =>
-        x match {
-          case t: DataType =>
-            chain(liftDepFunExpr[DataKind](f).map(lf => lf(t)))
-          case n: Nat => chain(liftDepFunExpr[NatKind](f).map(lf => lf(n)))
-          case a: AddressSpace =>
-            chain(liftDepFunExpr[AddressSpaceKind](f).map(lf => lf(a)))
-          case n2n: NatToNat =>
-            chain(liftDepFunExpr[NatToNatKind](f).map(lf => lf(n2n)))
-          case n2d: NatToData =>
-            chain(liftDepFunExpr[NatToDataKind](f).map(lf => lf(n2d)))
-        }
+      case DepApp(kind, f, x) => chain(liftDepFunExpr(kind, f).map(lf => lf(x)))
       case _ => chain(Expanding(p))
     }
   }
 
-  def liftDepFunExpr[K <: Kind](p: Expr): Result[K#T => Expr] = {
-    def chain(r: Result[Expr]): Result[K#T => Expr] =
-      r.bind(liftDepFunExpr[K], f => Expanding((x: K#T) => depApp[K](f, x)))
+  def liftDepFunExpr[T, KI <: Kind.Identifier](kind: Kind[T, _, KI], p: Expr): Result[T => Expr] = {
+    def chain(r: Result[Expr]): Result[T => Expr] =
+      r.bind(liftDepFunExpr[T, KI](kind, _), f => Expanding((x: T) => depApp(kind, f, x)))
 
     p match {
-      case DepLambda(x, e) =>
-        Reducing((a: K#T) => substitute.kindInExpr(a, `for` = x, in = e))
+      case DepLambda(kind, x, e) =>
+        Reducing((a: T) => substitute.kindInExpr(kind, a, `for` = x, in = e))
       case App(f, e) => chain(liftFunExpr(f).map(lf => lf(e)))
-      case DepApp(f, x) =>
-        x match {
-          case t: DataType =>
-            chain(liftDepFunExpr[DataKind](f).map(lf => lf(t)))
-          case n: Nat => chain(liftDepFunExpr[NatKind](f).map(lf => lf(n)))
-          case a: AddressSpace =>
-            chain(liftDepFunExpr[AddressSpaceKind](f).map(lf => lf(a)))
-          case n2n: NatToNat =>
-            chain(liftDepFunExpr[NatToNatKind](f).map(lf => lf(n2n)))
-          case n2d: NatToData =>
-            chain(liftDepFunExpr[NatToDataKind](f).map(lf => lf(n2d)))
-        }
+      case DepApp(kind, f, x) =>  chain(liftDepFunExpr(kind, f).map(lf => lf(x)))
       case _ => chain(Expanding(p))
     }
   }
 
-  def liftDependentFunctionType[K <: Kind](ty: Type): K#T => Type = {
+  def liftDependentFunctionType[T, I](kind: Kind[T, I, _], ty: Type): T => Type = {
     ty match {
-      case DepFunType(x, t) =>
-        (a: K#T) => substitute.kindInType(a, `for` = x, in = t)
+      case DepFunType(kind, x, t) =>
+        (a: T) => substitute.kindInType(kind, a, `for` = x, in = t)
       case _ => throw new Exception(s"did not expect $ty")
     }
   }

--- a/src/main/scala/rise/core/makeClosed.scala
+++ b/src/main/scala/rise/core/makeClosed.scala
@@ -1,41 +1,31 @@
 package rise.core
 
+import rise.core.types.Kind.{IAddressSpace, IDataType, INat, INatToData, INatToNat, IType}
+
 import scala.collection.immutable.Map
 import rise.core.types._
 
 object makeClosed {
   def apply(e: Expr): Expr = withCount(e)._1
   def withCount(e: Expr): (Expr, Int) = {
-    val emptySubs: (Map[Type, Type],
-      Map[NatIdentifier, Nat],
-      Map[AddressSpaceIdentifier, AddressSpace],
-      Map[NatToDataIdentifier, NatToData]) = (Map(), Map(), Map(), Map())
-
-    val (expr, (ts, ns, as, n2ds)) = DSL.infer.getFTVsRec(e).foldLeft((e, emptySubs))((acc, ftv) => acc match {
-      case (expr, (ts, ns, as, n2ds)) => ftv match {
-        case i: TypeIdentifier =>
-          val dt = DataTypeIdentifier(freshName("dt"), isExplicit = true)
-          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)),
-            (ts ++ Map(i -> dt), ns, as , n2ds))
-        case i: DataTypeIdentifier =>
-          val dt = i.asExplicit
-          (DepLambda[DataKind](dt, expr)(DepFunType[DataKind, Type](dt, expr.t)),
-            (ts ++ Map(i -> dt), ns, as , n2ds))
-        case i: NatIdentifier =>
-          val n = i.asExplicit
-          (DepLambda[NatKind](n, expr)(DepFunType[NatKind, Type](n, expr.t)),
-            (ts, ns ++ Map(i -> n), as, n2ds))
-        case i: AddressSpaceIdentifier =>
-          val a = i.asExplicit
-          (DepLambda[AddressSpaceKind](a, expr)(DepFunType[AddressSpaceKind, Type](a, expr.t)),
-            (ts, ns, as ++ Map(i -> a), n2ds))
-        case i: NatToDataIdentifier =>
-          val n2d = i.asExplicit
-          (DepLambda[NatToDataKind](n2d, expr)(DepFunType[NatToDataKind, Type](n2d, expr.t)),
-            (ts, ns, as, n2ds ++ Map(i -> n2d)))
+    val (_, ftvs) = IsClosedForm.varsToClose(e)
+    val (expr, ts) = ftvs.foldLeft((e, Map[Type, Type]()))((acc, ftv) => acc match {
+      case (expr, ts) => ftv match {
+        case IType(i) =>
+          val dt = DataTypeIdentifier(freshName("dt"))
+          (DepLambda(DataKind, dt, expr)(DepFunType(DataKind, dt, expr.t)), (ts ++ Map(i -> dt)))
+        case IDataType(i) =>
+          (DepLambda(DataKind, i, expr)(DepFunType(DataKind, i, expr.t)), ts)
+        case INat(i) =>
+          (DepLambda(NatKind, i, expr)(DepFunType(NatKind, i, expr.t)), ts)
+        case IAddressSpace(i) =>
+          (DepLambda(AddressSpaceKind, i, expr)(DepFunType(AddressSpaceKind, i, expr.t)), ts)
+        case INatToData(i) =>
+          (DepLambda(NatToDataKind, i, expr)(DepFunType(NatToDataKind, i, expr.t)), ts)
         case i => throw TypeException(s"${i.getClass} is not supported yet")
       }
     })
-    (new Solution(ts, ns, as, Map.empty, Map.empty, n2ds, Map.empty, Map.empty)(expr), ts.size + ns.size + as.size + n2ds.size)
+    val sol = new Solution(ts, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty, Map.empty)
+    (sol(expr), ftvs.length)
   }
 }

--- a/src/main/scala/rise/core/package.scala
+++ b/src/main/scala/rise/core/package.scala
@@ -23,7 +23,7 @@ package object core {
         s"Lambda(${toEvaluableString(x)}, ${toEvaluableString(e)})"
       case App(f, e) =>
         s"Apply(${toEvaluableString(f)}, ${toEvaluableString(e)})"
-      case DepLambda(x, e) =>
+      case DepLambda(_, x, e) =>
         x match {
           case n: NatIdentifier =>
             s"""DepLambda[NatKind](NatIdentifier("id$n"),
@@ -31,7 +31,7 @@ package object core {
           case dt: DataTypeIdentifier =>
             s"""DepLambda[DataKind]("id$dt", ${toEvaluableString(e)})"""
         }
-      case DepApp(f, x) =>
+      case DepApp(_, f, x) =>
         x match {
           case n: Nat => s"DepApply[NatKind](${toEvaluableString(f)}, $n)"
           case dt: DataType =>

--- a/src/main/scala/rise/core/primitives/foreignFunction.scala
+++ b/src/main/scala/rise/core/primitives/foreignFunction.scala
@@ -21,13 +21,13 @@ object foreignFunction {
     override val name: String = "foreignFunction"
     override def setType(ty: Type): Primitive = Primitive(funDecl, n)(ty)
     override def typeScheme: Type = {
-      val inTs = Seq.fill(n)(DataTypeIdentifier(freshName("dt"), isExplicit = true))
+      val inTs = Seq.fill(n)(DataTypeIdentifier(freshName("dt")))
       inTs.foldRight(expl { (outT: DataType) => inTs.foldRight(outT: Type)({
         case (lhsT, rhsT) =>
           lhsT ->: rhsT
       }) }: Type)({
         case (id, t) =>
-          DepFunType[DataKind, Type](id, t)
+          DepFunType(DataKind, id, t)
       })
     }
     override def primEq(obj: rise.core.Primitive): Boolean = obj match {

--- a/src/main/scala/rise/core/showRise.scala
+++ b/src/main/scala/rise/core/showRise.scala
@@ -1,5 +1,6 @@
 package rise.core
 
+import rise.core.types.Kind
 import rise.core.DrawTree.UnicodeConfig
 
 case class RenderException(msg: String) extends Exception {
@@ -243,8 +244,8 @@ class ShowRiseCompact {
         (false, newSize, fr >@> (fd => er >@> (ed => fd :+> ed)))
       }
 
-    case dl @ DepLambda(x, e) =>
-      val xs = s"${x.name}:${dl.kindName}"
+    case dl @ DepLambda(k, x, e) =>
+      val xs = s"${Kind.idName(k, x)}:${dl.kindName}"
       val (eInline, eSize, er) = drawAST(e)
       val newSize = eSize + 1
       if ((inlineSize > 0) && eInline) {
@@ -256,10 +257,10 @@ class ShowRiseCompact {
         (false, newSize, er >@> (ed => block(s"Λ$xs", ed)))
       }
 
-    case DepApp(f, x) =>
+    case DepApp(kind, f, x) =>
       val (fInline, fSize, fr) = f match {
-        case _: DepLambda[_] => drawAST(f, wrapped = true)
-        case _               => drawAST(f)
+        case _: DepLambda[_, _, _] => drawAST(f, wrapped = true)
+        case _                     => drawAST(f)
       }
       val xs = x.toString
       val newSize = fSize + 1

--- a/src/main/scala/rise/core/substitute.scala
+++ b/src/main/scala/rise/core/substitute.scala
@@ -76,8 +76,8 @@ object substitute {
   def natsInExpr(subs: Map[NatIdentifier, Nat], in: Expr): Expr = {
     object Visitor extends PureTraversal {
       override def expr: Expr => Pure[Expr] = {
-        case Identifier(name) if subs.contains(NatIdentifier(name, isExplicit = true)) =>
-          return_(Literal(NatData(subs(NatIdentifier(name, isExplicit = true)))) : Expr)
+        case Identifier(name) if subs.contains(NatIdentifier(name)) =>
+          return_(Literal(NatData(subs(NatIdentifier(name)))) : Expr)
         case e => super.expr(e)
       }
 

--- a/src/main/scala/rise/core/substitute.scala
+++ b/src/main/scala/rise/core/substitute.scala
@@ -9,18 +9,18 @@ object substitute {
 
   // substitute in Expr
 
-  def kindInExpr[K <: Kind](x: K#T, `for`: K#I, in: Expr): Expr =
-    (x, `for`) match {
-      case (dt: DataType, forDt: DataTypeIdentifier) =>
+  def kindInExpr[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: T, `for`: I, in: Expr): Expr =
+    (kind, x, `for`) match {
+      case (DataKind, dt: DataType, forDt: DataTypeIdentifier) =>
         dataTypeInExpr(dt, forDt, in)
-      case (n: Nat, forN: NatIdentifier) => natInExpr(n, forN, in)
-      case (a: AddressSpace, forA: AddressSpaceIdentifier) =>
+      case (NatKind, n: Nat, forN: NatIdentifier) => natInExpr(n, forN, in)
+      case (AddressSpaceKind, a: AddressSpace, forA: AddressSpaceIdentifier) =>
         addressSpaceInExpr(a, forA, in)
-      case (n2n: NatToNat, forN2N: NatToNatIdentifier) =>
+      case (NatToNatKind, n2n: NatToNat, forN2N: NatToNatIdentifier) =>
         n2nInExpr(n2n, forN2N, in)
-      case (n2d: NatToData, forN2D: NatToDataIdentifier) =>
+      case (NatToDataKind, n2d: NatToData, forN2D: NatToDataIdentifier) =>
         n2dInExpr(n2d, forN2D, in)
-      case (_, _) => ???
+      case (_, _, _) => ???
     }
 
   def exprInExpr(expression : Expr, `for`: Expr, in: Expr): Expr = {
@@ -53,8 +53,8 @@ object substitute {
     case i: Identifier => Set(i)
     case Lambda(x, e) => FV(e) - x
     case App(f, e) => FV(f) ++ FV(e)
-    case DepLambda(_, e) => FV(e)
-    case DepApp(f, _) => FV(f)
+    case DepLambda(_, _, e) => FV(e)
+    case DepApp(_, f, _) => FV(f)
     case Literal(_) => Set()
     case TypeAnnotation(e, _) => FV(e)
     case TypeAssertion(e, _) => FV(e)
@@ -104,20 +104,16 @@ object substitute {
 
   // substitute in Type
 
-  def kindInType[K <: Kind, T <: Type](x: K#T, `for`: K#I, in: T): T =
-    (x, `for`) match {
-      case (dt: DataType, forDt: DataTypeIdentifier) =>
-        typeInType(dt, forDt, in)
-      case (n: Nat, forN: NatIdentifier) =>
-        natInType(n, forN, in)
-      case (a: AddressSpace, forA: AddressSpaceIdentifier) =>
-        addressSpaceInType(a, forA, in)
-      case (n2n: NatToNat, forN2N: NatToNatIdentifier) =>
-        n2nInType(n2n, forN2N, in)
-      case (n2d: NatToData, forN2D: NatToDataIdentifier) =>
-        n2dInType(n2d, forN2D, in)
-      case (_, _) => ???
+  def kindInType[T, I, KI <: Kind.Identifier, U <: Type](kind: Kind[T, I, KI], x: T, `for`: I, in: U): U = {
+    (kind, x, `for`) match {
+      case (DataKind, dt: DataType, forDt: DataTypeIdentifier) => typeInType(dt, forDt, in)
+      case (NatKind, n: Nat, forN: NatIdentifier) => natInType(n, forN, in)
+      case (AddressSpaceKind, a: AddressSpace, forA: AddressSpaceIdentifier) => addressSpaceInType(a, forA, in)
+      case (NatToNatKind, n2n: NatToNat, forN2N: NatToNatIdentifier) => n2nInType(n2n, forN2N, in)
+      case (NatToDataKind, n2d: NatToData, forN2D: NatToDataIdentifier) => n2dInType(n2d, forN2D, in)
+      case (_, _, _) => ???
     }
+  }
 
   def typeInType[B <: Type](ty: Type, `for`: Type, in: B): B = {
     object Visitor extends PureTraversal {

--- a/src/main/scala/rise/core/traverse.scala
+++ b/src/main/scala/rise/core/traverse.scala
@@ -3,6 +3,7 @@ package rise.core
 import scala.language.implicitConversions
 import util.monads._
 import rise.core.semantics._
+import rise.core.types.Kind.{IAddressSpace, IDataType, IFragmentKind, IMatrixLayout, INat, INatToData, INatToNat, IType}
 import rise.core.types._
 
 object traverse {
@@ -23,19 +24,30 @@ object traverse {
       for { t1 <- `type`(i.t)}
         yield i.setType(t1).asInstanceOf[I]
     def typeIdentifierDispatch[I <: Kind.Identifier] : VarType => I => M[I] = vt => i => (i match {
-      case n: NatIdentifier => bind(typeIdentifier(vt)(n))(nat)
-      case dt: DataTypeIdentifier => bind(typeIdentifier(vt)(dt))(datatype)
-      case a: AddressSpaceIdentifier => bind(typeIdentifier(vt)(a))(addressSpace)
-      case m: MatrixLayoutIdentifier => bind(typeIdentifier(vt)(m))(matrixLayout)
-      case f: FragmentKindIdentifier => bind(typeIdentifier(vt)(f))(fragmentKind)
-      case n2n: NatToNatIdentifier => bind(typeIdentifier(vt)(n2n))(natToNat)
-      case n2d: NatToDataIdentifier => bind(typeIdentifier(vt)(n2d))(natToData)
-      case t: TypeIdentifier => typeIdentifier(vt)(t)
+      case t: IType => typeIdentifier(vt)(t)
+      case n: INat => bind(nat(n.id))(i => typeIdentifier(vt)(INat(i.asInstanceOf[NatIdentifier])))
+      case dt: IDataType => bind(datatype(dt.id))(i => typeIdentifier(vt)(IDataType(i.asInstanceOf[DataTypeIdentifier])))
+      case a: IAddressSpace => bind(addressSpace(a.id))(i => typeIdentifier(vt)(IAddressSpace(i.asInstanceOf[AddressSpaceIdentifier])))
+      case m: IMatrixLayout => bind(matrixLayout(m.id))(i => typeIdentifier(vt)(IMatrixLayout(i.asInstanceOf[MatrixLayoutIdentifier])))
+      case f: IFragmentKind => bind(fragmentKind(f.id))(i => typeIdentifier(vt)(IFragmentKind(i.asInstanceOf[FragmentKindIdentifier])))
+      case n2n: INatToNat => bind(natToNat(n2n.id))(i => typeIdentifier(vt)(INatToNat(i.asInstanceOf[NatToNatIdentifier])))
+      case n2d: INatToData => bind(natToData(n2d.id))(i => typeIdentifier(vt)(INatToData(i.asInstanceOf[NatToDataIdentifier])))
     }).asInstanceOf[M[I]]
     def natDispatch : VarType => Nat => M[Nat] = vt => {
-      case i : NatIdentifier =>
-        bind(typeIdentifier(vt)(i))(nat)
+      case i : NatIdentifier => bind(typeIdentifier(vt)(INat(i)))(i => nat(i.id))
       case n => nat(n)
+    }
+    def matrixLayoutDispatch : VarType => MatrixLayout => M[MatrixLayout] = vt => {
+      case i : MatrixLayoutIdentifier => bind(typeIdentifier(vt)(IMatrixLayout(i)))(i => matrixLayout(i.id))
+      case m => matrixLayout(m)
+    }
+    def fragmentKindDispatch : VarType => FragmentKind => M[FragmentKind] = vt => {
+      case i : FragmentKindIdentifier => bind(typeIdentifier(vt)(IFragmentKind(i)))(i => fragmentKind(i.id))
+      case m => fragmentKind(m)
+    }
+    def dataTypeDispatch : VarType => DataType => M[DataType] = vt => {
+      case i : DataTypeIdentifier => bind(typeIdentifier(vt)(IDataType(i)))(i => datatype(i.id))
+      case d => datatype(d)
     }
 
     def addressSpace : AddressSpace => M[AddressSpace] = return_
@@ -46,7 +58,7 @@ object traverse {
       case NatType               => return_(NatType : DataType)
       case s : ScalarType        => return_(s : DataType)
       case ArrayType(n, d) =>
-        for {n1 <- natDispatch(Reference)(n); d1 <- `type`[DataType](d)}
+        for {n1 <- natDispatch(Reference)(n); d1 <- dataTypeDispatch(Reference)(d)}
           yield ArrayType(n1, d1)
       case DepArrayType(n, n2d) =>
         for {n1 <- natDispatch(Reference)(n); n2d1 <- natToData(n2d)}
@@ -54,22 +66,26 @@ object traverse {
       case PairType(p1, p2) =>
         for {p11 <- `type`(p1); p21 <- `type`(p2)}
           yield PairType(p11, p21)
-      case pair@DepPairType(x, e) =>
-        for {x1 <- typeIdentifierDispatch(Binding)(x); e1 <- `type`(e)}
-          yield DepPairType(x1, e1)(pair.kindName)
+      case DepPairType(kind, x, d) =>
+        for {x1 <- typeIdentifierDispatch(Binding)(Kind.toIdentifier(kind, x)); d1 <- dataTypeDispatch(Reference)(d)}
+          yield DepPairType(kind, Kind.fromIdentifier(kind, x1), d1)
       case IndexType(n) =>
         for {n1 <- natDispatch(Reference)(n)}
           yield IndexType(n1)
-      case VectorType(n, e) =>
-        for {n1 <- natDispatch(Reference)(n); e1 <- `type`(e)}
-          yield VectorType(n1, e1)
+      case VectorType(n, d) =>
+        for {n1 <- natDispatch(Reference)(n); d1 <- dataTypeDispatch(Reference)(d)}
+          yield VectorType(n1, d1)
       case ManagedBufferType(dt) =>
-        for {dt1 <- datatype(dt)}
+        for {dt1 <- dataTypeDispatch(Reference)(dt)}
           yield ManagedBufferType(dt1)
       case o: OpaqueType => return_(o: DataType)
       case FragmentType(rows, columns, d3, dt, fragKind, layout) =>
-        for {rows1 <- nat(rows); columns1 <- nat(columns); d31 <- nat(d3); dt1 <- datatype(dt);
-          fragKind1 <- fragmentKind(fragKind); layout1 <- matrixLayout(layout)}
+        for {rows1 <- natDispatch(Reference)(rows);
+             columns1 <- natDispatch(Reference)(columns);
+             d31 <- natDispatch(Reference)(d3);
+             dt1 <- dataTypeDispatch(Reference)(dt);
+             fragKind1 <- fragmentKindDispatch(Reference)(fragKind);
+             layout1 <- matrixLayoutDispatch(Reference)(layout)}
         yield FragmentType(rows1, columns1, d31, dt1, fragKind1, layout1)
       case NatToDataApply(ntdf, n) =>
         for {ntdf1 <- natToData(ntdf); n1 <- natDispatch(Reference)(n)}
@@ -79,15 +95,15 @@ object traverse {
     def natToNat : NatToNat => M[NatToNat] = {
       case i : NatToNatIdentifier => return_(i.asInstanceOf[NatToNat])
       case NatToNatLambda(x, e) =>
-        for { x1 <- typeIdentifierDispatch(Binding)(x); e1 <- natDispatch(Reference)(e) }
-          yield NatToNatLambda(x1, e1)
+        for { x1 <- typeIdentifierDispatch(Binding)(INat(x)); e1 <- natDispatch(Reference)(e) }
+          yield NatToNatLambda(x1.id, e1)
     }
 
     def natToData : NatToData => M[NatToData] = {
       case i : NatToDataIdentifier => return_(i.asInstanceOf[NatToData])
-      case NatToDataLambda(x, e) =>
-        for { x1 <- typeIdentifierDispatch(Binding)(x); e1 <- `type`(e) }
-          yield NatToDataLambda(x1, e1)
+      case NatToDataLambda(x, d) =>
+        for { x1 <- typeIdentifierDispatch(Binding)(INat(x)); d1 <- dataTypeDispatch(Reference)(d) }
+          yield NatToDataLambda(x1.id, d1)
     }
 
     def data : Data => M[Data] = {
@@ -109,29 +125,16 @@ object traverse {
 
     def `type`[T <: Type ] : T => M[T] = t => (t match {
       case TypePlaceholder => return_(TypePlaceholder)
-      case i: DataTypeIdentifier => typeIdentifierDispatch(Reference)(i)
-      case i: TypeIdentifier => typeIdentifierDispatch(Reference)(i)
-      case dt: DataType => datatype(dt)
+      case i: TypeIdentifier =>
+        for { i1 <- typeIdentifierDispatch(Reference)(IType(i)) }
+          yield i1.id
+      case dt: DataType => dataTypeDispatch(Reference)(dt)
       case FunType(a, b) =>
         for {a1 <- `type`(a); b1 <- `type`(b)}
           yield FunType(a1, b1)
-      case DepFunType(x, t) => x match {
-        case n: NatIdentifier =>
-          for { n1 <- typeIdentifierDispatch(Binding)(n); t1 <- `type`(t)}
-            yield DepFunType[NatKind, Type](n1, t1)
-        case dt: DataTypeIdentifier =>
-          for { dt1 <- typeIdentifierDispatch(Binding)(dt); t1 <- `type`(t)}
-            yield DepFunType[DataKind, Type](dt1, t1)
-        case a: AddressSpaceIdentifier =>
-          for { a1 <- typeIdentifierDispatch(Binding)(a); t1 <- `type`(t)}
-            yield DepFunType[AddressSpaceKind, Type](a1, t1)
-        case n2n: NatToNatIdentifier =>
-          for { n2n1 <- typeIdentifierDispatch(Binding)(n2n); t1 <- `type`(t)}
-            yield DepFunType[NatToNatKind, Type](n2n1, t1)
-        case n2d: NatToDataIdentifier =>
-          for { n2d1 <- typeIdentifierDispatch(Binding)(n2d); t1 <- `type`(t)}
-            yield DepFunType[NatToDataKind, Type](n2d1, t1)
-      }
+      case DepFunType(kind, x, t) =>
+        for { n1 <- typeIdentifierDispatch(Binding)(Kind.toIdentifier(kind, x)); t1 <- `type`(t)}
+          yield DepFunType(kind, Kind.fromIdentifier(kind, n1), t1)
     }).asInstanceOf[M[T]]
 
     def expr : Expr => M[Expr] = {
@@ -148,31 +151,26 @@ object traverse {
           e1 <- expr(e)
           t1 <- `type`(a.t)
         } yield App(f1, e1)(t1)
-      case dl@DepLambda(x,e) => x match {
-        case n: NatIdentifier =>
-          for {n1 <- typeIdentifierDispatch(Binding)(n); e1 <- expr(e); t1 <- `type`(dl.t)}
-            yield DepLambda[NatKind](n1, e1)(t1)
-        case dt: DataTypeIdentifier =>
-          for {dt1 <- typeIdentifierDispatch(Binding)(dt); e1 <- expr(e); t1 <- `type`(dl.t)}
-            yield DepLambda[DataKind](dt1, e1)(t1)
-      }
-      case da@DepApp(f, x) => x match {
-        case n: Nat =>
-          for {f1 <- expr(f); n1 <- natDispatch(Reference)(n); t1 <- `type`(da.t)}
-            yield DepApp[NatKind](f1, n1)(t1)
-        case dt: DataType =>
-          for {f1 <- expr(f); dt1 <- `type`(dt); t1 <- `type`(da.t)}
-            yield DepApp[DataKind](f1, dt1)(t1)
-        case a: AddressSpace =>
-          for {f1 <- expr(f); a1 <- addressSpace(a); t1 <- `type`(da.t)}
-            yield DepApp[AddressSpaceKind](f1, a1)(t1)
-        case n2n: NatToNat =>
-          for {f1 <- expr(f); n2n1 <- natToNat(n2n); t1 <- `type`(da.t)}
-            yield DepApp[NatToNatKind](f1, n2n1)(t1)
-        case n2d: NatToData =>
-          for {f1 <- expr(f); n2d1 <- natToData(n2d); t1 <- `type`(da.t)}
-            yield DepApp[NatToDataKind](f1, n2d1)(t1)
-      }
+      case dl@DepLambda(kind, x,e) =>
+        for {n1 <- typeIdentifierDispatch(Binding)(Kind.toIdentifier(kind, x)); e1 <- expr(e); t1 <- `type`(dl.t)}
+          yield DepLambda(kind, Kind.fromIdentifier(kind, n1), e1)(t1)
+      case da@DepApp(NatKind, f, x: Nat) =>
+        for {f1 <- expr(f); n1 <- natDispatch(Reference)(x); t1 <- `type`(da.t)}
+          yield DepApp(NatKind, f1, n1)(t1)
+      case da@DepApp(DataKind, f, x: DataType) =>
+        for {f1 <- expr(f); dt1 <- `type`(x); t1 <- `type`(da.t)}
+          yield DepApp(DataKind, f1, dt1)(t1)
+      case da@DepApp(AddressSpaceKind, f, x: AddressSpace) =>
+        for {f1 <- expr(f); a1 <- addressSpace(x); t1 <- `type`(da.t)}
+          yield DepApp(AddressSpaceKind, f1, a1)(t1)
+      case da@DepApp(NatToNatKind, f, x: NatToNat) =>
+        for {f1 <- expr(f); n2n1 <- natToNat(x); t1 <- `type`(da.t)}
+          yield DepApp(NatToNatKind, f1, n2n1)(t1)
+      case da@DepApp(NatToDataKind, f, x: NatToData) =>
+        for {f1 <- expr(f); n2d1 <- natToData(x); t1 <- `type`(da.t)}
+          yield DepApp(NatToDataKind, f1, n2d1)(t1)
+      case DepApp(_, _, _) =>
+        ???
       case Literal(d) =>
         for { d1 <- data(d) }
           yield Literal(d1)

--- a/src/main/scala/rise/core/types/AddressSpace.scala
+++ b/src/main/scala/rise/core/types/AddressSpace.scala
@@ -3,16 +3,8 @@ package rise.core.types
 // TODO: should not be in the core
 sealed trait AddressSpace
 
-final case class AddressSpaceIdentifier(
-    name: String,
-    override val isExplicit: Boolean = false
-) extends AddressSpace
-    with Kind.Identifier
-    with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: AddressSpaceIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: AddressSpaceIdentifier =
-    this.copy(isExplicit = false)
+final case class AddressSpaceIdentifier( name: String) extends AddressSpace {
+  override def toString: String = name
 }
 
 // scalastyle:off public.methods.have.type

--- a/src/main/scala/rise/core/types/Constraints.scala
+++ b/src/main/scala/rise/core/types/Constraints.scala
@@ -298,16 +298,6 @@ object Constraint {
         case (p: arithexpr.arithmetic.IntDiv, _) => nat.unifyProd(p, b, preserve)
         case (_, p: arithexpr.arithmetic.IntDiv) => nat.unifyProd(p, a, preserve)
         case (arithexpr.arithmetic.Mod(x1, m1),
-<<<<<<< HEAD
-        arithexpr.arithmetic.Mod(x2: NatIdentifier, m2))
-          if m1 == m2 && canBeSubstituted(preserve, x2) =>
-          val k = NatIdentifier("k", RangeAdd(0, PosInf, 1), isExplicit = false)
-          Solution.subs(x2, k*m1 + x1%m1)
-        case (arithexpr.arithmetic.Mod(x2: NatIdentifier, m2),
-        arithexpr.arithmetic.Mod(x1, m1))
-          if m1 == m2 && canBeSubstituted(preserve, x2) =>
-          val k = NatIdentifier("k", RangeAdd(0, PosInf, 1), isExplicit = false)
-=======
           arithexpr.arithmetic.Mod(x2: NatIdentifier, m2))
           if m1 == m2 && canBeSubstituted(preserve, INat(x2)) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
@@ -316,7 +306,6 @@ object Constraint {
           arithexpr.arithmetic.Mod(x1, m1))
           if m1 == m2 && canBeSubstituted(preserve, INat(x2)) =>
           val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
->>>>>>> master
           Solution.subs(x2, k*m1 + x1%m1)
         case _ => error(s"cannot unify $a and $b")
       }
@@ -373,7 +362,7 @@ object Constraint {
           }
         case Pow(b, Cst(-1)) => pivotSolution(pivot, b, Cst(1) /^ value)
         case Mod(p, m) if p == pivot =>
-          val k = NatIdentifier("k", RangeAdd(0, PosInf, 1), isExplicit = false)
+          val k = NatIdentifier("k", RangeAdd(0, PosInf, 1))
           Some(Solution.subs(pivot, k*m + value))
         case _               =>
           None

--- a/src/main/scala/rise/core/types/Kinds.scala
+++ b/src/main/scala/rise/core/types/Kinds.scala
@@ -1,83 +1,77 @@
 package rise.core.types
 
-sealed trait Kind {
-  type T
-  type I <: Kind.Identifier with T
+sealed trait Kind[+T, +I, +KI <: Kind.Identifier] {
+  def name :String
 }
+
 
 object Kind {
-  trait Identifier {
-    def name: String
-  }
-  trait Explicitness {
-    val isExplicit: Boolean
-    def asExplicit: Explicitness
-    def asImplicit: Explicitness
-  }
-}
+  trait Identifier { def name: String }
+  case class IType(id : TypeIdentifier) extends Identifier { def name : String = id.name }
+  case class IDataType(id : DataTypeIdentifier) extends Identifier { def name : String = id.name }
+  case class INat(id : NatIdentifier) extends Identifier { def name : String = id.name }
+  case class IAddressSpace(id : AddressSpaceIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToNat(id : NatToNatIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToData(id : NatToDataIdentifier) extends Identifier { def name : String = id.name }
+  case class IMatrixLayout(id : MatrixLayoutIdentifier) extends Identifier { def name : String = id.name }
+  case class IFragmentKind(id : FragmentKindIdentifier) extends Identifier { def name : String = id.name }
+  case class INatCollection(id : NatCollectionIdentifier) extends Identifier { def name : String = id.name }
 
-sealed trait TypeKind extends Kind {
-  override type T = Type
-  override type I = TypeIdentifier
-}
-
-sealed trait DataKind extends Kind {
-  override type T = DataType
-  override type I = DataTypeIdentifier
-}
-
-sealed trait NatKind extends Kind {
-  override type T = Nat
-  override type I = NatIdentifier
-}
-
-sealed trait AddressSpaceKind extends Kind {
-  override type T = AddressSpace
-  override type I = AddressSpaceIdentifier
-}
-
-sealed trait NatToNatKind extends Kind {
-  override type T = NatToNat
-  override type I = NatToNatIdentifier
-}
-
-sealed trait NatToDataKind extends Kind {
-  override type T = NatToData
-  override type I = NatToDataIdentifier
-}
-
-sealed trait NatCollectionKind extends Kind {
-  override type T = NatCollection
-  override type I = NatCollectionIdentifier
-}
-
-trait KindName[K <: Kind] {
-  def get: String
-}
-
-object KindName {
-  implicit val typeKN: KindName[TypeKind] = new KindName[TypeKind] {
-    def get = "type"
-  }
-  implicit val dataKN: KindName[DataKind] = new KindName[DataKind] {
-    def get = "data"
-  }
-  implicit val natKN: KindName[NatKind] = new KindName[NatKind] {
-    def get = "nat"
-  }
-  implicit val addressSpaceKN: KindName[AddressSpaceKind] =
-    new KindName[AddressSpaceKind] {
-      def get = "addressSpace"
-    }
-  implicit val n2nKN: KindName[NatToNatKind] = new KindName[NatToNatKind] {
-    def get = "nat->nat"
-  }
-  implicit val n2dtKN: KindName[NatToDataKind] = new KindName[NatToDataKind] {
-    def get = "nat->data"
+  def idName[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : String = kind match {
+    case TypeKind => i.asInstanceOf[TypeIdentifier].name
+    case DataKind => i.asInstanceOf[DataTypeIdentifier].name
+    case NatKind => i.asInstanceOf[NatIdentifier].name
+    case AddressSpaceKind => i.asInstanceOf[AddressSpaceIdentifier].name
+    case NatToNatKind => i.asInstanceOf[NatToNatIdentifier].name
+    case NatToDataKind => i.asInstanceOf[NatToDataIdentifier].name
+    case NatCollectionKind => i.asInstanceOf[NatCollectionIdentifier].name
   }
 
-  implicit val natsKN: KindName[NatCollectionKind] =
-    new KindName[NatCollectionKind] {
-      override def get: String = "nats"
-    }
+  def toIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : KI = kind match {
+    case TypeKind => IType(i.asInstanceOf[TypeIdentifier]).asInstanceOf[KI]
+    case DataKind => IDataType(i.asInstanceOf[DataTypeIdentifier]).asInstanceOf[KI]
+    case NatKind => INat(i.asInstanceOf[NatIdentifier]).asInstanceOf[KI]
+    case AddressSpaceKind => IAddressSpace(i.asInstanceOf[AddressSpaceIdentifier]).asInstanceOf[KI]
+    case NatToNatKind => INatToNat(i.asInstanceOf[NatToNatIdentifier]).asInstanceOf[KI]
+    case NatToDataKind => INatToData(i.asInstanceOf[NatToDataIdentifier]).asInstanceOf[KI]
+    case NatCollectionKind => INatCollection(i.asInstanceOf[NatCollectionIdentifier]).asInstanceOf[KI]
+  }
+
+  def fromIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : KI) : I = kind match {
+    case TypeKind => i.asInstanceOf[IType].id.asInstanceOf[I]
+    case DataKind => i.asInstanceOf[IDataType].id.asInstanceOf[I]
+    case NatKind => i.asInstanceOf[INat].id.asInstanceOf[I]
+    case AddressSpaceKind => i.asInstanceOf[IAddressSpace].id.asInstanceOf[I]
+    case NatToNatKind => i.asInstanceOf[INatToNat].id.asInstanceOf[I]
+    case NatToDataKind => i.asInstanceOf[INatToData].id.asInstanceOf[I]
+    case NatCollectionKind => i.asInstanceOf[INatCollection].id.asInstanceOf[I]
+  }
+}
+
+case object TypeKind extends Kind[Type, TypeIdentifier, Kind.IType] {
+  override def name: String = "type"
+}
+
+case object DataKind extends Kind[DataType, DataTypeIdentifier, Kind.IDataType] {
+  override def name: String = "data"
+}
+
+case object NatKind extends Kind[Nat, NatIdentifier, Kind.INat] {
+  override def name: String = "nat"
+}
+
+case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier, Kind.IAddressSpace] {
+  override def name: String = "addressSpace"
+}
+
+case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier, Kind.INatToNat] {
+  override def name: String = "nat->nat"
+}
+
+case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier, Kind.INatToData] {
+  override def name: String = "nat->data"
+}
+
+case object NatCollectionKind extends Kind[NatCollection, NatCollectionIdentifier, Kind.INatCollection] {
+  override def name: String = "nats"
 }

--- a/src/main/scala/rise/core/types/Nat.scala
+++ b/src/main/scala/rise/core/types/Nat.scala
@@ -1,63 +1,33 @@
 package rise.core.types
 
 import arithexpr.arithmetic._
-import rise.core.types
 
-<<<<<<< HEAD
-class NatIdentifier(
-    override val name: String,
-    override val range: Range,
-    override val isExplicit: Boolean,
-    val isTuningParam: Boolean
-) extends NamedVar(name, range)
-    with types.Kind.Identifier
-    with types.Kind.Explicitness {
-  override lazy val toString: String = if (isExplicit) name else "_" + name
-
-  override def copy(r: Range): NatIdentifier =
-    new NatIdentifier(name, r, isExplicit, isTuningParam)
-
-  override def asExplicit: NatIdentifier = new NatIdentifier(name, range, true, isTuningParam)
-
-  override def asImplicit: NatIdentifier = new NatIdentifier(name, range, false, isTuningParam)
-
-  override def substitute(subs: collection.Map[ArithExpr, ArithExpr]): Option[ArithExpr] = {
-    subs.get(this).orElse(range.substitute(subs)
-      .map(NatIdentifier(name, _, isExplicit, isTuningParam)))
-  }
-
-  override def visitAndRebuild(f: ArithExpr => ArithExpr): ArithExpr = {
-    f(new NatIdentifier(name, range.visitAndRebuild(f), isExplicit, isTuningParam))
-  }
-
-  override def cloneSimplified(): NatIdentifier with SimplifiedExpr =
-    new NatIdentifier(name, range, isExplicit, isTuningParam) with SimplifiedExpr
+object IsTuningParameter {
+  def apply(name: String)(ni: NatIdentifier): Boolean =
+    ni.name == TuningParameter.prefix + name
 }
 
-object NatIdentifier {
-  def apply(name: String, range: Range, isExplicit: Boolean, isTuningParam: Boolean): NatIdentifier =
-    new NatIdentifier(name, range, isExplicit = isExplicit, isTuningParam = isTuningParam)
+object TuningParameter {
+  val prefix = "tuned_"
+  def apply(name: String): NatIdentifier = NatIdentifier(prefix + name)
+  def apply(name: String, range: Range): NatIdentifier = NatIdentifier(prefix + name, range)
+  def unapply(ni: NatIdentifier): Boolean = {
+    if (ni.name.startsWith(prefix)) {
+      true
+    } else {
+      false
+    }
+  }
+}
 
-  def apply(name: String, range: Range, isExplicit: Boolean): NatIdentifier =
-    new NatIdentifier(name, range, isExplicit = isExplicit, isTuningParam = false)
-
-  def apply(name: String, isExplicit: Boolean): NatIdentifier =
-    apply(name, RangeUnknown, isExplicit)
-
-  def apply(name: String, range: Range): NatIdentifier =
-    apply(name, range, isExplicit = false)
-
-  def apply(name: String): NatIdentifier =
-    apply(name, isExplicit = false)
-
-  def apply(nv: NamedVar, isExplicit: Boolean, isTuningParam: Boolean): NatIdentifier =
-    new NatIdentifier(nv.name, nv.range, isExplicit, isTuningParam)
-=======
+object TuningParameterName {
+  def apply(ni: NatIdentifier): String =
+    ni.name.drop(TuningParameter.prefix.length)
+}
 
 object NatIdentifier {
   def apply(name: String): NatIdentifier = new NamedVar(name)
   def apply(name: String, range: Range): NatIdentifier = new NamedVar(name, range)
->>>>>>> master
 }
 
 final class NatToNatApply(val f: NatToNat, val n: Nat)

--- a/src/main/scala/rise/core/types/Nat.scala
+++ b/src/main/scala/rise/core/types/Nat.scala
@@ -3,6 +3,7 @@ package rise.core.types
 import arithexpr.arithmetic._
 import rise.core.types
 
+<<<<<<< HEAD
 class NatIdentifier(
     override val name: String,
     override val range: Range,
@@ -51,6 +52,12 @@ object NatIdentifier {
 
   def apply(nv: NamedVar, isExplicit: Boolean, isTuningParam: Boolean): NatIdentifier =
     new NatIdentifier(nv.name, nv.range, isExplicit, isTuningParam)
+=======
+
+object NatIdentifier {
+  def apply(name: String): NatIdentifier = new NamedVar(name)
+  def apply(name: String, range: Range): NatIdentifier = new NamedVar(name, range)
+>>>>>>> master
 }
 
 final class NatToNatApply(val f: NatToNat, val n: Nat)

--- a/src/main/scala/rise/core/types/NatCollection.scala
+++ b/src/main/scala/rise/core/types/NatCollection.scala
@@ -26,17 +26,8 @@ sealed abstract class NatCollection {
   def apply(idxs: Nat*): Nat = new NatCollectionIndexing(this, idxs)
 }
 
-final case class NatCollectionIdentifier(
-    name: String,
-   override val isExplicit: Boolean = false
- ) extends NatCollection
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatCollectionIdentifier =
-      this.copy(isExplicit = true)
-  override def asImplicit: NatCollectionIdentifier =
-    this.copy(isExplicit = false)
+final case class NatCollectionIdentifier(name: String) extends NatCollection {
+  override def toString: String = name
 }
 
 /**

--- a/src/main/scala/rise/core/types/NatToData.scala
+++ b/src/main/scala/rise/core/types/NatToData.scala
@@ -11,14 +11,8 @@ sealed trait NatToData {
   def apply(n: Nat): DataType = NatToDataApply(this, n)
 }
 
-final case class NatToDataIdentifier(name: String,
-                                     override val isExplicit: Boolean = false
-                                    ) extends NatToData
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatToDataIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: NatToDataIdentifier = this.copy(isExplicit = false)
+final case class NatToDataIdentifier(name: String) extends NatToData {
+  override def toString: String = name
 }
 
 case class NatToDataLambda private (x: NatIdentifier, body: DataType)

--- a/src/main/scala/rise/core/types/NatToNat.scala
+++ b/src/main/scala/rise/core/types/NatToNat.scala
@@ -6,14 +6,8 @@ sealed trait NatToNat {
   def apply(n: Nat): Nat = NatToNatApply(this, n)
 }
 
-final case class NatToNatIdentifier(name: String,
-                                    override val isExplicit: Boolean = false
-                                   ) extends NatToNat
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: NatToNatIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: NatToNatIdentifier = this.copy(isExplicit = false)
+final case class NatToNatIdentifier(name: String) extends NatToNat {
+  override def toString: String = name
 }
 
 final case class NatToNatLambda private (x: NatIdentifier, body: Nat)

--- a/src/main/scala/rise/core/types/Solution.scala
+++ b/src/main/scala/rise/core/types/Solution.scala
@@ -91,7 +91,6 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToDataLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range, isExplicit = true)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToDataLambda(xSub, apply(body).asInstanceOf[DataType])
@@ -104,7 +103,6 @@ case class Solution(ts: Map[Type, Type],
       case lambda@NatToNatLambda(x, body) =>
         val xSub = apply(x) match {
           case n: NatIdentifier => n
-          case n: arithexpr.arithmetic.NamedVar => NatIdentifier(n.name, n.range, isExplicit = true)
           case other => throw NonIdentifierInBinderException(lambda, other)
         }
         NatToNatLambda(xSub, apply(body))
@@ -132,29 +130,28 @@ case class Solution(ts: Map[Type, Type],
     combine(this, other)
   }
 
-  def apply(constraints: Seq[Constraint]): Seq[Constraint] = {
-    constraints.map {
-      case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
-      case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))
-      case BoolConstraint(a, b) => BoolConstraint(apply(a), apply(b))
-      case MatrixLayoutConstraint(a, b) => MatrixLayoutConstraint(apply(a), apply(b))
-      case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
-      case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
-      case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
-      case DepConstraint(df, arg: Nat, t) => DepConstraint[NatKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: DataType, t) =>
-        DepConstraint[DataKind](apply(df), apply(arg).asInstanceOf[DataType], apply(t))
-      case DepConstraint(df, arg: Type, t) =>
-        DepConstraint[TypeKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: AddressSpace, t) =>
-        DepConstraint[AddressSpaceKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatToData, t) =>
-        DepConstraint[NatToDataKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatToNat, t) =>
-        DepConstraint[NatToNatKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(df, arg: NatCollection, t) =>
-        DepConstraint[NatCollectionKind](apply(df), apply(arg), apply(t))
-      case DepConstraint(_, _, _) => throw new Exception("Impossible case")
-    }
+  def apply(constraints: Seq[Constraint]): Seq[Constraint] = constraints.map(apply)
+  def apply(constraint: Constraint): Constraint = constraint match {
+    case TypeConstraint(a, b) => TypeConstraint(apply(a), apply(b))
+    case NatConstraint(a, b) => NatConstraint(apply(a), apply(b))
+    case BoolConstraint(a, b) => BoolConstraint(apply(a), apply(b))
+    case MatrixLayoutConstraint(a, b) => MatrixLayoutConstraint(apply(a), apply(b))
+    case FragmentTypeConstraint(a, b) => FragmentTypeConstraint(apply(a), apply(b))
+    case NatToDataConstraint(a, b) => NatToDataConstraint(apply(a), apply(b))
+    case NatCollectionConstraint(a, b) => NatCollectionConstraint(apply(a), apply(b))
+    case DepConstraint(NatKind, df, arg: Nat, t) => DepConstraint(NatKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(DataKind, df, arg: DataType, t) =>
+      DepConstraint(DataKind, apply(df), apply(arg).asInstanceOf[DataType], apply(t))
+    case DepConstraint(TypeKind, df, arg: Type, t) =>
+      DepConstraint(TypeKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(AddressSpaceKind, df, arg: AddressSpace, t) =>
+      DepConstraint(AddressSpaceKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(NatToDataKind, df, arg: NatToData, t) =>
+      DepConstraint(NatToDataKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(NatToNatKind, df, arg: NatToNat, t) =>
+      DepConstraint(NatToNatKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(NatCollectionKind, df, arg: NatCollection, t) =>
+      DepConstraint(NatCollectionKind, apply(df), apply(arg), apply(t))
+    case DepConstraint(_, _, _, _) => throw new Exception("Impossible case")
   }
 }

--- a/src/main/scala/rise/core/types/Type.scala
+++ b/src/main/scala/rise/core/types/Type.scala
@@ -5,17 +5,15 @@ import rise.core._
 import rise.core.equality._
 
 sealed trait Type {
-  def =~=(b: Type): Boolean = typeAlphaEq[TypeKind](this)(b)
-  def =~~=(b: Type): Boolean = typePartialAlphaEq[TypeKind](this)(b)
+  def =~=(b: Type): Boolean = typeAlphaEq[Type](this)(b)
+  def =~~=(b: Type): Boolean = typePartialAlphaEq[Type](this)(b)
 }
 
 object TypePlaceholder extends Type {
   override def toString: String = "?"
 }
 
-final case class TypeIdentifier(name: String)
-    extends Type
-    with Kind.Identifier {
+final case class TypeIdentifier(name: String) extends Type {
   override def toString: String = "_" + name
 }
 
@@ -24,26 +22,17 @@ final case class FunType[T <: Type, U <: Type](inT: T, outT: U)
   override def toString: String = s"($inT -> $outT)"
 }
 
-final case class DepFunType[K <: Kind: KindName, T <: Type](
-    x: K#I with Kind.Explicitness,
-    t: T
-) extends Type {
+final case class DepFunType[T, I, KI <: Kind.Identifier, U <: Type] (kind: Kind[T, I, KI],x: I, t: U) extends Type {
   override def toString: String =
-    s"(${x.name}: ${implicitly[KindName[K]].get} -> $t)"
+    s"(${Kind.idName(kind, x)}: ${kind.name} -> $t)"
 }
 
 // == Data types ==============================================================
 
 sealed trait DataType extends Type
 
-final case class DataTypeIdentifier(name: String,
-                                    override val isExplicit: Boolean = false
-                                   ) extends DataType
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: DataTypeIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: DataTypeIdentifier = this.copy(isExplicit = false)
+final case class DataTypeIdentifier(name: String) extends DataType {
+  override def toString: String = name
 }
 
 sealed trait ScalarType extends DataType
@@ -98,15 +87,8 @@ object MatrixLayout {
   object None extends MatrixLayout
 }
 
-final case class MatrixLayoutIdentifier(name: String,
-                                        override val isExplicit: Boolean = false
-                                       ) extends MatrixLayout
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: MatrixLayoutIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: MatrixLayoutIdentifier =
-    this.copy(isExplicit = false)
+final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout {
+  override def toString: String = name
 }
 
 sealed trait FragmentKind
@@ -117,15 +99,8 @@ object FragmentKind {
   object Accumulator extends FragmentKind { override def toString = "Accumulator"}
 }
 
-final case class FragmentKindIdentifier(name: String,
-                                        override val isExplicit: Boolean = false
-                                       ) extends FragmentKind
-  with Kind.Identifier
-  with Kind.Explicitness {
-  override def toString: String = if (isExplicit) name else "_" + name
-  override def asExplicit: FragmentKindIdentifier = this.copy(isExplicit = true)
-  override def asImplicit: FragmentKindIdentifier =
-    this.copy(isExplicit = false)
+final case class FragmentKindIdentifier(name: String) extends FragmentKind {
+  override def toString: String = name
 }
 
 object FragmentType {
@@ -153,18 +128,8 @@ final case class ManagedBufferType(dt: DataType) extends DataType {
 
 }
 
-final case class DepPairType[K <: Kind: KindName](
-                            x: K#I,
-                            t: DataType
-                           ) extends DataType {
-  type Kind = K
-
-  // Note(federico): for pattern-matching purposes, if we ever need to
-  // recover the kind name from a pattern-match over just DataType
-  val kindName: KindName[K] = implicitly[KindName[K]]
-
-  override def toString: String =
-    s"(${x.name}: ${kindName.get} ** $t)"
+final case class DepPairType[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I, t: DataType) extends DataType {
+  override def toString: String = s"(${Kind.idName(kind, x)}: ${kind.name} ** $t)"
 }
 
 
@@ -192,7 +157,7 @@ final case class DepArrayType(size: Nat, fdt: NatToData) extends DataType {
 
 object DepArrayType {
   def apply(size: Nat, f: Nat => DataType): DepArrayType = {
-    val n = NatIdentifier(freshName("n"), RangeAdd(0, size, 1), isExplicit = true)
+    val n = NatIdentifier(freshName("n"), RangeAdd(0, size, 1))
     DepArrayType(size, NatToDataLambda(n, f(n)))
   }
 }

--- a/src/main/scala/rise/core/types/check.scala
+++ b/src/main/scala/rise/core/types/check.scala
@@ -42,24 +42,18 @@ object check {
       // ----------- App
       expr `:` t2
 
-    case DepLambda(x, e) =>
+    case DepLambda(kind, x, e) =>
       val t = ctx `|-` e
       // ----------- DepLambda
-      expr `:` (x match {
-        case n: NatIdentifier => DepFunType[NatKind, Type](n, t)
-        case dt: DataTypeIdentifier => DepFunType[DataKind, Type](dt, t)
-        case a: AddressSpaceIdentifier => DepFunType[AddressSpaceKind, Type](a, t)
-        case n2n: NatToNatIdentifier => DepFunType[NatToNatKind, Type](n2n, t)
-        case n2d: NatToDataIdentifier => DepFunType[NatToDataKind, Type](n2d, t)
-      })
+      expr `:` DepFunType(kind, x, t)
 
-    case DepApp(f, e) =>
-      val (x, t) = ctx `|-` f match {
-        case DepFunType(x, t) => (x, t)
+    case DepApp(kind, f, e) =>
+      val (k, x, t) = ctx `|-` f match {
+        case DepFunType(kind2, x, t) if kind == kind2 => (kind2, x, t)
         case t => throw TypeException(s"expected dependent function type and got $t")
       }
       // ----------- DepApp
-      expr `:` substitute.kindInType(e, `for`= x, in = t)
+      expr `:` substitute.kindInType(k, e, `for`= x, in = t)
 
     case Literal(d) =>
       // ----------- Literal
@@ -82,8 +76,6 @@ object check {
       t1 match {
         case TypePlaceholder =>
           throw TypeException(s"TypePlaceholder found")
-        case i: Kind.Explicitness if !i.isExplicit =>
-          throw TypeException(s"Implicit type variable found")
         case _ => t1
       }
     }

--- a/src/main/scala/rise/core/types/latex.scala
+++ b/src/main/scala/rise/core/types/latex.scala
@@ -1,0 +1,598 @@
+package rise.core.types
+
+import scala.language.{implicitConversions, postfixOps}
+import rise.core.DSL.Type._
+import rise.core._
+
+object latex {
+  import builderDSL._
+  // LaTeX printer
+  def toLaTeX[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI]): String = kind match {
+    case TypeKind => "\\mathsf{type}"
+    case DataKind => "\\mathsf{data}"
+    case NatKind => "\\mathsf{nat}"
+    case NatCollectionKind => "\\mathsf{nats}"
+    case AddressSpaceKind => "\\mathsf{addrSpace}"
+//    case MatrixLayoutKind => "\\mathsf{matrixLayout}"
+//    case FragmentKind => "\\mathsf{fragment}"
+    case NatToNatKind =>
+      s"${toLaTeX(natkind)}\\hspace{-.25em}\\rightarrow\\hspace{-.25em}${toLaTeX(natkind)}"
+    case NatToDataKind =>
+      s"${toLaTeX(natkind)}\\hspace{-.25em}\\rightarrow\\hspace{-.25em}${toLaTeX(datakind)}"
+  }
+  def kindToLaTeX[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI]): String = toLaTeX(kind)
+
+  def toLaTeX(t: Type): String = t match {
+    case TypePlaceholder => s"?"
+    case TypeIdentifier(name) => name
+    case FunType(inT, outT) =>
+      s"${toLaTeX(inT)} \\rightarrow ${toLaTeX(outT)}"
+    case d@DepFunType(kind, x, t) =>
+      s"(${kindIdentifier(kind, x)}) \\rightarrow ${toLaTeX(t)}"
+    case dt: DataType => toLaTeX(dt)
+  }
+
+  def toLaTeX(dt: DataType): String = dt match {
+    case DataTypeIdentifier(name) => name
+    case _: ScalarType => s"$dt"
+    case NatType => s"\\mathsf{natType}"
+    case IndexType(size) =>
+      s"\\mathsf{idx}[${toLaTeX(size)}]"
+    case VectorType(size, elemType) =>
+      s"\\mathsf{vec}[${toLaTeX(elemType)}, ${toLaTeX(size)}]"
+    case FragmentType(rows, columns, d3, dataType, fragmentKind, layout) =>
+      s"\\mathsf{fragment}[${toLaTeX(rows)}, ${toLaTeX(columns)}, ${toLaTeX(d3)}, " +
+        s"${toLaTeX(dataType)}, ${toLaTeX(fragmentKind)}, ${toLaTeX(layout)}]"
+
+    case PairType(dt1, dt2) =>
+      s"(${toLaTeX(dt1)},\\ ${toLaTeX(dt2)})"
+    case ArrayType(size, elemType) =>
+      s"${toLaTeX(size)}_\\bullet ${toLaTeX(elemType)}"
+
+    case DepPairType(kind, x, t) =>
+      s"(${kindIdentifier(kind, x)}\\ \\ast\\ast\\ ${toLaTeX(t)})"
+    case DepArrayType(size, fdt) =>
+      s"${toLaTeX(size)}_{\\bullet\\bullet} ${toLaTeX(fdt)}"
+
+    case apply: NatToDataApply => s"${apply.f}\\ ${apply.n}"
+    case ManagedBufferType(_) | OpaqueType(_) => ???
+  }
+
+  def toLaTeX(nat: Nat): String = nat match {
+    case apply: NatToNatApply => s"${toLaTeX(apply.f)}\\ ${toLaTeX(apply.n)}"
+    case _ => s"$nat"
+  }
+
+  def toLaTeX(addressSpace: AddressSpace): String = addressSpace match {
+    case AddressSpaceIdentifier(name) => name
+    case AddressSpace.Global => "\\mathsf{global}"
+    case AddressSpace.Local => "\\mathsf{local}"
+    case AddressSpace.Private => "\\mathsf{private}"
+    case AddressSpace.Constant => "\\mathsf{constant}"
+  }
+
+  def toLaTeX(ntn: NatToNat): String = ntn match {
+    case NatToNatIdentifier(name) => name
+    case NatToNatLambda(x, body) => s"${toLaTeX(x)} \\mapsto ${toLaTeX(body)}"
+  }
+
+  def toLaTeX(ntd: NatToData): String = ntd match {
+    case NatToDataIdentifier(name) => name
+    case NatToDataLambda(x, body) => s"${toLaTeX(x)} \\mapsto ${toLaTeX(body)}"
+  }
+
+  def toLaTeX(kind: FragmentKind): String = kind match {
+    case FragmentKind.AMatrix => "\\mathsf{AMatrix}"
+    case FragmentKind.BMatrix => "\\mathsf{BMatrix}"
+    case FragmentKind.Accumulator => "\\mathsf{Accumulator}"
+    case FragmentKindIdentifier(name) => name
+  }
+
+  def toLaTeX(layout: MatrixLayout): String = layout match {
+    case MatrixLayout.Row_Major => "\\mathsf{Row\\_Major}"
+    case MatrixLayout.Col_Major => "\\mathsf{Col\\_Major}"
+    case MatrixLayout.None => ???
+    case MatrixLayoutIdentifier(name) => name
+  }
+
+  def toLaTeX(expr: Expr): String = expr match {
+    case Identifier(name) => name
+    case Lambda(x, e) => s"\\lambda ${toLaTeX(x)}. ${toLaTeX(e)}"
+    case App(f, e) => s"${toLaTeX(f)}\\ ${toLaTeX(e)}"
+    case DepLambda(kind, x, e) => s"\\Lambda ${kindIdentifier(kind, x)}. ${toLaTeX(e)}"
+    case DepApp(_, f, x) => s"${toLaTeX(f)}\\ ${x match {
+      case d: DataType => toLaTeX(d)
+      case n: Nat => toLaTeX(n)
+      case a: AddressSpace => toLaTeX(a)
+      case ntd: NatToData => toLaTeX(ntd)
+      case ntn: NatToNat => toLaTeX(ntn)
+      case m: MatrixLayout => toLaTeX(m)
+      case f: FragmentKind => toLaTeX(f)
+    }}"
+    case Literal(d) => d.toString
+    case Opaque(e, t) => ???
+    case TypeAnnotation(e, annotation) => ???
+    case TypeAssertion(e, assertion) => ???
+    case primitive: Primitive => primitive.name
+  }
+
+  private def kindIdentifier[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I): String =
+    kind.name match {
+      case "nat" => s"${Kind.idName(kind, x)}: ${toLaTeX(NatKind)}"
+    }
+
+  object wellFormedTypes {
+    val kinds: String =
+      kappa ::=  Seq[Kind[Any, Any, _ <: Kind.Identifier]](
+        typekind, datakind, natkind, //natskind,
+        ntdkind, ntnkind, addrkind,
+        // matrixKind, fragmentKind
+      ) .map(k => kindToLaTeX(k))
+        .mkString(" \\mid ")
+
+    val structuralRules: String = (
+      ("x" `:` kappa) in Delta
+      ) -------------------- (
+      Delta |- ("x" `:` kappa)
+      )
+
+    val typeEquality: Row = Row(
+      |=(forall(sigma)
+      (s"\\mathit{dom}($Delta)" to "\\mathbb{N}")
+      (s"$sigma($N) = $sigma($M)")
+      ) -------------------- (
+        Delta |- (s"$N \\equiv $M" `:` natkind)
+        )
+    )
+
+//    val fragments: Row = Row(
+//      (
+//        Frag in FiniteSet(aMatrix, bMatrix, accumulator)
+//        ) -------------------- (
+//        Delta |- (Frag `:` fragmentKind)
+//        )
+//    )
+//
+//    val matrixLayout: Row = Row(
+//      (
+//        Mat in FiniteSet(rowMajor, colMajor)
+//        ) -------------------- (
+//        Delta |- (Mat `:` matrixKind)
+//        )
+//    )
+
+    val addressSpaces: Row = Row((
+      A in FiniteSet(global, local, `private`, constant)
+      ) -------------------- (
+      Delta |- (A `:` addrkind)
+      )
+    )
+
+    val natToNatTypeLevelFunctions: Row = Row((
+      (Delta `,` (n `:` natkind)) |- (M `:` natkind)
+      ) -------------------- (
+      Delta |- ((n |->: M) `:` ntnkind)
+      )
+    )
+
+    val natToDataTypeLevelFunctions: Row = Row((
+      (Delta `,` (n `:` natkind)) |- (T `:` datakind)
+      ) -------------------- (
+      Delta |- ((n |->: T) `:` ntdkind)
+      )
+    )
+
+    val natCollections: Rows = Rows()
+
+    val naturalNumbers: Rows = Rows(
+      Row(
+        ""
+          -------------------- (
+          Delta |- ("\\underline{\\ell}" `:` natkind)
+          ),
+        (
+          Delta |- (N `:` natkind) quad
+            Delta |- (M `:` natkind) quad
+            "\\oplus" in FiniteSet("+", "*", ldots)
+          ) -------------------- (
+          Delta |- (s"$N \\oplus $M" `:` natkind)
+          )),
+      Row(
+        (
+          Delta |- (FN `:` ntnkind) quad Delta |- (M `:` natkind)
+          ) -------------------- (
+          Delta |- (FN(M) `:` natkind)
+          ))
+    )
+
+    val dataTypes: Rows = Rows(
+      Row(
+        ""
+          -------------------- (
+          Delta |- ("\\mathsf{scalar}" `:` datakind)
+          ),
+        ""
+          -------------------- (
+          Delta |- (NatType `:` datakind)
+          ),
+        (
+          Delta |- (N `:` natkind)
+          ) -------------------- (
+          Delta |- (IndexType(N) `:` datakind)
+          )),
+      Row(
+        (
+          Delta |- (N `:` natkind) qquad
+            Delta |- (T `:` datakind)
+          ) -------------------- (
+          Delta |- (VectorType(N, T) `:` datakind)
+          )),
+//      Row(
+//        ( Delta |- (N `:` natkind) quad
+//          Delta |- (M `:` natkind) quad
+//          Delta |- (K `:` natkind) quad
+//          Delta |- (T `:` datakind) quad
+//          Delta |- (Frag `:` fragmentKind) quad
+//          Delta |- (Mat `:` matrixKind)
+//          ) -------------------- (
+//          Delta |- (FragmentType(N, M, K, T, Frag, Mat) `:` datakind)
+//          )),
+      Row(
+        (
+          Delta |- (S `:` datakind) quad Delta |- (T `:` datakind)
+          ) -------------------- (
+          Delta |- ((S x T) `:` datakind)
+          )),
+      Row(
+        (
+          Delta |- (N `:` natkind) quad Delta |- (T `:` datakind)
+          ) -------------------- (
+          Delta |- (N `.` T `:` datakind)
+          )),
+      Row(
+        (
+          (Delta `,` (n `:` natkind)) |- (T `:` datakind)
+          ) -------------------- (
+          Delta |- (DepPairType(NatKind, n, T) `:` datakind)
+          )),
+      Row(
+        (
+          Delta |- (N `:` natkind) quad Delta |- (FT `:` ntdkind)
+          ) -------------------- (
+          Delta |- (N `*.` FT `:` datakind)
+          )),
+      Row(
+        (
+          Delta |- (FT `:` ntdkind) quad Delta |- (N `:` natkind)
+          ) -------------------- (
+          Delta |- (FT(N) `:` datakind)
+          )
+      )
+    )
+
+    val types: Rows = Rows(
+      Row(
+        (
+          Delta |- (T `:` datakind)
+          ) -------------------- (
+          Delta |- (T `:` typekind)
+          ),
+        (
+          Delta |- (Theta1 `:` typekind) quad
+            Delta |- (Theta2 `:` typekind)
+          ) -------------------- (
+          Delta |- (Theta1 ->: Theta2 `:` typekind)
+          )),
+      Row(
+        (
+          (Delta `,` ("x" `:` kappa)) |- (Theta `:` typekind) qquad
+            kappa in FiniteSet(addrkind, ntnkind, ntdkind, natkind, datakind)
+          ) -------------------- (
+          // DepFunType
+          Delta |- (s"(x: $kappa) \\rightarrow ${toLaTeX(Theta)}" `:` typekind)
+          ))
+    )
+  }
+
+  object typingRules {
+    val structural: Row = Row(
+      (
+        (x `:` Theta) in Gamma
+        ) -------------------- (
+        Delta | Gamma |- (x `:` Theta)
+        ),
+      (
+        Delta | Gamma |- (E `:` Theta1) quad
+          Delta |- (s"${toLaTeX(Theta1)} \\equiv ${toLaTeX(Theta2)}" `:` typekind)
+        ) -------------------- (
+        Delta | Gamma |- (E `:` Theta2)
+        ),
+      (
+        (prim `:` Theta) in NamedSet("\\mathsf{Primitives}")
+        ) -------------------- (
+        Delta | Gamma |- (prim `:` Theta)
+        )
+    )
+
+    val introAndElim: Rows = Rows(
+      Row(
+        (
+          Delta | (Gamma `,` (x `:` Theta1)) |- (E `:` Theta2)
+          ) -------------------- (
+          Delta | Gamma |- (Lambda(x, E)(TypePlaceholder) `:` Theta1 ->: Theta2)
+          ),
+        (
+          Delta | Gamma1 |- (E1 `:` Theta1 ->: Theta2) quad
+            Delta | Gamma2 |- (E2 `:` Theta1)
+          ) -------------------- (
+          Delta | (Gamma1 `,` Gamma2) |- (App(E1, E2)(TypePlaceholder) `:` Theta2)
+          )
+      ),
+      Row(
+        (
+          (Delta `,` ("x" `:` kappa)) | Gamma |- (E `:` Theta) quad
+            "x" notin NamedSet(s"ftv($Gamma)")
+          ) -------------------- (
+          Delta | Gamma |-
+            ValueTypePair(s"\\Lambda x. $E", s"(x: $kappa) \\rightarrow ${toLaTeX(Theta)}")
+          ),
+        (
+          Delta | Gamma |-
+            ValueTypePair(E, s"(x: $kappa) \\rightarrow ${toLaTeX(Theta)}") quad
+            Delta |- (tau `:` kappa)
+          ) -------------------- (
+          Delta | Gamma |-
+            ValueTypePair(s"$E\\ $tau", s"${toLaTeX(Theta)}[$tau/x]")
+          )
+      )
+    )
+  }
+
+  //noinspection ScalaStyle
+  object builderDSL {
+    val Delta: KindingEnvVar = KindingEnvVar("\\Delta")
+    val Gamma: TypingEnvVar = TypingEnvVar("\\Gamma")
+    val Gamma1: TypingEnvVar = TypingEnvVar("\\Gamma_1")
+    val Gamma2: TypingEnvVar = TypingEnvVar("\\Gamma_2")
+
+    val typekind: TypeKind.type = TypeKind
+    val datakind: DataKind.type = DataKind
+    val natkind: NatKind.type = NatKind
+    val natskind: NatCollectionKind.type = NatCollectionKind
+    val ntdkind: NatToDataKind.type = NatToDataKind
+    val ntnkind: NatToNatKind.type = NatToNatKind
+    val addrkind: AddressSpaceKind.type = AddressSpaceKind
+//    val matrixKind: MatrixLayout = MatrixLayout
+//    val fragmentKind: FragmentKind = FragmentKind
+
+    val global: String = toLaTeX(AddressSpace.Global)
+    val local: String = toLaTeX(AddressSpace.Local)
+    val `private`: String = toLaTeX(AddressSpace.Private)
+    val constant: String = toLaTeX(AddressSpace.Constant)
+
+//    val aMatrix: String = toLaTeX(Fragment.AMatrix)
+//    val bMatrix: String = toLaTeX(Fragment.BMatrix)
+//    val accumulator: String = toLaTeX(Fragment.Accumulator)
+
+    val rowMajor: String = toLaTeX(MatrixLayout.Row_Major)
+    val colMajor: String = toLaTeX(MatrixLayout.Col_Major)
+
+    val kappa: String = "\\kappa"
+    val tau: String = "\\tau"
+    val sigma: String = "\\sigma"
+    val prim: String = "\\mathsf{prim}"
+
+    val ldots: String = "\\ldots"
+
+    val A: AddressSpaceIdentifier = aid("A")
+    val N: NatIdentifier = nid("N")
+    val M: NatIdentifier = nid("M")
+    val K: NatIdentifier = nid("K")
+    val n: NatIdentifier = nid("n")
+    val S: DataTypeIdentifier = did("S")
+    val T: DataTypeIdentifier = did("T")
+    val Theta: TypeIdentifier = tid("\\theta")
+    val Theta1: TypeIdentifier = tid("\\theta_1")
+    val Theta2: TypeIdentifier = tid("\\theta_2")
+    val FN: NatToNatIdentifier = ntnid("F_N")
+    val FT: NatToDataIdentifier = ntdid("F_T")
+    val Frag: FragmentKindIdentifier = fid("F")
+    val Mat: MatrixLayoutIdentifier = mid("Mat")
+
+    val E: Identifier = Identifier("E")(TypePlaceholder)
+    val E1: Identifier = Identifier("E_1")(TypePlaceholder)
+    val E2: Identifier = Identifier("E_2")(TypePlaceholder)
+    val x: Identifier = Identifier("x")(TypePlaceholder)
+
+    def forall(x: String)(dom: String)(body: String): String =
+      s"\\forall $x : $dom . $body"
+
+    def |= (rhs: String) = s"\\models $rhs"
+
+    implicit class GenericKindPairBuilder(kind: String) {
+      def `:` (x: String): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class TypeKindPairBuilder(kind: TypeKind.type) {
+      def `:` (x: Type): TypeKindPair = TypeKindPair(x, kind)
+      def `:` (str: String): TypeKindPair = TypeKindPair(str, kind)
+    }
+
+    implicit class DataKindPairBuilder(kind: DataKind.type) {
+      def `:` (x: DataType): TypeKindPair = TypeKindPair(x, kind)
+      def `:` (str: String): TypeKindPair = TypeKindPair(str, kind)
+    }
+
+    implicit class NatKindPairBuilder(kind: NatKind.type) {
+      def `:` (x: Nat): TypeKindPair = TypeKindPair(x, kind)
+      def `:` (str: String): TypeKindPair = TypeKindPair(str, kind)
+    }
+
+    implicit class AddressSpaceKindPairBuilder(kind: AddressSpaceKind.type) {
+      def `:` (x: AddressSpace): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class FragmentKindPairBuilder(kind: FragmentKind) {
+      def `:` (x: FragmentKind): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class MatrixLayoutKindPairBuilder(kind: MatrixLayout) {
+      def `:` (x: MatrixLayout): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class NatToNatKindPairBuilder(kind: NatToNatKind.type) {
+      def `:` (x: NatToNat): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class NatToDataKindPairBuilder(kind: NatToDataKind.type) {
+      def `:` (x: NatToData): TypeKindPair = TypeKindPair(x, kind)
+    }
+
+    implicit class ValueTypePairBuilder(ty: Type) {
+      def `:` (x: Expr): ValueTypePair = ValueTypePair(x, ty)
+      def `:` (x: String): ValueTypePair = ValueTypePair(x, ty)
+    }
+
+    implicit class KindingEnvOps(kindingEnv: KindingEnv) {
+      def |-(typeKindPair: TypeKindPair): KindingJudgement = KindingJudgement(kindingEnv, typeKindPair)
+      def `,` (typeKindPair: TypeKindPair): ExtendedKindingEnv = ExtendedKindingEnv(kindingEnv, typeKindPair)
+
+      def | (typingEnv: TypingEnv): Env = Env(kindingEnv, typingEnv)
+    }
+
+    implicit class TypingEnvOps(typingEnv: TypingEnv) {
+      def `,` (valueTypePair: ValueTypePair): ExtendedTypingEnv = ExtendedTypingEnv(typingEnv, valueTypePair)
+      def `,` (rhsTypingEnv: TypingEnv): UnionTypingEnv = UnionTypingEnv(typingEnv, rhsTypingEnv)
+    }
+
+    implicit class EnvOps(env: Env) {
+      def |-(valueTypePair: ValueTypePair): TypeJudgement = TypeJudgement(env, valueTypePair)
+    }
+
+    case class TypeKindPair(ty: Any/* Type | DataType | ... | String */, kind: Any/* Kind | String */) {
+      override def toString: String = {
+        val kindString = kind match {
+          case k: Kind[_, _, _] => toLaTeX(k)
+          case _ => s"$kind"
+        }
+        val tyString = ty match {
+          case t: Type => toLaTeX(t)
+          case n: Nat => toLaTeX(n)
+          case a: AddressSpace => toLaTeX(a)
+          case ntn: NatToNat => toLaTeX(ntn)
+          case ntd: NatToData => toLaTeX(ntd)
+          case _ => s"$ty"
+        }
+        s"$tyString : $kindString"
+      }
+    }
+
+    case class ValueTypePair(value: Any, ty: Any) {
+      override def toString: String = {
+        val valueString = value match {
+          case e: Expr => toLaTeX(e)
+          case _ => s"$value"
+        }
+        val tyString = ty match {
+          case t: Type => toLaTeX(t)
+          case n: Nat => toLaTeX(n)
+          case a: AddressSpace => toLaTeX(a)
+          case ntn: NatToNat => toLaTeX(ntn)
+          case ntd: NatToData => toLaTeX(ntd)
+          case _ => s"$ty"
+        }
+        s"$valueString : $tyString"
+      }
+    }
+
+    case class KindingJudgement(env: KindingEnv, tk: TypeKindPair) {
+      override def toString: String = s"$env \\vdash $tk"
+    }
+
+    case class TypeJudgement(env: Env, vt: ValueTypePair) {
+      override def toString: String = s"$env \\vdash $vt"
+    }
+
+    implicit class SetOp(lhs: Any) {
+      def in (rhs: Set): String = s"$lhs \\in $rhs"
+      def notin (rhs: Set): String = s"$lhs \\not\\in $rhs"
+    }
+
+    implicit class To(lhs: String) {
+      def to (rhs: String): String = s"$lhs \\to $rhs"
+    }
+
+    implicit class Spacing(lhs: Any) {
+      def quad (rhs: Any): String = s"$lhs \\quad $rhs"
+      def qquad (rhs: Any): String = s"$lhs \\qquad $rhs"
+      def \\ (rhs: Any): String = s"$lhs \\\\ $rhs"
+    }
+
+    implicit class NatToNatBuilder(rhs: Nat) {
+      def |->: (lhs: NatIdentifier): NatToNat = NatToNatLambda(lhs, rhs)
+    }
+
+    implicit class NatToDataBuilder(rhs: DataType) {
+      def |->: (lhs: NatIdentifier): NatToData = NatToDataLambda(lhs, rhs)
+    }
+
+    implicit class Define(lhs: Any) {
+      def ::= (rhs: Any): String = s"$lhs ::= $rhs"
+    }
+
+    implicit class Rule(lhs: Any) {
+      def -------------------- (rhs: Any): String =  s"\\cfrac{$lhs}{$rhs}"
+    }
+
+    case class Row(strings: String*) {
+      override def toString: String = strings.mkString("\\qquad\n")
+    }
+
+    case class Rows(rows: Row*) {
+      override def toString: String = rows.mkString("\\\\[1em]\n")
+    }
+
+    sealed trait Set
+    case class FiniteSet(members: Any*) extends Set {
+      override def toString: String = members.map({
+        case kind: Kind[_, _, _] => toLaTeX(kind)
+        case m => m.toString
+      }).mkString("\\{", ", ", "\\}")
+    }
+    case class NamedSet(name: String) extends Set {
+      override def toString: String = name
+    }
+
+    sealed trait KindingEnv extends Set
+    case class KindingEnvVar(name: String) extends KindingEnv {
+      override def toString: String = name
+    }
+    case class ExtendedKindingEnv(env: KindingEnv, typeKindPair: TypeKindPair) extends KindingEnv {
+      override def toString: String = s"$env, $typeKindPair"
+    }
+
+    sealed trait TypingEnv extends Set
+    case class TypingEnvVar(name: String) extends TypingEnv {
+      override def toString: String = name
+    }
+    case class ExtendedTypingEnv(env: TypingEnv, valueTypePair: ValueTypePair) extends TypingEnv {
+      override def toString: String = s"$env, $valueTypePair"
+    }
+    case class UnionTypingEnv(lhs: TypingEnv, rhs: TypingEnv) extends TypingEnv {
+      override def toString: String = s"$lhs, $rhs"
+    }
+
+    case class Env(delta: KindingEnv, gamma: TypingEnv) extends Set {
+      override def toString: String = s"$delta \\mid $gamma"
+    }
+
+    def tid(name: String): TypeIdentifier = TypeIdentifier(name)
+    def aid(name: String): AddressSpaceIdentifier = AddressSpaceIdentifier(name)
+    def nid(name: String): NatIdentifier = NatIdentifier(name)
+    def did(name: String): DataTypeIdentifier = DataTypeIdentifier(name)
+    def ntnid(name: String): NatToNatIdentifier = NatToNatIdentifier(name)
+    def ntdid(name: String): NatToDataIdentifier = NatToDataIdentifier(name)
+    def fid(name: String): FragmentKindIdentifier = FragmentKindIdentifier(name)
+    def mid(name: String): MatrixLayoutIdentifier = MatrixLayoutIdentifier(name)
+  }
+}

--- a/src/main/scala/rise/core/types/package.scala
+++ b/src/main/scala/rise/core/types/package.scala
@@ -1,21 +1,22 @@
 package rise.core
 
-import arithexpr.arithmetic.ArithExpr
+import arithexpr.arithmetic.{ArithExpr, NamedVar}
 
 package object types {
+  type NatIdentifier = NamedVar
   type Nat = ArithExpr
 
   type ->[T1 <: Type, T2 <: Type] = FunType[T1, T2]
 
-  type `(dt)->`[T <: Type] = DataDepFunType[T]
-  type DataDepFunType[T <: Type] = DepFunType[DataKind, T]
+  type `(dt)->`[T <: Type, KI <: Kind.Identifier] = DataDepFunType[T, KI]
+  type DataDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[DataType, DataTypeIdentifier, KI, T]
 
-  type `(nat)->`[T <: Type] = NatDepFunType[T]
-  type NatDepFunType[T <: Type] = DepFunType[NatKind, T]
+  type `(nat)->`[T <: Type, KI <: Kind.Identifier] = NatDepFunType[T, KI]
+  type NatDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[Nat, NatIdentifier, KI, T]
 
-  type `(nat->nat)->`[T <: Type] = NatToNatDepFunType[T]
-  type NatToNatDepFunType[T <: Type] = DepFunType[NatToNatKind, T]
+  type `(nat->nat)->`[T <: Type, KI <: Kind.Identifier] = NatToNatDepFunType[T, KI]
+  type NatToNatDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[NatToNat, NatToNatIdentifier, KI, T]
 
-  type `(nat->data)->`[T <: Type] = NatToDataDepFunType[T]
-  type NatToDataDepFunType[T <: Type] = DepFunType[NatToDataKind, T]
+  type `(nat->data)->`[T <: Type, KI <: Kind.Identifier] = NatToDataDepFunType[T, KI]
+  type NatToDataDepFunType[T <: Type, KI <: Kind.Identifier] = DepFunType[NatToData, NatToDataIdentifier, KI, T]
 }

--- a/src/main/scala/rise/core/uniqueNames.scala
+++ b/src/main/scala/rise/core/uniqueNames.scala
@@ -2,6 +2,7 @@ package rise.core
 
 import util.monads._
 import rise.core.traverse._
+import rise.core.types.Kind.{IAddressSpace, IDataType, INat}
 import rise.core.types._
 
 object uniqueNames {
@@ -47,89 +48,89 @@ object uniqueNames {
       aN
     }
 
-    def renameInExpr(e: Expr)(values: Map[Identifier, Identifier],
-                              types: Map[Kind.Identifier, Kind.Identifier]): Pure[Expr] =
-      Renaming(values, types).expr(e)
+    def renameInExpr(e: Expr)(
+      values: Map[Identifier, Identifier],
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
+    ): Pure[Expr] = Renaming(values, nats, dts, ass).expr(e)
 
-    def renameInTypes[T <: Type](t: T)(types: Map[Kind.Identifier, Kind.Identifier]): Pure[T] =
-      Renaming(Map(), types).`type`(t)
+    def renameInTypes[T <: Type](t: T)(
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
+    ): Pure[T] = Renaming(Map(), nats, dts, ass).`type`(t)
 
-    def renameInNat(n: Nat)(types: Map[Kind.Identifier, Kind.Identifier]): Nat = {
+    def renameInNat(n: Nat)(types: Map[NatIdentifier, NatIdentifier]): Nat = {
       n.visitAndRebuild({
-        case i: NatIdentifier =>
-          types.get(i)
-            .map(_.asInstanceOf[NatIdentifier])
-            .getOrElse(i)
+        case i: NatIdentifier => types.getOrElse(i, i)
         case ae => ae
       })
     }
 
     case class Renaming(
       values: Map[Identifier, Identifier],
-      types: Map[Kind.Identifier, Kind.Identifier]
+      nats: Map[NatIdentifier, NatIdentifier],
+      dts: Map[DataTypeIdentifier, DataTypeIdentifier],
+      ass: Map[AddressSpaceIdentifier, AddressSpaceIdentifier]
     ) extends PureTraversal {
-      override def nat : Nat => Pure[Nat] = n => return_(renameInNat(n)(types))
+      override def nat : Nat => Pure[Nat] = n => return_(renameInNat(n)(nats))
       override def expr : Expr => Pure[Expr] = {
         case x: Identifier => return_(values(x) : Expr)
 
         case l@Lambda(x, b) => for {
-          xt2 <- renameInTypes(x.t)(types)
+          xt2 <- renameInTypes(x.t)(nats, dts, ass)
           x2 = x.copy(s"x$nextValN")(xt2)
-          b2 <- renameInExpr(b)(values + (x -> x2), types)
-          t2 <- renameInTypes(l.t)(types)
+          b2 <- renameInExpr(b)(values + (x -> x2), nats, dts, ass)
+          t2 <- renameInTypes(l.t)(nats, dts, ass)
         } yield Lambda(x2, b2)(t2)
 
-        case d@DepLambda(x: NatIdentifier, b) =>
-          val x2 = NatIdentifier(s"n$nextNatN", x.range, x.isExplicit)
+        case d@DepLambda(NatKind, x: NatIdentifier, b) =>
+          val x2 = NatIdentifier(s"n$nextNatN", x.range)
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types + (x -> x2))
-          } yield DepLambda[NatKind](x2, b2)(t2)
+            b2 <- renameInExpr(b)(values, nats + (x -> x2), dts, ass)
+            t2 <- renameInTypes(d.t)(nats + (x -> x2), dts, ass)
+          } yield DepLambda(NatKind, x2, b2)(t2)
 
-        case d@DepLambda(x: DataTypeIdentifier, b) =>
-          val x2 = DataTypeIdentifier(s"dt$nextDtN", x.isExplicit)
+        case d@DepLambda(DataKind, x: DataTypeIdentifier, b) =>
+          val x2 = DataTypeIdentifier(s"dt$nextDtN")
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types)
-          } yield DepLambda[DataKind](x2, b2)(t2)
+            b2 <- renameInExpr(b)(values, nats, dts + (x -> x2), ass)
+            t2 <- renameInTypes(d.t)(nats, dts, ass)
+          } yield DepLambda(DataKind, x2, b2)(t2)
 
-        case d@DepLambda(x: AddressSpaceIdentifier, b) =>
-          val x2 = AddressSpaceIdentifier(s"a$nextAN", x.isExplicit)
+        case d@DepLambda(AddressSpaceKind, x: AddressSpaceIdentifier, b) =>
+          val x2 = AddressSpaceIdentifier(s"a$nextAN")
           for {
-            b2 <- renameInExpr(b)(values, types + (x -> x2))
-            t2 <- renameInTypes(d.t)(types)
-          } yield DepLambda[AddressSpaceKind](x2, b2)(t2)
+            b2 <- renameInExpr(b)(values, nats, dts, ass + (x -> x2))
+            t2 <- renameInTypes(d.t)(nats, dts, ass)
+          } yield DepLambda(AddressSpaceKind, x2, b2)(t2)
 
         case e => super.expr(e)
       }
 
       override def `type`[T <: Type] : T => Pure[T] = {
-        case i: DataTypeIdentifier =>
-          return_(types.getOrElse(i, i).asInstanceOf[T])
+        case i: DataTypeIdentifier => return_(dts.getOrElse(i, i).asInstanceOf[T])
 
-        case DepFunType(x: NatIdentifier, b) =>
-          val x2 = types.getOrElse(x,
-            NatIdentifier(s"n$nextNatN", x.range, x.isExplicit))
-            .asInstanceOf[NatIdentifier with Kind.Explicitness]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
-            yield DepFunType[NatKind, Type](x2, b2).asInstanceOf[T]
+        case DepFunType(NatKind, x: NatIdentifier, b) =>
+          val x2 = nats.getOrElse(x, NatIdentifier(s"n$nextNatN", x.range))
+          for { b2 <- renameInTypes(b)(nats + (x -> x2), dts, ass) }
+            yield DepFunType(NatKind, x2, b2).asInstanceOf[T]
 
-        case DepFunType(x: DataTypeIdentifier, b) =>
-          val x2 = types.getOrElse(x,
-            DataTypeIdentifier(s"dt$nextDtN", x.isExplicit)).asInstanceOf[DataTypeIdentifier]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
-            yield DepFunType[DataKind, Type](x2, b2).asInstanceOf[T]
+        case DepFunType(DataKind, x: DataTypeIdentifier, b) =>
+          val x2 = dts.getOrElse(x, DataTypeIdentifier(s"dt$nextDtN"))
+          for { b2 <- renameInTypes(b)(nats, dts + (x -> x2), ass) }
+            yield DepFunType(DataKind, x2, b2).asInstanceOf[T]
 
-        case DepFunType(x: AddressSpaceIdentifier, b) =>
-          val x2 = types.getOrElse(x,
-            AddressSpaceIdentifier(s"dt$nextAN", x.isExplicit)).asInstanceOf[AddressSpaceIdentifier]
-          for { b2 <- renameInTypes(b)(types + (x -> x2)) }
-            yield DepFunType[AddressSpaceKind, Type](x2, b2).asInstanceOf[T]
+        case DepFunType(AddressSpaceKind, x: AddressSpaceIdentifier, b) =>
+          val x2 = ass.getOrElse(x, AddressSpaceIdentifier(s"dt$nextAN"))
+          for { b2 <- renameInTypes(b)(nats, dts, ass + (x -> x2)) }
+            yield DepFunType(AddressSpaceKind, x2, b2).asInstanceOf[T]
 
         case e => super.`type`(e)
       }
     }
 
-    Renaming(Map(), Map()).expr(e).unwrap
+    Renaming(Map(), Map(), Map(), Map()).expr(e).unwrap
   }
 }

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -85,12 +85,12 @@ object lowering {
 
   // TODO: load identity instead, then change with other rules?
   @rule def circularBuffer(load: Expr): Strategy[Rise] = {
-    case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
+    case e@DepApp(NatKind, DepApp(NatKind, slide(), sz: Nat), Cst(1)) => Success(
       p.circularBuffer(sz)(sz)(eraseType(load)) !: e.t)
   }
 
   @rule def rotateValues(write: Expr): Strategy[Rise] = {
-    case e@DepApp(DepApp(slide(), sz: Nat), Cst(1)) => Success(
+    case e@DepApp(NatKind, DepApp(NatKind, slide(), sz: Nat), Cst(1)) => Success(
       p.rotateValues(sz)(eraseType(write)) !: e.t)
   }
 
@@ -319,7 +319,7 @@ object lowering {
     }
 
     @rule def circularBuffer(a: AddressSpace): Strategy[Rise] = {
-      case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)) =>
         Success(
           oclCircularBuffer(a)(n)(n)(fun(x => x))
             !: e.t)
@@ -327,14 +327,14 @@ object lowering {
 
     @rule def circularBufferLoadFusion: Strategy[Rise] = {
       case e@App(App(
-        cb @ DepApp(DepApp(DepApp(oclCircularBuffer(), _), _), _),
+        cb @ DepApp(NatKind, DepApp(NatKind, DepApp(AddressSpaceKind, oclCircularBuffer(), _), _), _),
         load), App(App(map(), f), in)
       ) =>
         Success(eraseType(cb)(preserveType(f) >> load, in) !: e.t)
     }
 
     @rule def rotateValues(a: AddressSpace, write: Expr): Strategy[Rise] = {
-      case e@DepApp(DepApp(slide(), n: Nat), Cst(1)) =>
+      case e@DepApp(NatKind, DepApp(NatKind, slide(), n: Nat), Cst(1)) =>
         Success(
           oclRotateValues(a)(n)(eraseType(write))
             !: e.t)

--- a/src/main/scala/rise/elevate/rules/package.scala
+++ b/src/main/scala/rise/elevate/rules/package.scala
@@ -15,8 +15,8 @@ package object rules {
   def betaReduction: Strategy[Rise] = {
     case App(Lambda(x, b), v) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
-    case DepApp(DepLambda(x, b), v) =>
-      Success(substitute.kindInExpr(v, `for` = x, in = b))
+    case DepApp(k1, DepLambda(k2, x, b), v) if k1 == k2 =>
+      Success(substitute.kindInExpr(k2, v, `for` = x, in = b))
     case _ => Failure(betaReduction)
   }
 
@@ -33,8 +33,8 @@ package object rules {
       Success(substitute.exprInExpr(v, `for` = x, in = b))
     case App(Lambda(x, b), v) if !containsAtLeast(1, x)(ev)(b) =>
       Success(substitute.exprInExpr(v, `for` = x, in = b))
-    case DepApp(DepLambda(x, b), v) =>
-      Success(substitute.kindInExpr(v, `for` = x, in = b))
+    case DepApp(k1, DepLambda(k2, x, b), v) if k1 == k2 =>
+      Success(substitute.kindInExpr(k2, v, `for` = x, in = b))
     case _ => Failure(gentleBetaReduction())
   }
 

--- a/src/main/scala/rise/elevate/rules/traversal.scala
+++ b/src/main/scala/rise/elevate/rules/traversal.scala
@@ -13,16 +13,7 @@ object traversal {
   case class body(s: Strategy[Rise]) extends Strategy[Rise] {
     def apply(e: Rise): RewriteResult[Rise] = e match {
       case Lambda(x, f) => s(f).mapSuccess(Lambda(x, _)(e.t))
-      case DepLambda(x: NatIdentifier, f) =>
-        s(f).mapSuccess(DepLambda[NatKind](x, _)(e.t))
-      case DepLambda(x: DataTypeIdentifier, f) =>
-        s(f).mapSuccess(DepLambda[DataKind](x, _)(e.t))
-      case DepLambda(x: AddressSpaceIdentifier, f) =>
-        s(f).mapSuccess(DepLambda[AddressSpaceKind](x, _)(e.t))
-      case DepLambda(x: NatToNatIdentifier, f) =>
-        s(f).mapSuccess(DepLambda[NatToNatKind](x, _)(e.t))
-      case DepLambda(x: NatToDataIdentifier, f) =>
-        s(f).mapSuccess(DepLambda[NatToDataKind](x, _)(e.t))
+      case DepLambda(kind, x, f) => s(f).mapSuccess(DepLambda(kind, x, _)(e.t))
       case _ => Failure(s)
     }
     override def toString = s"body($s)"
@@ -72,7 +63,7 @@ object traversal {
           // To achieve a traversal that most closely corresponds to the execution order we ...
           case a @ App(f, e) => e.t match {
             // ... traverse arguments with a function type after the called function ...
-            case FunType(_, _) | DepFunType(_, _) =>
+            case FunType(_, _) | DepFunType(_, _, _) =>
               s(f) match {
                 case Success(x: Rise) => Success(App(x, e)(a.t))
                 case Failure(state)   => if (carryOverState)
@@ -169,25 +160,8 @@ object traversal {
           case App(_,_) => throw new Exception("this should not happen")
           case Identifier(_) => None
           case l @ Lambda(x, e) => Some(s(e).mapSuccess(Lambda(x, _)(l.t)))
-          case dl @ DepLambda(x, e) => x match {
-            case n: NatIdentifier =>
-              Some(s(e).mapSuccess(DepLambda[NatKind](n, _)(dl.t)))
-            case dt: DataTypeIdentifier =>
-              Some(s(e).mapSuccess(DepLambda[DataKind](dt, _)(dl.t)))
-            case addr: AddressSpaceIdentifier =>
-              Some(s(e).mapSuccess(DepLambda[AddressSpaceKind](addr, _)(dl.t)))
-          }
-          case da @ DepApp(f, x)=> x match {
-            case n: Nat => Some(s(f).mapSuccess(DepApp[NatKind](_, n)(da.t)))
-            case dt: DataType =>
-              Some(s(f).mapSuccess(DepApp[DataKind](_, dt)(da.t)))
-            case addr: AddressSpace =>
-              Some(s(f).mapSuccess(DepApp[AddressSpaceKind](_, addr)(da.t)))
-            case n2n: NatToNat =>
-              Some(s(f).mapSuccess(DepApp[NatToNatKind](_, n2n)(da.t)))
-            case n2d: NatToData =>
-              Some(s(f).mapSuccess(DepApp[NatToDataKind](_, n2d)(da.t)))
-          }
+          case dl @ DepLambda(kind, x, e) => Some(s(e).mapSuccess(DepLambda(kind, x, _)(dl.t)))
+          case da @ DepApp(kind, f, x) => Some(s(f).mapSuccess(DepApp(kind, _, x)(da.t)))
           case Literal(_) => None
           case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
           case _: TypeAssertion => throw new Exception("Type assertions should be gone.")

--- a/src/main/scala/rise/elevate/rules/vectorize.scala
+++ b/src/main/scala/rise/elevate/rules/vectorize.scala
@@ -90,7 +90,7 @@ object vectorize {
 
   // padEmpty (p*v) (asScalar in) -> asScalar (padEmpty p in)
   @rule def padEmptyBeforeAsScalar: Strategy[Rise] = {
-    case App(DepApp(padEmpty(), pv: Nat), App(asScalar(), in)) =>
+    case App(DepApp(NatKind, padEmpty(), pv: Nat), App(asScalar(), in)) =>
       in.t match {
         case ArrayType(_, VectorType(v, _)) if (pv % v) == (0: Nat) =>
           Success(asScalar(padEmpty(pv / v)(in)))
@@ -100,7 +100,7 @@ object vectorize {
 
   // padEmpty p (asVector v in) -> asVector v (padEmpty (p*v) in)
   @rule def padEmptyBeforeAsVector: Strategy[Rise] = {
-    case e @ App(DepApp(padEmpty(), p: Nat), App(asV @ DepApp(_, v: Nat), in))
+    case e @ App(DepApp(NatKind, padEmpty(), p: Nat), App(asV @ DepApp(NatKind, _, v: Nat), in))
     if isAsVector(asV) =>
       Success(eraseType(asV)(padEmpty(p*v)(in)) !: e.t)
   }
@@ -108,10 +108,10 @@ object vectorize {
   // TODO: express as a combination of smaller rules
   @rule def alignSlide: Strategy[Rise] = {
     case e @ App(transpose(),
-      App(App(map(), DepApp(asVector(), Cst(v))),
+      App(App(map(), DepApp(NatKind, asVector(), Cst(v))),
         App(join(), App(App(map(), transpose()),
-          App(App(map(), DepApp(padEmpty(), Cst(p))),
-            App(App(map(), DepApp(DepApp(slide(), Cst(3)), Cst(1))),
+          App(App(map(), DepApp(NatKind, padEmpty(), Cst(p))),
+            App(App(map(), DepApp(NatKind, DepApp(NatKind, slide(), Cst(3)), Cst(1))),
               in
             )
           )
@@ -135,9 +135,9 @@ object vectorize {
       Success(r !: e.t)
 
     case e @ App(transpose(),
-      App(App(map(), DepApp(asVector(), Cst(v))),
-        App(transpose(), App(DepApp(padEmpty(), Cst(p)),
-          App(DepApp(DepApp(slide(), Cst(3)), Cst(1)), in)
+      App(App(map(), DepApp(NatKind, asVector(), Cst(v))),
+        App(transpose(), App(DepApp(NatKind, padEmpty(), Cst(p)),
+          App(DepApp(NatKind, DepApp(NatKind, slide(), Cst(3)), Cst(1)), in)
         ))
       )
     ) if p <= v =>
@@ -156,9 +156,9 @@ object vectorize {
   // TODO: express as a combination of smaller rules
   // FIXME: function f needs to be element-wise (a hidden mapVec)
   @rule def mapAfterShuffle: Strategy[Rise] = {
-    case e @ App(DepApp(asVector(), v: Nat),
-      App(join(), App(DepApp(DepApp(slide(), v2: Nat), Cst(1)),
-        App(DepApp(take(), t: Nat), App(asScalar(),
+    case e @ App(DepApp(NatKind, asVector(), v: Nat),
+      App(join(), App(DepApp(NatKind, DepApp(NatKind, slide(), v2: Nat), Cst(1)),
+        App(DepApp(NatKind, take(), t: Nat), App(asScalar(),
           App(App(map(), f), in)
         ))
       ))
@@ -172,9 +172,9 @@ object vectorize {
 
   // FIXME: this is very specific
   @rule def padEmptyBeforeZipAsVector: Strategy[Rise] = {
-    case e @ App(DepApp(padEmpty(), p: Nat), App(
+    case e @ App(DepApp(NatKind, padEmpty(), p: Nat), App(
       Lambda(x, App(App(zip(),
-        App(asV @ DepApp(_, v: Nat), App(fst(), x2))),
+        App(asV @ DepApp(NatKind, _, v: Nat), App(fst(), x2))),
         App(asV2, App(snd(), x3)))),
       in
     )) if x =~= x2 && x =~= x3 && isAsVector(asV) && asV =~= asV2 =>
@@ -186,8 +186,8 @@ object vectorize {
   }
 
   def isAsVector: Rise => Boolean = {
-    case DepApp(asVector(), _: Nat) => true
-    case DepApp(asVectorAligned(), _: Nat) => true
+    case DepApp(NatKind, asVector(), _: Nat) => true
+    case DepApp(NatKind, asVectorAligned(), _: Nat) => true
     case _ => false
   }
 

--- a/src/main/scala/rise/elevate/strategies/lowering.scala
+++ b/src/main/scala/rise/elevate/strategies/lowering.scala
@@ -33,10 +33,10 @@ object lowering {
   def insert(expr: Rise): Strategy[Rise] = _ => Success(expr)
   def extract(what: Strategy[Rise]): Strategy[Rise] = (expr: Rise) => {
     what(expr).flatMapFailure(_ => expr match {
-      case App(f,e)        => extract(what)(f).flatMapFailure(_ => extract(what)(e))
-      case Lambda(x, e)    => extract(what)(x).flatMapFailure(_ => extract(what)(e))
-      case DepLambda(_, e) => extract(what)(e)
-      case DepApp(_, _)       => Failure(extract(what))
+      case App(f,e)           => extract(what)(f).flatMapFailure(_ => extract(what)(e))
+      case Lambda(x, e)       => extract(what)(x).flatMapFailure(_ => extract(what)(e))
+      case DepLambda(_, _, e) => extract(what)(e)
+      case DepApp(_, _, _)    => Failure(extract(what))
       case _: Identifier      => Failure(extract(what))
       case _: Literal         => Failure(extract(what))
       case _: TypeAnnotation  => throw new Exception("Type annotations should be gone.")

--- a/src/main/scala/rise/elevate/strategies/predicate.scala
+++ b/src/main/scala/rise/elevate/strategies/predicate.scala
@@ -26,7 +26,7 @@ object predicate {
   }
 
   def isLambda: is = is(_.isInstanceOf[Lambda], "Lambda")
-  def isDepLambda: is = is(_.isInstanceOf[DepLambda[_]], "DepLambda")
+  def isDepLambda: is = is(_.isInstanceOf[DepLambda[_, _, _]], "DepLambda")
   def isIdentifier: is = is(_.isInstanceOf[Identifier], "Identifier")
   def isApply: is = is(_.isInstanceOf[App], "Apply")
 

--- a/src/main/scala/rise/eqsat/Expr.scala
+++ b/src/main/scala/rise/eqsat/Expr.scala
@@ -127,16 +127,14 @@ object Expr {
       case i: core.Identifier => Var(bound.indexOf(i))
       case core.App(f, e) => App(fromNamed(f, bound), fromNamed(e, bound))
       case core.Lambda(i, e) => Lambda(fromNamed(e, bound + i))
-      case core.DepApp(f, n: rct.Nat) =>
+      case core.DepApp(rct.NatKind, f, n: rct.Nat) =>
         NatApp(fromNamed(f, bound), Nat.fromNamed(n, bound))
-      case core.DepApp(f, dt: rct.DataType) =>
+      case core.DepApp(rct.DataKind, f, dt: rct.DataType) =>
         DataApp(fromNamed(f, bound), DataType.fromNamed(dt, bound))
-      case core.DepApp(_, _) => ???
-      case core.DepLambda(n: rct.NatIdentifier, e) =>
-        NatLambda(fromNamed(e, bound + n))
-      case core.DepLambda(dt: rct.DataTypeIdentifier, e) =>
-        DataLambda(fromNamed(e, bound + dt))
-      case core.DepLambda(_, _) => ???
+      case core.DepApp(_, _, _) => ???
+      case core.DepLambda(rct.NatKind, n: rct.NatIdentifier, e) => NatLambda(fromNamed(e, bound + n))
+      case core.DepLambda(rct.DataKind, dt: rct.DataTypeIdentifier, e) => DataLambda(fromNamed(e, bound + dt))
+      case core.DepLambda(_, _, _) => ???
       case core.Literal(d) => Literal(d)
       // note: we set the primitive type to a place holder here,
       // because we do not want type information at the node level
@@ -155,15 +153,15 @@ object Expr {
         val i = core.Identifier(s"x${bound.expr.size}")(Type.toNamed(funT.inT, bound))
         core.Lambda(i, toNamed(e, bound + i)) _
       case NatApp(f, x) =>
-        core.DepApp[rct.NatKind](toNamed(f, bound), Nat.toNamed(x, bound)) _
+        core.DepApp(rct.NatKind, toNamed(f, bound), Nat.toNamed(x, bound)) _
       case NatLambda(e) =>
-        val i = rct.NatIdentifier(s"n${bound.nat.size}", isExplicit = true)
-        core.DepLambda[rct.NatKind](i, toNamed(e, bound + i)) _
+        val i = rct.NatIdentifier(s"n${bound.nat.size}")
+        core.DepLambda(rct.NatKind, i, toNamed(e, bound + i)) _
       case DataApp(f, x) =>
-        core.DepApp[rct.DataKind](toNamed(f, bound), DataType.toNamed(x, bound)) _
+        core.DepApp(rct.DataKind, toNamed(f, bound), DataType.toNamed(x, bound)) _
       case DataLambda(e) =>
-        val i = rct.DataTypeIdentifier(s"dt${bound.data.size}", isExplicit = true)
-        core.DepLambda[rct.DataKind](i, toNamed(e, bound + i)) _
+        val i = rct.DataTypeIdentifier(s"dt${bound.data.size}")
+        core.DepLambda(rct.DataKind, i, toNamed(e, bound + i)) _
       case Literal(d) => core.Literal(d).setType _
       case Primitive(p) => p.setType _
     })(Type.toNamed(expr.t, bound))

--- a/src/main/scala/rise/eqsat/TypeNode.scala
+++ b/src/main/scala/rise/eqsat/TypeNode.scala
@@ -115,9 +115,9 @@ object Type {
     Type(t match {
       case dt: rct.DataType => DataType.fromNamed(dt, bound).node
       case rct.FunType(a, b) => FunType(fromNamed(a, bound), fromNamed(b, bound))
-      case rct.DepFunType(x: rct.NatIdentifier, t) => NatFunType(fromNamed(t, bound + x))
-      case rct.DepFunType(x: rct.DataTypeIdentifier, t) => DataFunType(fromNamed(t, bound + x))
-      case rct.DepFunType(_, _) => ???
+      case rct.DepFunType(rct.NatKind, x: rct.NatIdentifier, t) => NatFunType(fromNamed(t, bound + x))
+      case rct.DepFunType(rct.DataKind, x: rct.DataTypeIdentifier, t) => DataFunType(fromNamed(t, bound + x))
+      case rct.DepFunType(_, _, _) => ???
       case rct.TypePlaceholder | rct.TypeIdentifier(_) =>
         throw new Exception(s"did not expect $t")
     })
@@ -128,11 +128,11 @@ object Type {
       case dt: DataTypeNode[Nat, DataType] => DataType.toNamed(DataType(dt), bound)
       case FunType(a, b) => rct.FunType(toNamed(a, bound), toNamed(b, bound))
       case NatFunType(t) =>
-        val i = rct.NatIdentifier(s"n${bound.nat.size}", isExplicit = true)
-        rct.DepFunType[rct.NatKind, rct.Type](i, toNamed(t, bound + i))
+        val i = rct.NatIdentifier(s"n${bound.nat.size}")
+        rct.DepFunType(rct.NatKind, i, toNamed(t, bound + i))
       case DataFunType(t) =>
-        val i = rct.DataTypeIdentifier(s"n${bound.data.size}", isExplicit = true)
-        rct.DepFunType[rct.DataKind, rct.Type](i, toNamed(t, bound + i))
+        val i = rct.DataTypeIdentifier(s"n${bound.data.size}")
+        rct.DepFunType(rct.DataKind, i, toNamed(t, bound + i))
     }
   }
 
@@ -150,7 +150,7 @@ object DataType {
       case rct.IndexType(s) => IndexType(Nat.fromNamed(s, bound))
       case rct.PairType(dt1, dt2) => PairType(fromNamed(dt1, bound), fromNamed(dt2, bound))
       case rct.ArrayType(s, et) => ArrayType(Nat.fromNamed(s, bound), fromNamed(et, bound))
-      case _: rct.DepArrayType | _: rct.DepPairType[_] |
+      case _: rct.DepArrayType | _: rct.DepPairType[_, _, _] |
            _: rct.NatToDataApply | _: rct.FragmentType | _: rct.ManagedBufferType | _: rct.OpaqueType =>
         throw new Exception(s"did not expect $dt")
     })

--- a/src/main/scala/rise/openCL/DSL.scala
+++ b/src/main/scala/rise/openCL/DSL.scala
@@ -2,7 +2,7 @@ package rise.openCL
 
 import rise.core.DSL._
 import rise.core.{Expr, Primitive}
-import rise.core.types.AddressSpaceKind
+import rise.core.types.AddressSpace
 import shine.OpenCL.{GlobalSize, LocalSize}
 
 object DSL {
@@ -32,17 +32,17 @@ object DSL {
                                    to: ToBeTyped[A],
                                    f: ToBeTyped[B]
                                  ): ToBeTyped[rise.core.Lambda] = fun(x => to(f(x)))
-  val toGlobal: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
+  val toGlobal: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Global
   )
   def toGlobalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toGlobal, f)
-  val toLocal: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
+  val toLocal: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Local
   )
   def toLocalFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =
     toFun(toLocal, f)
-  val toPrivate: ToBeTyped[rise.core.DepApp[AddressSpaceKind]] = toMem(
+  val toPrivate: ToBeTyped[rise.core.DepApp[AddressSpace, _]] = toMem(
     rise.core.types.AddressSpace.Private
   )
   def toPrivateFun[T <: Expr](f: ToBeTyped[T]): ToBeTyped[rise.core.Lambda] =

--- a/src/main/scala/shine/C/Compilation/TranslationContext.scala
+++ b/src/main/scala/shine/C/Compilation/TranslationContext.scala
@@ -25,7 +25,7 @@ class TranslationContext() extends shine.DPIA.Compilation.TranslationContext {
       //TODO makes a decision. Not allowed!
       case DepArrayType(n, ft) =>
         DepMapSeqI(unroll = false)(n, ft, ft,
-          depFun[NatKind]()(k =>
+          depFun(NatKind)(k =>
             λ(ExpType(ft(k), read))(x => λ(AccType( ft(k) ))(a => assign(ft(k), a, x) ))),
           rhs, lhs)
 

--- a/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
@@ -25,13 +25,13 @@ object AcceptorTranslation {
     E match {
       // on the fly beta-reduction
       case Apply(fun, arg) => acc(Lifting.liftFunction(fun).reducing(arg))(A)
-      case DepApply(fun, arg) => arg match {
+      case DepApply(kind, fun, arg) => arg match {
         case a: Nat =>
-          acc(Lifting.liftDependentFunction[NatKind, ExpType](
-            fun.asInstanceOf[ Phrase[NatKind `()->:` ExpType]])(a))(A)
+          acc(Lifting.liftDependentFunction(
+            fun.asInstanceOf[ Phrase[NatIdentifier `()->:` ExpType]])(a))(A)
         case a: DataType =>
-          acc(Lifting.liftDependentFunction[DataKind, ExpType](
-            fun.asInstanceOf[Phrase[DataKind `()->:` ExpType]])(a))(A)
+          acc(Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(A)
       }
 
       case e
@@ -103,7 +103,7 @@ object AcceptorTranslation {
     case depMapSeq@DepMapSeq(unroll) =>
       val (n, ft1, ft2, f, array) = depMapSeq.unwrap
       con(array)(λ(expT(n`.d`ft1, read))(x =>
-        DepMapSeqI(unroll)(n, ft1, ft2, _Λ_[NatKind]()((k: NatIdentifier) =>
+        DepMapSeqI(unroll)(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
           λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
@@ -115,7 +115,7 @@ object AcceptorTranslation {
       // Turn the f imperative by means of forwarding the acceptor translation
       con(input)(λ(expT(DepPairType(x, elemT), read))(pair =>
         DMatchI(x, elemT, outT,
-          _Λ_[NatKind]()((fst: NatIdentifier) =>
+          _Λ_(NatKind)((fst: NatIdentifier) =>
             λ(expT(DataType.substitute(fst, x, elemT), read))(snd =>
               acc(f(fst)(snd))(A)
             )), pair)))
@@ -127,7 +127,7 @@ object AcceptorTranslation {
     case Iterate(n, m, k, dt, f, array) =>
       con(array)(λ(expT((m * n.pow(k))`.`dt, read))(x =>
         IterateIAcc(n, m, k, dt, A,
-          _Λ_[NatKind]()(l => λ(accT(l `.` dt))(o =>
+          _Λ_(NatKind)(l => λ(accT(l `.` dt))(o =>
             λ(expT((l * n)`.`dt, read))(x => acc(f(l)(x))(o)))),
           x)))
 
@@ -252,7 +252,7 @@ object AcceptorTranslation {
     // OpenMP
     case omp.DepMapPar(n, ft1, ft2, f, array) =>
       con(array)(λ(expT(n`.d`ft1, read))(x =>
-        ompI.DepMapParI(n, ft1, ft2, _Λ_[NatKind]()((k: NatIdentifier) =>
+        ompI.DepMapParI(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
           λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
@@ -271,7 +271,7 @@ object AcceptorTranslation {
     case depMap@ocl.DepMap(level, dim) =>
       val (n, ft1, ft2, f, array) = depMap.unwrap
       con(array)(λ(expT(n`.d`ft1, read))(x =>
-        oclI.DepMapI(level, dim)(n, ft1, ft2, _Λ_[NatKind]()((k: NatIdentifier) =>
+        oclI.DepMapI(level, dim)(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
           λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
@@ -279,7 +279,7 @@ object AcceptorTranslation {
     case ocl.Iterate(a, n, m, k, dt, f, array) =>
       con(array)(λ(expT({m * n.pow(k)}`.`dt, read))(x =>
         oclI.IterateIAcc(a, n, m, k, dt, A,
-          _Λ_[NatKind]()(l => λ(accT(l`.`dt))(o =>
+          _Λ_(NatKind)(l => λ(accT(l`.`dt))(o =>
             λ(expT({l * n}`.`dt, read))(x => acc(f(l)(x))(o)))),
           x)))
 

--- a/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
@@ -44,13 +44,13 @@ object ContinuationTranslation {
 
       // on the fly beta-reduction
       case Apply(fun, arg) => con(Lifting.liftFunction(fun).reducing(arg))(C)
-      case DepApply(fun, arg) => arg match {
+      case DepApply(kind, fun, arg) => arg match {
         case a: Nat =>
-          con(Lifting.liftDependentFunction[NatKind, ExpType](
-            fun.asInstanceOf[Phrase[NatKind `()->:` ExpType]])(a))(C)
+          con(Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a))(C)
         case a: DataType =>
-          con(Lifting.liftDependentFunction[DataKind, ExpType](
-            fun.asInstanceOf[Phrase[DataKind `()->:` ExpType]])(a))(C)
+          con(Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(C)
       }
 
       case IfThenElse(cond, thenP, elseP) =>
@@ -110,7 +110,7 @@ object ContinuationTranslation {
       // Turn the f imperative by means of forwarding the continuation translation
       con(input)(λ(expT(DepPairType(x, elemT), read))(pair =>
         DMatchI(x, elemT, outT,
-          _Λ_[NatKind]()((fst: NatIdentifier) =>
+          _Λ_(NatKind)((fst: NatIdentifier) =>
             λ(expT(DataType.substitute(fst, x, elemT), read))(snd =>
               con(f(fst)(snd))(C)
             )), pair)))

--- a/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
@@ -26,13 +26,13 @@ object FedeTranslation {
       // on the fly beta-reduction
       case Apply(fun, arg) => fedAcc(env)(
         Lifting.liftFunction(fun).reducing(arg))(C)
-      case DepApply(fun, arg) => arg match {
+      case DepApply(kind, fun, arg) => arg match {
         case a: Nat => fedAcc(env)(
-          Lifting.liftDependentFunction[NatKind, ExpType](
-            fun.asInstanceOf[Phrase[NatKind `()->:` ExpType]])(a))(C)
+          Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a))(C)
         case a: DataType => fedAcc(env)(
-          Lifting.liftDependentFunction[DataKind, ExpType](
-            fun.asInstanceOf[Phrase[DataKind `()->:` ExpType]])(a))(C)
+          Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(C)
       }
 
       case IfThenElse(cond, thenP, elseP) => ???

--- a/src/main/scala/shine/DPIA/Compilation/FunDef.scala
+++ b/src/main/scala/shine/DPIA/Compilation/FunDef.scala
@@ -26,11 +26,11 @@ class FunDef(val name: String,
     ) = p match {
       case Apply(f, a) =>
         splitBodyAndParams(Lifting.liftFunction(f).reducing(a), ps, defs)
-      case DepApply(f, a) =>
+      case DepApply(_, f, a) =>
         splitBodyAndParams(Lifting.liftDependentFunction(f)(a), ps, defs)
       case l: Lambda[ExpType, _]@unchecked =>
         splitBodyAndParams(l.body, l.param +: ps, defs)
-      case ndl: DepLambda[_, _] =>
+      case ndl: DepLambda[_, _, _] =>
         splitBodyAndParams(ndl.body,
           Identifier(ndl.x.name, ExpType(int, read)) +: ps, defs)
       case ln:LetNat[ExpType, _]@unchecked =>

--- a/src/main/scala/shine/DPIA/Compilation/Passes/UnrollLoops.scala
+++ b/src/main/scala/shine/DPIA/Compilation/Passes/UnrollLoops.scala
@@ -25,7 +25,7 @@ object UnrollLoops {
             }
           case f@ForNat(true) =>
             f.loopBody match {
-              case shine.DPIA.Phrases.DepLambda(x, body) =>
+              case shine.DPIA.Phrases.DepLambda(kind, x, body) =>
                 Continue(unrollLoop(f.n, init = 0, step = 1, i =>
                   PhraseType.substitute(i, `for` = x, in = body)), this)
               case _ => throw new Exception("This should not happen")

--- a/src/main/scala/shine/DPIA/Compilation/StreamTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/StreamTranslation.scala
@@ -23,14 +23,14 @@ object StreamTranslation {
 
       // on the fly beta-reduction
       case Apply(fun, arg) => str(Lifting.liftFunction(fun).reducing(arg))(C)
-      case DepApply(fun, arg) => arg match {
+      case DepApply(_, fun, arg) => arg match {
         case a: Nat => str(
-          Lifting.liftDependentFunction[NatKind, ExpType](
-            fun.asInstanceOf[Phrase[NatKind `()->:` ExpType]])(a)
+          Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a)
         )(C)
         case a: DataType => str(
-          Lifting.liftDependentFunction[DataKind, ExpType](
-            fun.asInstanceOf[Phrase[DataKind `()->:` ExpType]])(a)
+          Lifting.liftDependentFunction(
+            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a)
         )(C)
       }
 
@@ -82,9 +82,9 @@ object StreamTranslation {
           (expT(dt2, read) ->: (comm: CommType)) ->: (comm: CommType)
         )(next2 =>
           C(nFun(i => fun(expT(dt1 x dt2, read) ->: (comm: CommType))(k =>
-            Apply(DepApply[NatKind, (ExpType ->: CommType) ->: CommType](next1, i),
+            Apply(DepApply(NatKind, next1, i),
               fun(expT(dt1, read))(x1 =>
-                Apply(DepApply[NatKind, (ExpType ->: CommType) ->: CommType](next2, i),
+                Apply(DepApply(NatKind, next2, i),
                   fun(expT(dt2, read))(x2 =>
                     k(MakePair(dt1, dt2, read, x1, x2))
                   ))))),

--- a/src/main/scala/shine/DPIA/DSL/Core.scala
+++ b/src/main/scala/shine/DPIA/DSL/Core.scala
@@ -26,21 +26,19 @@ object λ extends funDef
 
 object nFun {
   def apply[T <: PhraseType](f: NatIdentifier => Phrase[T],
-                             range: arithexpr.arithmetic.Range): DepLambda[NatKind, T] = {
+                             range: arithexpr.arithmetic.Range): DepLambda[Nat, NatIdentifier, T] = {
     val x = NatIdentifier(freshName("n"), range)
-    DepLambda[NatKind, T](x, f(x))
+    DepLambda(NatKind, x, f(x))
   }
 }
 
 trait depFunDef {
-  def apply[K <: Kind](): Object {
-    def apply[T <: PhraseType](f: K#I => Phrase[T])
-                              (implicit w: Kind.IdentifierMaker[K], kn: KindName[K]): DepLambda[K, T]
+  def apply[T, I <: Kind.Identifier](kind: Kind[T, I]): Object {
+    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U]
   } = new {
-    def apply[T <: PhraseType](f: K#I => Phrase[T])
-                              (implicit w: Kind.IdentifierMaker[K], kn: KindName[K]): DepLambda[K, T] = {
-      val x = w.makeIdentifier()
-      DepLambda(x, f(x))
+    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U] = {
+      val x = kind.makeIdentifier
+      DepLambda(kind, x, f(x))
     }
   }
 }

--- a/src/main/scala/shine/DPIA/DSL/ImperativePrimitives.scala
+++ b/src/main/scala/shine/DPIA/DSL/ImperativePrimitives.scala
@@ -76,7 +76,7 @@ object streamNext {
     f: Phrase[ExpType ->: CommType]
   ): Phrase[CommType] = {
     Phrases.Apply(
-      Phrases.DepApply[NatKind, (ExpType ->: CommType) ->: CommType](next, i),
+      Phrases.DepApply(NatKind, next, i),
       f
     )
   }

--- a/src/main/scala/shine/DPIA/DSL/package.scala
+++ b/src/main/scala/shine/DPIA/DSL/package.scala
@@ -97,14 +97,14 @@ package object DSL {
 
   implicit class CallNatDependentLambda[T <: PhraseType](fun: Phrase[`(nat)->:`[T]]) {
     def apply(arg: Nat): Phrase[T] =
-      Lifting.liftDependentFunction[NatKind, T](fun)(arg)
+      Lifting.liftDependentFunction(fun)(arg)
 
     def $(arg: Nat): Phrase[T] = apply(arg)
   }
 
   implicit class CallTypeDependentLambda[T <: PhraseType](fun: Phrase[`(dt)->:`[T]]) {
     def apply(arg: DataType): Phrase[T] =
-      Lifting.liftDependentFunction[DataKind, T](fun)(arg)
+      Lifting.liftDependentFunction(fun)(arg)
 
     def $(arg: DataType): Phrase[T] = apply(arg)
   }

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -37,7 +37,7 @@ private class InferAccessAnnotation {
 
   @tailrec
   private def funOutIsWrite(ePt: PhraseType): Boolean = ePt match {
-    case DepFunType(_, t) => funOutIsWrite(t)
+    case DepFunType(_, _, t) => funOutIsWrite(t)
     case FunType(_, t) => funOutIsWrite(t)
     case expT: ExpType => expT `<=` ExpType(expT.dataType, write)
     case _ => throw error("This should never happen.")
@@ -128,9 +128,9 @@ private class InferAccessAnnotation {
           ctx, isKernelParamFun)
       case appl: r.App =>
         inferApp(appl, ctx, addsKernelParam(e, isKernelParamFun))
-      case depL: r.DepLambda[_] =>
+      case depL: r.DepLambda[_, _, _] =>
         inferDepLambda(depL, ctx, isKernelParamFun)
-      case depA: r.DepApp[_] =>
+      case depA: r.DepApp[_, _] =>
         inferDepApp(depA, ctx, addsKernelParam(e, isKernelParamFun))
       case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
       case _: TypeAssertion => throw new Exception("Type assertions should be gone.")
@@ -199,7 +199,7 @@ private class InferAccessAnnotation {
   }
 
   private def inferDepLambda(
-    depLambda: r.DepLambda[_],
+    depLambda: r.DepLambda[_, _, _],
     ctx: Context,
     kernelParamFun: Boolean
   ): (PhraseType, Subst) = {
@@ -207,40 +207,39 @@ private class InferAccessAnnotation {
     val depLambdaType =
       depLambda.x match {
         case n: rt.NatIdentifier =>
-          DepFunType[NatKind, PhraseType](natIdentifier(n), eType)
+          DepFunType(NatKind, natIdentifier(n), eType)
         case dt: rt.DataTypeIdentifier =>
-          DepFunType[DataKind, PhraseType](dataTypeIdentifier(dt), eType)
+          DepFunType(DataKind, dataTypeIdentifier(dt), eType)
         case ad: rt.AddressSpaceIdentifier =>
-          DepFunType[AddressSpaceKind, PhraseType](
-            addressSpaceIdentifier(ad), eType)
+          DepFunType(AddressSpaceKind, addressSpaceIdentifier(ad), eType)
         case n2n: rt.NatToNatIdentifier =>
-          DepFunType[NatToNatKind, PhraseType](natToNatIdentifier(n2n), eType)
+          DepFunType(NatToNatKind, natToNatIdentifier(n2n), eType)
         case n2d: rt.NatToDataIdentifier =>
-          DepFunType[NatToDataKind, PhraseType](natToDataIdentifier(n2d), eType)
+          DepFunType(NatToDataKind, natToDataIdentifier(n2d), eType)
       }
     ptAnnotationMap.put(depLambda, depLambdaType)
     (depLambdaType, eSubst)
   }
 
   private def inferDepApp(
-    depApp: r.DepApp[_],
+    depApp: r.DepApp[_, _],
     ctx: Context,
     kernelParamFun: Boolean
   ): (PhraseType, Subst) = {
     val (fType, fSubst) = inferPhraseTypes(depApp.f, ctx, kernelParamFun)
     val depAppType =
       depApp.x match {
-        case dt: rt.DataKind#T =>
-          Lifting.liftDependentFunctionType[DataKind](fType)(dataType(dt))
-        case addr: rt.AddressSpaceKind#T =>
-          Lifting.liftDependentFunctionType[AddressSpaceKind](fType)(
+        case dt: rt.DataType =>
+          Lifting.liftDependentFunctionType[DataType](fType)(dataType(dt))
+        case addr: rt.AddressSpace =>
+          Lifting.liftDependentFunctionType[AddressSpace](fType)(
             addressSpace(addr))
-        case n: rt.NatKind#T =>
-          Lifting.liftDependentFunctionType[NatKind](fType)(n)
-        case n2n: rt.NatToNatKind#T =>
-          Lifting.liftDependentFunctionType[NatToNatKind](fType)(ntn(n2n))
-        case n2d: rt.NatToDataKind#T =>
-          Lifting.liftDependentFunctionType[NatToDataKind](fType)(ntd(n2d))
+        case n: rt.Nat =>
+          Lifting.liftDependentFunctionType[Nat](fType)(n)
+        case n2n: rt.NatToNat =>
+          Lifting.liftDependentFunctionType[NatToNat](fType)(ntn(n2n))
+        case n2d: rt.NatToData =>
+          Lifting.liftDependentFunctionType[NatToData](fType)(ntd(n2d))
       }
     ptAnnotationMap.put(depApp, depAppType)
     (depAppType, fSubst)
@@ -305,8 +304,8 @@ private class InferAccessAnnotation {
           (gs1 `(Nat)->:` (gs2 `(Nat)->:` (gs3 `(Nat)->:`
           ((t: rt.DataType) ->: (_: rt.DataType))
         ))))) =>
-          nFunT(ls1, nFunT(ls2, nFunT(ls3,
-            nFunT(gs1, nFunT(gs2, nFunT(gs3,
+          nFunT(fromRise.natIdentifier(ls1), nFunT(fromRise.natIdentifier(ls2), nFunT(fromRise.natIdentifier(ls3),
+            nFunT(fromRise.natIdentifier(gs1), nFunT(fromRise.natIdentifier(gs2), nFunT(fromRise.natIdentifier(gs3),
               expT(t, write) ->: expT(t, write)))))))
         case _ => error()
       }
@@ -351,7 +350,7 @@ private class InferAccessAnnotation {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(n, expT(dt1, ai) ->: expT(dt2, ai))
+          nFunT(fromRise.natIdentifier(n), expT(dt1, ai) ->: expT(dt2, ai))
         case _ => error()
       }
 
@@ -378,7 +377,7 @@ private class InferAccessAnnotation {
 
       case rp.natAsIndex() | rp.take() | rp.drop() => p.t match {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
-          nFunT(n, expT(dt1, read) ->: expT(dt2, read))
+          nFunT(fromRise.natIdentifier(n), expT(dt1, read) ->: expT(dt2, read))
         case _ => error()
       }
 
@@ -415,7 +414,7 @@ private class InferAccessAnnotation {
         case tile `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(tile,
+          nFunT(fromRise.natIdentifier(tile),
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, write))
         case _ => error()
@@ -426,7 +425,7 @@ private class InferAccessAnnotation {
         case  sz `(Nat)->:`
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(sz,
+          nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(s, write)) ->:
             expT(inT, read) ->: expT(outT, read))
         case _ => error()
@@ -436,7 +435,7 @@ private class InferAccessAnnotation {
         case alloc `(Nat)->:` (sz `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
-          nFunT(alloc, nFunT(sz,
+          nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -447,7 +446,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
           aFunT(a,
-            nFunT(sz,
+            nFunT(fromRise.natIdentifier(sz),
               (expT(s, read) ->: expT(s, write)) ->:
               expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -458,7 +457,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)))) =>
 
-          aFunT(a, nFunT(alloc, nFunT(sz,
+          aFunT(a, nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
             (expT(s, read) ->: expT(t, write)) ->:
               expT(inT, read) ->: expT(outT, read))))
         case _ => error()
@@ -467,7 +466,7 @@ private class InferAccessAnnotation {
       case rp.slide() | rp.padClamp() => p.t match {
         case sz `(Nat)->:` (sp `(Nat)->:`
           ((dt1: rt.DataType) ->: (dt2: rt.DataType))) =>
-          nFunT(sz, nFunT(sp,
+          nFunT(fromRise.natIdentifier(sz), nFunT(fromRise.natIdentifier(sp),
             expT(dt1, read) ->: expT(dt2, read)))
         case _ => error()
       }
@@ -476,8 +475,8 @@ private class InferAccessAnnotation {
         case k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType)) =>
-          nFunT(k,
-            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
+          nFunT(fromRise.natIdentifier(k),
+            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
             expT(at3, read) ->: expT(at4, write) )
         case _ => error()
       }
@@ -486,8 +485,8 @@ private class InferAccessAnnotation {
         case a `(Addr)->:` (k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType))) =>
-          aFunT(a, nFunT(k,
-            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
+          aFunT(a, nFunT(fromRise.natIdentifier(k),
+            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
               expT(at3, read) ->: expT(at4, write) ))
         case _ => error()
       }
@@ -503,7 +502,7 @@ private class InferAccessAnnotation {
 
       case rp.padEmpty() => p.t match {
         case r `(Nat)->:` ((n`.`t) ->: (_`.`_)) =>
-          nFunT(r, expT(n`.`t, write) ->: expT((n + r)`.`t, write))
+          nFunT(fromRise.natIdentifier(r), expT(n`.`t, write) ->: expT((n + r)`.`t, write))
         case _ => error()
       }
 
@@ -511,7 +510,7 @@ private class InferAccessAnnotation {
         case l `(Nat)->:` (q `(Nat)->:`
           ((t: rt.DataType) ->: (n`.`_) ->: (_`.`_))) =>
 
-          nFunT(l, nFunT(q,
+          nFunT(fromRise.natIdentifier(l), nFunT(fromRise.natIdentifier(q),
             expT(t, read) ->: expT(n`.`t, read) ->:
               expT((l + n + q)`.`t, read)))
         case _ => error()
@@ -528,7 +527,7 @@ private class InferAccessAnnotation {
         case (n `(Nat)->:` (idxF `(NatToNat)->:` (idxFinv `(NatToNat)->:` ((_`.`t) ->: (_`.`_) )))) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(n, n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
+          nFunT(fromRise.natIdentifier(n), n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
         case _ => error()
       }
 
@@ -538,7 +537,7 @@ private class InferAccessAnnotation {
             expT(dataType(dt), read)
           case rt.FunType(in: rt.DataType, out) =>
             expT(in, read) ->: buildType(out)
-          case rt.DepFunType(d: rt.DataTypeIdentifier, t) =>
+          case rt.DepFunType(rt.DataKind, d: rt.DataTypeIdentifier, t) =>
             dFunT(d, buildType(t))
           case _ => throw Exception("This should not happen")
         }
@@ -555,9 +554,9 @@ private class InferAccessAnnotation {
 
       case rp.depMapSeq() =>
         def buildType(t: rt.Type): PhraseType = t match {
-          case rt.FunType(rt.DepFunType(i, rt.FunType(elemInT:rt.DataType, elemOutT:rt.DataType)),
+          case rt.FunType(rt.DepFunType(rt.NatKind, i: rt.NatIdentifier, rt.FunType(elemInT:rt.DataType, elemOutT:rt.DataType)),
             rt.FunType(inArr@rt.DepArrayType(_, _), outArr@rt.DepArrayType(_, _))) =>
-            val iNat = natIdentifier(i.asInstanceOf[rt.NatIdentifier])
+            val iNat = natIdentifier(i)
             nFunT(iNat, expT(dataType(elemInT), read) ->: expT(dataType(elemOutT), write)) ->:
               expT(dataType(inArr), read) ->: expT(dataType(outArr), write)
           case _ => error("did not expect t")
@@ -567,31 +566,24 @@ private class InferAccessAnnotation {
       case rp.dmatch() =>
         val a = accessTypeIdentifier()
         def buildType(t: rt.Type): PhraseType = t match {
-          case rt.FunType(rt.DepPairType(x, elemT),
-            rt.FunType(rt.DepFunType(i, rt.FunType(app1:rt.DataType, outT:rt.DataType)), retT:rt.DataType)) =>
-            x match {
-              case x:rt.NatIdentifier =>
-                assert(i.isInstanceOf[rt.NatIdentifier])
-                val i_ = natIdentifier(i.asInstanceOf[rt.NatIdentifier])
-                expT(DepPairType(natIdentifier(x), dataType(elemT)), read) ->:
-                  nFunT(i_, expT(dataType(app1), read) ->: expT(dataType(outT), a)) ->:
-                    expT(dataType(retT), a)
-              case _ => ???
-            }
+          case rt.FunType(rt.DepPairType(_, x: rt.NatIdentifier, elemT),
+            rt.FunType(rt.DepFunType(rt.NatKind, i: rt.NatIdentifier,
+              rt.FunType(app1:rt.DataType, outT:rt.DataType)), retT:rt.DataType)) =>
+
+            val i_ = natIdentifier(i.asInstanceOf[rt.NatIdentifier])
+            expT(DepPairType(natIdentifier(x), dataType(elemT)), read) ->:
+              nFunT(i_, expT(dataType(app1), read) ->: expT(dataType(outT), a)) ->:
+                expT(dataType(retT), a)
           case _ => error(s"did not expect t")
         }
         buildType(p.t)
 
       case rp.makeDepPair() =>
         def buildType(t: rt.Type): PhraseType = t match {
-          case rt.DepFunType(fst, rt.FunType(sndT:rt.DataType, outT:rt.DataType)) =>
+          case rt.DepFunType(rt.NatKind, fst: rt.NatIdentifier, rt.FunType(sndT:rt.DataType, outT:rt.DataType)) =>
             val a1 = accessTypeIdentifier()
-            fst match {
-              case fst:rt.NatIdentifier =>
-                val fst_ = natIdentifier(fst)
-                nFunT(fst_, expT(dataType(sndT), a1) ->: expT(dataType(outT), a1))
-              case _ => ???
-            }
+            val fst_ = natIdentifier(fst)
+            nFunT(fst_, expT(dataType(sndT), a1) ->: expT(dataType(outT), a1))
 
           case _ => error(s"did not expect $t")
         }
@@ -641,7 +633,7 @@ private class InferAccessAnnotation {
   ): Boolean =
     if (kernelParamFun)
       expr.t match {
-        case _: rt.FunType[_, _] | _: rt.DepFunType[_, _] => true
+        case _: rt.FunType[_, _] | _: rt.DepFunType[_, _, _, _] => true
         case _ => false
       }
     else false
@@ -663,7 +655,7 @@ private class InferAccessAnnotation {
           Success(outSubst(argSubst))
         )
       )
-    case (DepFunType(lx, la), DepFunType(rx, ra)) if lx == rx =>
+    case (DepFunType(_, lx, la), DepFunType(_, rx, ra)) if lx == rx =>
       subUnifyPhraseType(la, ra)
     case _ => Try(error(s"Cannot subunify $less and $larger."))
   }
@@ -671,7 +663,7 @@ private class InferAccessAnnotation {
   def `type`(ty: rt.Type): PhraseType = ty match {
     case dt: rt.DataType => ExpType(dataType(dt), accessTypeIdentifier())
     case rt.FunType(i, o) => `type`(i) ->: `type`(o)
-    case rt.DepFunType(i, t) => i match {
+    case rt.DepFunType(_, i, t) => i match {
       case dt: rt.DataTypeIdentifier =>
         dataTypeIdentifier(dt) ->: `type`(t)
       case n: rt.NatIdentifier =>
@@ -689,8 +681,8 @@ private class InferAccessAnnotation {
     case (rt.FunType(inT, outT), FunType(inPT, outPT)) =>
       checkConsistency(inT, inPT)
       checkConsistency(outT, outPT)
-    case (rt.DepFunType(x, t), DepFunType(y, pt)) =>
-      if (x.name != y.name) error(s"Identifiers $x and $y differ")
+    case (rt.DepFunType(k, x, t), DepFunType(_, y, pt)) =>
+      if (rt.Kind.idName(k, x) != y.name) error(s"Identifiers $x and $y differ")
       checkConsistency(t, pt)
     case (dt: rt.DataType, ExpType(dpt: DataType, _)) =>
 

--- a/src/main/scala/shine/DPIA/Phrases/PrettyPhrasePrinter.scala
+++ b/src/main/scala/shine/DPIA/Phrases/PrettyPhrasePrinter.scala
@@ -8,7 +8,7 @@ object PrettyPhrasePrinter {
     p match {
       case app: Apply[a, T] => s"(${apply(app.fun)})(${apply(app.arg)})"
 
-      case app: DepApply[_, T] => s"(${apply(app.fun)})(${app.arg})"
+      case app: DepApply[_, _, T] => s"(${apply(app.fun)})(${app.arg})"
 
       case p1: Proj1[a, b] => s"π1(${apply(p1.pair)})"
 
@@ -25,7 +25,7 @@ object PrettyPhrasePrinter {
 
       case Lambda(param, body) => s"λ ${apply(param)}: ${param.t} -> ${apply(body)}"
 
-      case dl @ DepLambda(param, body) => s"Λ (${param.name}: ${dl.kn.get}) -> ${apply(body)}"
+      case DepLambda(kind, param, body) => s"Λ (${param.name}: ${kind.name}) -> ${apply(body)}"
 
       case LetNat(binder, defn, body) => s"nLet ${binder.name} = ${apply(defn)} in ${apply(body)}"
 

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -52,59 +52,59 @@ object VisitAndRebuild {
           case Apply(p, q) =>
             Apply(apply(p, v), apply(q, v))
 
-          case DepLambda(a, p) => a match {
+          case DepLambda(_, a, p) => a match {
             case n: NatIdentifier =>
-              DepLambda[NatKind, PhraseType](
+              DepLambda(NatKind,
                 NatIdentifier(
                   v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name),
                 apply(p, v))
             case dt: DataTypeIdentifier =>
-              DepLambda[DataKind, PhraseType](
+              DepLambda(DataKind,
                 v.data(dt).asInstanceOf[DataTypeIdentifier],
                 apply(p, v))
             case ad: AddressSpaceIdentifier =>
-              DepLambda[AddressSpaceKind, PhraseType](
+              DepLambda(AddressSpaceKind,
                 v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier],
                 apply(p, v))
             case ac: AccessTypeIdentifier =>
-              DepLambda[AccessKind, PhraseType](
+              DepLambda(AccessKind,
                 v.access(ac).asInstanceOf[AccessTypeIdentifier],
                 apply(p, v))
             case n2n: NatToNatIdentifier =>
-              DepLambda[NatToNatKind, PhraseType](
+              DepLambda(NatToNatKind,
                 v.natToNat(n2n).asInstanceOf[NatToNatIdentifier],
                 apply(p, v))
             case n2d: NatToDataIdentifier =>
-              DepLambda[NatToDataKind, PhraseType](
+              DepLambda(NatToDataKind,
                 v.natToData(n2d).asInstanceOf[NatToDataIdentifier],
                 apply(p, v))
             case _ => ???
           }
 
-          case DepApply(p, a) => a match {
+          case DepApply(_, p, a) => a match {
             case n: Nat =>
-              DepApply[NatKind, T](
-                apply(p, v).asInstanceOf[Phrase[NatKind `()->:` T]],
+              DepApply(NatKind,
+                apply(p, v).asInstanceOf[Phrase[NatIdentifier `()->:` T]],
                 v.nat(n))
             case dt: DataType =>
-              DepApply[DataKind, T](
-                apply(p, v).asInstanceOf[Phrase[DataKind `()->:` T]],
+              DepApply(DataKind,
+                apply(p, v).asInstanceOf[Phrase[DataTypeIdentifier `()->:` T]],
                 visitDataTypeAndRebuild(dt, v))
             case ad: AddressSpace =>
-              DepApply[AddressSpaceKind, T](
-                apply(p, v).asInstanceOf[Phrase[AddressSpaceKind `()->:` T]],
+              DepApply(AddressSpaceKind,
+                apply(p, v).asInstanceOf[Phrase[AddressSpaceIdentifier `()->:` T]],
                 v.addressSpace(ad))
             case ac: AccessType =>
-              DepApply[AccessKind, T](
-                apply(p, v).asInstanceOf[Phrase[AccessKind `()->:` T]],
+              DepApply(AccessKind,
+                apply(p, v).asInstanceOf[Phrase[AccessTypeIdentifier `()->:` T]],
                 v.access(ac))
             case n2n: NatToNat =>
-              DepApply[NatToNatKind, T](
-                apply(p, v).asInstanceOf[Phrase[NatToNatKind `()->:` T]],
+              DepApply(NatToNatKind,
+                apply(p, v).asInstanceOf[Phrase[NatToNatIdentifier `()->:` T]],
                 v.natToNat(n2n))
             case n2d: NatToData =>
-              DepApply[NatToDataKind, T](
-                apply(p, v).asInstanceOf[Phrase[NatToDataKind `()->:` T]],
+              DepApply(NatToDataKind,
+                apply(p, v).asInstanceOf[Phrase[NatToDataIdentifier `()->:` T]],
                 v.natToData(n2d))
             case ph: PhraseType => ???
           }
@@ -147,30 +147,30 @@ object VisitAndRebuild {
         visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
       case PassiveFunType(inT, outT) => PassiveFunType(
         visitPhraseTypeAndRebuild(inT, v), visitPhraseTypeAndRebuild(outT, v))
-      case DepFunType(x, t) => x match {
+      case DepFunType(_, x, t) => x match {
         case n: NatIdentifier =>
-          DepFunType[NatKind, PhraseType](
+          DepFunType(NatKind,
             NatIdentifier(
               v.nat(n).asInstanceOf[arithexpr.arithmetic.NamedVar].name),
             visitPhraseTypeAndRebuild(t, v))
         case dt: DataTypeIdentifier =>
-          DepFunType[DataKind, PhraseType](
+          DepFunType(DataKind,
             v.data(dt).asInstanceOf[DataTypeIdentifier],
             visitPhraseTypeAndRebuild(t, v))
         case ad: AddressSpaceIdentifier =>
-          DepFunType[AddressSpaceKind, PhraseType](
+          DepFunType(AddressSpaceKind,
             v.addressSpace(ad).asInstanceOf[AddressSpaceIdentifier],
             visitPhraseTypeAndRebuild(t, v))
         case ac: AccessTypeIdentifier =>
-          DepFunType[AccessKind, PhraseType](
+          DepFunType(AccessKind,
             v.access(ac).asInstanceOf[AccessTypeIdentifier],
             visitPhraseTypeAndRebuild(t, v))
         case n2n: NatToNatIdentifier =>
-          DepFunType[NatToNatKind, PhraseType](
+          DepFunType(NatToNatKind,
             v.natToNat(n2n).asInstanceOf[NatToNatIdentifier],
             visitPhraseTypeAndRebuild(t, v))
         case n2d: NatToDataIdentifier =>
-          DepFunType[NatToDataKind, PhraseType](
+          DepFunType(NatToDataKind,
             v.natToData(n2d).asInstanceOf[NatToDataIdentifier],
             visitPhraseTypeAndRebuild(t, v))
       }

--- a/src/main/scala/shine/DPIA/Types/Kind.scala
+++ b/src/main/scala/shine/DPIA/Types/Kind.scala
@@ -3,101 +3,48 @@ package shine.DPIA.Types
 import shine.DPIA
 import shine.DPIA.NatIdentifier
 
-sealed trait Kind {
-  type T
-  type I <: Kind.Identifier
+sealed trait Kind[+T, +I <: Kind.Identifier] {
+  def name: String
+  def makeIdentifier: I
 }
 
 object Kind {
   trait Identifier {
     def name: String
   }
-
-  trait IdentifierMaker[K <: Kind] {
-    def makeIdentifier(): K#I
-  }
-
-  implicit object DataTypeIdentifierMaker
-    extends IdentifierMaker[DataKind] {
-    override def makeIdentifier(): DataTypeIdentifier =
-      DataTypeIdentifier(DPIA.freshName("dt"))
-  }
-  implicit object NatIdentifierMaker
-    extends IdentifierMaker[NatKind] {
-    override def makeIdentifier(): NatIdentifier =
-      NatIdentifier(DPIA.freshName("n"))
-  }
-  implicit object AddrIdentifierMaker
-    extends IdentifierMaker[AddressSpaceKind] {
-    override def makeIdentifier(): AddressSpaceIdentifier =
-      AddressSpaceIdentifier(DPIA.freshName("addr"))
-  }
-  implicit object AccessTypeIdentifierMaker
-    extends IdentifierMaker[AccessKind] {
-    override def makeIdentifier(): AccessTypeIdentifier =
-      AccessTypeIdentifier(DPIA.freshName("access"))
-  }
 }
 
-sealed trait PhraseKind extends Kind {
-  override type T = PhraseType
+case object PhraseKind extends Kind[PhraseType, Kind.Identifier] {
+  override def name: String = "phrase"
+  override def makeIdentifier: Kind.Identifier = ???
 }
 
-sealed trait DataKind extends Kind {
-  override type T = DataType
-  override type I = DataTypeIdentifier
+case object DataKind extends Kind[DataType, DataTypeIdentifier] {
+  override def name: String = "data"
+  override def makeIdentifier: DataTypeIdentifier = DataTypeIdentifier(DPIA.freshName("dt"))
 }
 
-sealed trait NatKind extends Kind {
-  override type T = DPIA.Nat
-  override type I = DPIA.NatIdentifier
+case object NatKind extends Kind[DPIA.Nat, DPIA.NatIdentifier] {
+  override def name: String = "nat"
+  override def makeIdentifier: NatIdentifier = NatIdentifier(DPIA.freshName("n"))
 }
 
-sealed trait AddressSpaceKind extends Kind {
-  override type T = AddressSpace
-  override type I = AddressSpaceIdentifier
+case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier] {
+  override def name: String = "addressSpace"
+  override def makeIdentifier: AddressSpaceIdentifier = AddressSpaceIdentifier(DPIA.freshName("addr"))
 }
 
-sealed trait AccessKind extends Kind {
-  override type T = AccessType
-  override type I = AccessTypeIdentifier
+case object AccessKind extends Kind[AccessType, AccessTypeIdentifier] {
+  override def name: String = "access"
+  override def makeIdentifier: AccessTypeIdentifier = AccessTypeIdentifier(DPIA.freshName("access"))
 }
 
-sealed trait NatToNatKind extends Kind {
-  override type T = NatToNat
-  override type I = NatToNatIdentifier
+case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier] {
+  override def name: String = "nat->nat"
+  override def makeIdentifier: NatToNatIdentifier = NatToNatIdentifier(DPIA.freshName("n2n"))
 }
 
-sealed trait NatToDataKind extends Kind {
-  override type T = NatToData
-  override type I = NatToDataIdentifier
-}
-
-trait KindName[K <: Kind] {
-  def get: String
-}
-
-object KindName {
-  implicit val phraseKN: KindName[PhraseKind] = new KindName[PhraseKind] {
-    def get = "phrase"
-  }
-  implicit val natKN: KindName[NatKind] = new KindName[NatKind] {
-    def get = "nat"
-  }
-  implicit val dataKN: KindName[DataKind] = new KindName[DataKind] {
-    def get = "data"
-  }
-  implicit val addressSpaceKN: KindName[AddressSpaceKind] =
-    new KindName[AddressSpaceKind] {
-    def get = "addressSpace"
-  }
-  implicit val accessKN: KindName[AccessKind] = new KindName[AccessKind] {
-    def get = "access"
-  }
-  implicit val n2nKN: KindName[NatToNatKind] = new KindName[NatToNatKind] {
-    def get = "nat->nat"
-  }
-  implicit val n2dtKN: KindName[NatToDataKind] = new KindName[NatToDataKind] {
-    def get = "nat->data"
-  }
+case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier] {
+  override def name: String = "nat->data"
+  override def makeIdentifier: NatToDataIdentifier = NatToDataIdentifier(DPIA.freshName("n2d"))
 }

--- a/src/main/scala/shine/DPIA/Types/TypeCheck.scala
+++ b/src/main/scala/shine/DPIA/Types/TypeCheck.scala
@@ -17,9 +17,9 @@ object TypeCheck {
         TypeCheck(q)
         errorIfNotEqOrSubtype(q.t, p.t.inT)
 
-      case DepLambda(_, p) => TypeCheck(p)
+      case DepLambda(_, _, p) => TypeCheck(p)
 
-      case DepApply(p, _) => TypeCheck(p)
+      case DepApply(_, p, _) => TypeCheck(p)
 
       case LetNat(_, defn, body) => TypeCheck(defn); TypeCheck(body)
 
@@ -116,8 +116,8 @@ object TypeCheck {
           accessSub == read && notContainingArrayType(bSub)
       case (FunType(subInT, subOutT), FunType(superInT, superOutT)) =>
         subtypeCheck(superInT, subInT) && subtypeCheck(subOutT,  superOutT)
-      case (DepFunType(subInT, subOutT), DepFunType(superInT, superOutT)) =>
-        subInT == superInT && subtypeCheck(subOutT, superOutT)
+      case (DepFunType(kind1, subInT, subOutT), DepFunType(kind2, superInT, superOutT)) =>
+        kind1 == kind2 && subInT == superInT && subtypeCheck(subOutT, superOutT)
       case _ => false
     }
   }

--- a/src/main/scala/shine/DPIA/Types/package.scala
+++ b/src/main/scala/shine/DPIA/Types/package.scala
@@ -26,42 +26,42 @@ package object Types {
     def `:`[T <: PhraseType](p: Phrase[T]): Unit = typeAssert(p, pt)
   }
 
-  type NatDependentFunctionType[T <: PhraseType] = DepFunType[NatKind, T]
+  type NatDependentFunctionType[T <: PhraseType] = DepFunType[NatIdentifier, T]
 
   object NatDependentFunctionType {
-    def apply[T <: PhraseType](n: NatIdentifier, t: T): DepFunType[NatKind, T] =
-      DepFunType[NatKind, T](n, t)
+    def apply[T <: PhraseType](n: NatIdentifier, t: T): DepFunType[NatIdentifier, T] =
+      DepFunType(NatKind, n, t)
   }
 
-  type TypeDependentFunctionType[T <: PhraseType] = DepFunType[DataKind, T]
+  type TypeDependentFunctionType[T <: PhraseType] = DepFunType[DataTypeIdentifier, T]
 
   object TypeDependentFunctionType {
     def apply[T <: PhraseType](
       dt: DataTypeIdentifier,
       t: T
-    ): DepFunType[DataKind, T] =
-      DepFunType[DataKind, T](dt, t)
+    ): DepFunType[DataTypeIdentifier, T] =
+      DepFunType(DataKind, dt, t)
   }
 
   type AddrSpaceDependentFunctionType[T <: PhraseType] =
-    DepFunType[AddressSpaceKind, T]
+    DepFunType[AddressSpaceIdentifier, T]
 
   object AddrSpaceDependentFunctionType {
     def apply[T <: PhraseType](
       addr: AddressSpaceIdentifier,
       t: T
-    ): DepFunType[AddressSpaceKind, T] =
-      DepFunType[AddressSpaceKind, T](addr, t)
+    ): DepFunType[AddressSpaceIdentifier, T] =
+      DepFunType(AddressSpaceKind, addr, t)
   }
 
-  type AccessDependentFunctionType[T <: PhraseType] = DepFunType[AccessKind, T]
+  type AccessDependentFunctionType[T <: PhraseType] = DepFunType[AccessTypeIdentifier, T]
 
   object AccessDependentFunctionType {
     def apply[T <: PhraseType](
       at: AccessTypeIdentifier,
       t: T
-    ): DepFunType[AccessKind, T] =
-      DepFunType[AccessKind, T](at, t)
+    ): DepFunType[AccessTypeIdentifier, T] =
+      DepFunType(AccessKind, at, t)
   }
 
   object n2dtFun {

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -16,7 +16,8 @@ import scala.collection.mutable
 object fromRise {
   def apply(expr: r.Expr)(implicit ev: Traversable[Rise]): Phrase[_ <: PhraseType] = {
     if (!r.IsClosedForm(expr)) {
-      throw new Exception(s"expression is not in closed form: $expr\n\n with type ${expr.t}")
+      val (fV, fT) = r.IsClosedForm.varsToClose(expr)
+      throw new Exception(s"expression is not in closed form: $expr\n\n with type ${expr.t}\n free vars: $fV\n free type vars: $fT\n\n")
     }
     val bnfExpr = normalize(ev).apply(betaReduction)(expr).get
     val rwMap = inferAccess(bnfExpr)
@@ -39,27 +40,26 @@ object fromRise {
       val ee = expression(e, ptMap).asInstanceOf[Phrase[PhraseType]]
       Apply(ef, ee)
 
-    case r.DepLambda(x, e) => x match {
+    case r.DepLambda(kind, x, e) => x match {
       case ni: rt.NatIdentifier =>
-        DepLambda[NatKind](natIdentifier(ni))(expression(e, ptMap))
+        DepLambda(NatKind, natIdentifier(ni))(expression(e, ptMap))
       case dti: rt.DataTypeIdentifier =>
-        DepLambda[DataKind](dataTypeIdentifier(dti))(expression(e, ptMap))
+        DepLambda(DataKind, dataTypeIdentifier(dti))(expression(e, ptMap))
       case addri: rt.AddressSpaceIdentifier =>
-        DepLambda[AddressSpaceKind](
-          addressSpaceIdentifier(addri))(expression(e, ptMap))
+        DepLambda(AddressSpaceKind, addressSpaceIdentifier(addri))(expression(e, ptMap))
     }
 
-    case r.DepApp(f, x) =>
-      def depApp[K <: Kind](f: r.Expr, arg: K#T): DepApply[K, PhraseType] =
-        DepApply[K, PhraseType](
-          expression(f, ptMap).asInstanceOf[Phrase[DepFunType[K, PhraseType]]],
+    case r.DepApp(kind, f, x) =>
+      def depApp[T, I <: Kind.Identifier](kind: Kind[T, I], f: r.Expr, arg: T): DepApply[T, I, PhraseType] =
+        DepApply[T, I, PhraseType](kind,
+          expression(f, ptMap).asInstanceOf[Phrase[DepFunType[I, PhraseType]]],
           arg)
 
       x match {
-        case n: Nat             => depApp[NatKind](f, n)
-        case dt: rt.DataType    => depApp[DataKind](f, dataType(dt))
-        case a: rt.AddressSpace => depApp[AddressSpaceKind](f, addressSpace(a))
-        case n2n: rt.NatToNat   => depApp[NatToNatKind](f, nat2nat(n2n))
+        case n: Nat             => depApp(NatKind, f, n)
+        case dt: rt.DataType    => depApp(DataKind, f, dataType(dt))
+        case a: rt.AddressSpace => depApp(AddressSpaceKind, f, addressSpace(a))
+        case n2n: rt.NatToNat   => depApp(NatToNatKind, f, nat2nat(n2n))
       }
 
     case r.Literal(d) => d match {
@@ -98,12 +98,10 @@ object fromRise {
   }
 
   object depFun {
-    def apply[K <: Kind](x: K#I): Object {
-      def apply[T <: PhraseType](body: Phrase[T])
-                                (implicit kn: KindName[K]): DepLambda[K, T]
+    def apply[T, I <: Kind.Identifier](kind: Kind[T, I], x: I): Object {
+      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U]
     } = new {
-      def apply[T <: PhraseType](body: Phrase[T])
-                                (implicit kn: KindName[K]): DepLambda[K, T] = DepLambda(x, body)
+      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
     }
   }
 
@@ -136,7 +134,7 @@ object fromRise {
         case nFunT(n, expT(`NatType`, `read`) ->:
           expT(IndexType(_), `read`))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT(NatType, read), e =>
             NatAsIndex(n, e)))
       }
@@ -275,7 +273,7 @@ object fromRise {
           expT(ArrayType(n, _), `read`) ->:
           expT(_, `read`))
         =>
-        depFun[AddressSpaceKind](a)(
+        depFun(AddressSpaceKind, a)(
           fun[ExpType ->: ExpType ->: ExpType](
             expT(t, read) ->: expT(s, read) ->: expT(t, write), f =>
               fun[ExpType](expT(t, write), i =>
@@ -290,7 +288,7 @@ object fromRise {
           expT(ArrayType(n, _), `read`) ->:
           expT(_, `read`))
         =>
-        depFun[AddressSpaceKind](a)(
+        depFun(AddressSpaceKind, a)(
           fun[ExpType ->: ExpType ->: ExpType](
             expT(t, read) ->: expT(s, read) ->: expT(t, write), f =>
               fun[ExpType](expT(t, write), i =>
@@ -332,7 +330,7 @@ object fromRise {
         case nFunT(n, expT(ArrayType(_, t), a) ->:
           expT(ArrayType(m, ArrayType(_, _)), _))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT({m*n}`.`t, a), e =>
             Split(n, m, a, t, e)))
       }
@@ -342,8 +340,8 @@ object fromRise {
           expT(ArrayType(insz, t), `read`) ->:
           expT(ArrayType(np1, ArrayType(_, _)), `read`)))
         =>
-        depFun[NatKind](sz)(
-          depFun[NatKind](sp)(
+        depFun(NatKind, sz)(
+          depFun(NatKind, sp)(
             fun[ExpType](expT(insz`.`t, read), e =>
               Slide(np1-1, sz, sp, t, e))))
       }
@@ -354,8 +352,8 @@ object fromRise {
             expT(ArrayType(insz, _), `read`) ->:
             expT(ArrayType(n, _), `read`)))
         =>
-        depFun[NatKind](alloc)(
-          depFun[NatKind](sz)(
+        depFun(NatKind, alloc)(
+          depFun(NatKind, sz)(
             fun[ExpType ->: ExpType](
               expT(s, read) ->: expT(t, write), load =>
                 fun[ExpType](expT(insz`.`s, read), e =>
@@ -368,7 +366,7 @@ object fromRise {
           (inT @ expT(ArrayType(m, s), `read`)) ->:
           expT(ArrayType(n, t), `write`))
         =>
-          depFun[NatKind](tile)(
+          depFun(NatKind, tile)(
             fun[ExpType ->: ExpType](fa ->: fb, f =>
               fun[ExpType](inT, e =>
                 DepTile(n, tile, m-n, s, t, f, e))))
@@ -380,7 +378,7 @@ object fromRise {
             expT(ArrayType(insz, _), `read`) ->:
             expT(ArrayType(n, _), `read`))
         =>
-        depFun[NatKind](sz)(
+        depFun(NatKind, sz)(
           fun[ExpType ->: ExpType](
             expT(s, read) ->: expT(s, write), wr =>
               fun[ExpType](expT(insz`.`s, read), e =>
@@ -393,9 +391,9 @@ object fromRise {
           expT(ArrayType(insz, _), `read`) ->:
           expT(ArrayType(n, _), `read`))))
         =>
-        depFun[AddressSpaceKind](a)(
-          depFun[NatKind](alloc)(
-            depFun[NatKind](sz)(
+        depFun(AddressSpaceKind, a)(
+          depFun(NatKind, alloc)(
+            depFun(NatKind, sz)(
               fun[ExpType ->: ExpType](
                 expT(s, read) ->: expT(t, write), load =>
                   fun[ExpType](expT(insz`.`s, read), e =>
@@ -408,8 +406,8 @@ object fromRise {
           expT(ArrayType(insz, _), `read`) ->:
           expT(ArrayType(n, _), `read`)))
         =>
-        depFun[AddressSpaceKind](a)(
-          depFun[NatKind](sz)(
+        depFun(AddressSpaceKind, a)(
+          depFun(NatKind, sz)(
               fun[ExpType ->: ExpType](
                 expT(t, read) ->: expT(t, write), write_t =>
                   fun[ExpType](expT(insz`.`t, read), e =>
@@ -420,9 +418,9 @@ object fromRise {
         case nFunT(n, n2nFunT(idxF, n2nFunT(idxFinv,
           expT(ArrayType(_, t), a) ->: expT(ArrayType(_, _), _))))
         =>
-        depFun[NatKind](n)(
-          depFun[NatToNatKind](idxF)(
-            depFun[NatToNatKind](idxFinv)(
+        depFun(NatKind, n)(
+          depFun(NatToNatKind, idxF)(
+            depFun(NatToNatKind, idxFinv)(
               fun[ExpType](expT(n`.`t, a), e =>
                 Reorder(n, t, a, idxF, idxFinv, e)))))
       }
@@ -459,7 +457,7 @@ object fromRise {
         case nFunT(n, expT(ArrayType(nm, t), `read`) ->:
           expT(ArrayType(_, _), `read`))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT(nm`.`t, read), e => Take(n, nm-n, t, e)))
       }
 
@@ -467,7 +465,7 @@ object fromRise {
         case nFunT(n, expT(ArrayType(nm, t), `read`) ->:
           expT(ArrayType(_, _), `read`))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT(nm`.`t, read), e =>
             Drop(n, nm-n, t, e)))
       }
@@ -478,8 +476,8 @@ object fromRise {
           expT(ArrayType(n, _), `read`) ->:
           expT(ArrayType(_, _), `read`)))
         =>
-        depFun[NatKind](l)(
-          depFun[NatKind](q)(
+        depFun(NatKind, l)(
+          depFun(NatKind, q)(
             fun[ExpType](expT(t, read), cst =>
               fun[ExpType](expT(n`.`t, read), e =>
                 PadCst(n, l, q, t, cst, e)))))
@@ -489,7 +487,7 @@ object fromRise {
         case nFunT(r,
           expT(ArrayType(n, t), `write`) ->: _)
         =>
-        depFun[NatKind](r)(
+        depFun(NatKind, r)(
           fun[ExpType](expT(n`.`t, `write`), e =>
             PadEmpty(n, r, t, e)))
       }
@@ -499,8 +497,8 @@ object fromRise {
           expT(ArrayType(n, t), `read`) ->:
           expT(ArrayType(_, _), `read`)))
         =>
-        depFun[NatKind](l)(
-          depFun[NatKind](q)(
+        depFun(NatKind, l)(
+          depFun(NatKind, q)(
             fun[ExpType](expT(n`.`t, read), e =>
               PadClamp(n, l, q, t, e))))
       }
@@ -680,7 +678,7 @@ object fromRise {
             case FunType(ExpType(dt: DataTypeIdentifier, `read`), out) =>
               val (i, o) = collectTypes(out)
               (dt +: i, o)
-            case DepFunType(_, t) => collectTypes(t)
+            case DepFunType(_, _, t) => collectTypes(t)
             case _ => throw new Exception("This should not be possible")
           }
         }
@@ -688,7 +686,7 @@ object fromRise {
         assert(inTs.length == n)
 
         inTs.foldRight[Phrase[_ <: PhraseType]](
-          depFun[DataKind](outT)({
+          depFun(DataKind, outT)({
             val args = Seq.tabulate(n)(i => Identifier(freshName("x"), ExpType(inTs(i), read)))
             args.foldRight[Phrase[_ <: PhraseType]](
               ForeignFunctionCall(decl, n)(inTs, outT, args)
@@ -697,7 +695,7 @@ object fromRise {
             }
           })
         ) {
-          case (t, f) => depFun[DataKind](t)(f)
+          case (t, f) => depFun(DataKind, t)(f)
         }
 
       case core.generate() => fromType {
@@ -726,7 +724,7 @@ object fromRise {
           expT(ArrayType(insz, _), `read`) ->:
           expT(ArrayType(m, _), `write`) )
         =>
-        depFun[NatKind](k)(
+        depFun(NatKind, k)(
           fun[`(nat)->:`[ExpType ->: ExpType]](
             l ->: (expT(ln`.`t, read) ->: expT(l`.`t, write)), f =>
               fun[ExpType](expT(insz`.`t, read), e =>
@@ -740,7 +738,7 @@ object fromRise {
           expT(ArrayType(insz, _), `read`) ->:
           expT(ArrayType(m, _), `write`) ))
         =>
-        depFun[AddressSpaceKind](a)(depFun[NatKind](k)(
+        depFun(AddressSpaceKind, a)(depFun(NatKind, k)(
           fun[`(nat)->:`[ExpType ->: ExpType]](
             l ->: (expT(ln`.`t, read) ->: expT(l`.`t, write)), f =>
               fun[ExpType](expT(insz`.`t, read), e =>
@@ -752,7 +750,7 @@ object fromRise {
           expT(ArrayType(mn, _), a) ->:
           expT(ArrayType(m, VectorType(_, t)), _))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT(mn`.`t, a), e =>
             AsVector(n, m, t, a, e)))
       }
@@ -762,7 +760,7 @@ object fromRise {
           expT(ArrayType(mn, _), a) ->:
           expT(ArrayType(m, VectorType(_, t)), _))
         =>
-        depFun[NatKind](n)(
+        depFun(NatKind, n)(
           fun[ExpType](expT(mn`.`t, read), e =>
             AsVectorAligned(n, m, t, a, e)))
       }
@@ -800,7 +798,7 @@ object fromRise {
       case rocl.oclToMem() => fromType {
         case aFunT(a, expT(t, `write`) ->: expT(_, `read`))
         =>
-        depFun[AddressSpaceKind](a)(
+        depFun(AddressSpaceKind, a)(
           fun[ExpType](expT(t, write), e =>
             ocl.ToMem(a, t, e)))
       }
@@ -811,8 +809,8 @@ object fromRise {
           expT(t, `write`) ->: _))))))
         =>
           import shine.OpenCL.{LocalSize, GlobalSize}
-          depFun[NatKind](ls1)(depFun[NatKind](ls2)(depFun[NatKind](ls3)(
-            depFun[NatKind](gs1)(depFun[NatKind](gs2)(depFun[NatKind](gs3)(
+          depFun(NatKind, ls1)(depFun(NatKind, ls2)(depFun(NatKind, ls3)(
+            depFun(NatKind, gs1)(depFun(NatKind, gs2)(depFun(NatKind, gs3)(
               fun[ExpType](expT(t, write), e =>
                 ocl.Run(LocalSize(ls1, ls2, ls3), GlobalSize(gs1, gs2, gs3))(t, e))))))))
       }
@@ -830,7 +828,7 @@ object fromRise {
 
       case core.makeDepPair() => fromType {
         case nFunT(fst, expT(sndT, a) ->: expT(_, _)) =>
-          depFun[NatKind](fst)(fun[ExpType](expT(sndT, a), snd => MakeDepPair(a, fst, sndT, snd)))
+          depFun(NatKind, fst)(fun[ExpType](expT(sndT, a), snd => MakeDepPair(a, fst, sndT, snd)))
       }
 
       case rcuda.globalToShared() => fromType {
@@ -941,11 +939,11 @@ object fromRise {
     case rt.AddressSpace.Local => AddressSpace.Local
     case rt.AddressSpace.Private => AddressSpace.Private
     case rt.AddressSpace.Constant => AddressSpace.Constant
-    case rt.AddressSpaceIdentifier(name, _) => AddressSpaceIdentifier(name)
+    case rt.AddressSpaceIdentifier(name) => AddressSpaceIdentifier(name)
   }
 
   def nat2nat(n2n: rt.NatToNat): NatToNat = n2n match {
-    case rt.NatToNatIdentifier(name, _) =>
+    case rt.NatToNatIdentifier(name) =>
       NatToNatIdentifier(name)
     case rt.NatToNatLambda(x, body) =>
       NatToNatLambda(x.range, NatIdentifier(x.name), body)
@@ -964,7 +962,7 @@ object fromRise {
     case rt.DepArrayType(sz, f) => DepArrayType(sz, ntd(f))
     case rt.PairType(a, b) => PairType(dataType(a), dataType(b))
     case rt.NatToDataApply(f, n) => NatToDataApply(ntd(f), n)
-    case rt.DepPairType(x, t) =>
+    case rt.DepPairType(_, x, t) =>
       x match {
       case x:rt.NatIdentifier => DepPairType(natIdentifier(x), dataType(t))
       case _ => ???
@@ -989,7 +987,7 @@ object fromRise {
     case rt.MatrixLayout.Row_Major => MatrixLayout.Row_Major
     case rt.MatrixLayout.Col_Major => MatrixLayout.Col_Major
     case rt.MatrixLayout.None => MatrixLayout.None
-    case rt.MatrixLayoutIdentifier(name, _) => layouts.getOrElseUpdate(name, MatrixLayoutIdentifier(name))
+    case rt.MatrixLayoutIdentifier(name) => layouts.getOrElseUpdate(name, MatrixLayoutIdentifier(name))
     case _ => throw new Exception("this should not happen")
   }
 
@@ -1012,12 +1010,12 @@ object fromRise {
   def ntd(ntd: rt.NatToData): NatToData= ntd match {
     case rt.NatToDataLambda(n, body) =>
       NatToDataLambda(natIdentifier(n), dataType(body))
-    case rt.NatToDataIdentifier(x, _) => NatToDataIdentifier(x)
+    case rt.NatToDataIdentifier(x) => NatToDataIdentifier(x)
   }
 
   def ntn(ntn: rt.NatToNat): NatToNat= ntn match {
     case rt.NatToNatLambda(n, body) => NatToNatLambda(natIdentifier(n), body)
-    case rt.NatToNatIdentifier(x, _) => NatToNatIdentifier(x)
+    case rt.NatToNatIdentifier(x) => NatToNatIdentifier(x)
   }
 
   def dataTypeIdentifier(dt: rt.DataTypeIdentifier): DataTypeIdentifier =

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -34,9 +34,9 @@ package object DPIA {
   type x[T1 <: PhraseType, T2 <: PhraseType] = PhrasePairType[T1, T2]
   type ->:[T <: PhraseType, R <: PhraseType] = FunType[T, R]
   type `->p:`[T <: PhraseType, R <: PhraseType] = PassiveFunType[T, R]
-  type `()->:`[K <: Kind, R <: PhraseType] = DepFunType[K, R]
-  type `(nat)->:`[R <: PhraseType] = DepFunType[NatKind, R]
-  type `(dt)->:`[R <: PhraseType] = DepFunType[DataKind, R]
+  type `()->:`[I <: Kind.Identifier, R <: PhraseType] = DepFunType[I, R]
+  type `(nat)->:`[R <: PhraseType] = DepFunType[NatIdentifier, R]
+  type `(dt)->:`[R <: PhraseType] = DepFunType[DataTypeIdentifier, R]
   type VarType = ExpType x AccType
 
   object VarType {
@@ -94,10 +94,10 @@ package object DPIA {
   }
 
   implicit class DepFunTypeConstructor[R <: PhraseType](r: R) {
-    def ->:(i: DataTypeIdentifier): `()->:`[DataKind, R] = DepFunType[DataKind, R](i, r)
-    def ->:(n: NatIdentifier): `()->:`[NatKind, R] = DepFunType[NatKind, R](n, r)
-    def ->:(n: NatToNatIdentifier): `()->:`[NatToNatKind, R] = DepFunType[NatToNatKind, R](n, r)
-    def ->:(n: NatToDataIdentifier): `()->:`[NatToDataKind, R] = DepFunType[NatToDataKind, R](n, r)
+    def ->:(i: DataTypeIdentifier): `()->:`[DataTypeIdentifier, R] = DepFunType(DataKind, i, r)
+    def ->:(n: NatIdentifier): `()->:`[NatIdentifier, R] = DepFunType(NatKind, n, r)
+    def ->:(n: NatToNatIdentifier): `()->:`[NatToNatIdentifier, R] = DepFunType(NatToNatKind, n, r)
+    def ->:(n: NatToDataIdentifier): `()->:`[NatToDataIdentifier, R] = DepFunType(NatToDataKind, n, r)
   }
 
   object expT {
@@ -125,16 +125,11 @@ package object DPIA {
   }
 
   object nFunT {
-    def apply(n: rt.NatIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[NatKind, PhraseType](fromRise.natIdentifier(n), t)
-    }
-
     def apply(n: NatIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[NatKind, PhraseType](n, t)
+      DepFunType(NatKind, n, t)
     }
 
-    def unapply[K <: Kind, T <: PhraseType](funType: DepFunType[K, T]
-                                           ): Option[(NatIdentifier, T)] = {
+    def unapply[I <: Kind.Identifier, U <: PhraseType](funType: DepFunType[I, U]): Option[(NatIdentifier, U)] = {
       funType.x match {
         case n: NatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected Nat DepFunType")
@@ -144,23 +139,21 @@ package object DPIA {
 
   object dFunT {
     def apply(d: rt.DataTypeIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[DataKind, PhraseType](fromRise.dataTypeIdentifier(d), t)
+      DepFunType(DataKind, fromRise.dataTypeIdentifier(d), t)
     }
   }
 
   object aFunT {
     def apply(a: rt.AddressSpaceIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[AddressSpaceKind, PhraseType](
-        fromRise.addressSpaceIdentifier(a), t)
+      DepFunType(AddressSpaceKind, fromRise.addressSpaceIdentifier(a), t)
     }
 
     def apply(a: AddressSpaceIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[AddressSpaceKind, PhraseType](a, t)
+      DepFunType(AddressSpaceKind, a, t)
     }
 
-    def unapply[K <: Kind,
-      T <: PhraseType](funType: DepFunType[K, T]
-                      ): Option[(AddressSpaceIdentifier, T)] = {
+    def unapply[I <: Kind.Identifier, T <: PhraseType](funType: DepFunType[I, T]
+                                                      ): Option[(AddressSpaceIdentifier, T)] = {
       funType.x match {
         case a: AddressSpaceIdentifier => Some((a, funType.t))
         case _ => throw new Exception("Expected AddressSpace DepFunType")
@@ -170,15 +163,15 @@ package object DPIA {
 
   object n2nFunT {
     def apply(n: rt.NatToNatIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[NatToNatKind, PhraseType](fromRise.natToNatIdentifier(n), t)
+      DepFunType(NatToNatKind, fromRise.natToNatIdentifier(n), t)
     }
 
     def apply(n: NatToNatIdentifier, t: PhraseType): PhraseType = {
-      DepFunType[NatToNatKind, PhraseType](n, t)
+      DepFunType(NatToNatKind, n, t)
     }
 
-    def unapply[K <: Kind, T <: PhraseType](funType: DepFunType[K, T]
-                                           ): Option[(NatToNatIdentifier, T)] = {
+    def unapply[I <: Kind.Identifier, T <: PhraseType](funType: DepFunType[I, T]
+                                                      ): Option[(NatToNatIdentifier, T)] = {
       funType.x match {
         case n: NatToNatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected Nat DepFunType")

--- a/src/main/scala/shine/DPIA/primitives/functional/DepMapSeq.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/DepMapSeq.scala
@@ -7,16 +7,16 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class DepMapSeq(unroll: Boolean)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMapSeq(unroll: Boolean)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val k = f.t.x
-      DepFunType[NatKind, PhraseType](k, FunType(expT(NatToDataApply(ft1, k), read), expT(NatToDataApply(ft2, k), write)))
+      DepFunType(NatKind, k, FunType(expT(NatToDataApply(ft1, k), read), expT(NatToDataApply(ft2, k), write)))
     })
     array :: expT(DepArrayType(n, ft1), read)
     true
   }
   override val t: ExpType = expT(DepArrayType(n, ft2), write)
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): DepMapSeq = new DepMapSeq(unroll)(v.nat(n), v.natToData(ft1), v.natToData(ft2), VisitAndRebuild(f, v), VisitAndRebuild(array, v))
-  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
+  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
 }

--- a/src/main/scala/shine/DPIA/primitives/functional/Iterate.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Iterate.scala
@@ -7,11 +7,11 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class Iterate(val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class Iterate(val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val l = f.t.x
-      DepFunType[NatKind, PhraseType](l, FunType(expT(ArrayType(l * n, dt), read), expT(ArrayType(l, dt), write)))
+      DepFunType(NatKind, l, FunType(expT(ArrayType(l * n, dt), read), expT(ArrayType(l, dt), write)))
     })
     array :: expT(ArrayType(m * n.pow(k), dt), read)
     true

--- a/src/main/scala/shine/DPIA/primitives/imperative/ForNat.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ForNat.scala
@@ -7,15 +7,15 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class ForNat(unroll: Boolean)(val n: Nat, val loopBody: Phrase[DepFunType[NatKind, CommType]]) extends CommandPrimitive {
+final case class ForNat(unroll: Boolean)(val n: Nat, val loopBody: Phrase[DepFunType[NatIdentifier, CommType]]) extends CommandPrimitive {
   assert {
     loopBody :: ({
       val i = loopBody.t.x
-      DepFunType[NatKind, PhraseType](i, comm)
+      DepFunType(NatKind, i, comm)
     })
     true
   }
   override val t: CommType = comm
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): ForNat = new ForNat(unroll)(v.nat(n), VisitAndRebuild(loopBody, v))
-  def unwrap: (Nat, Phrase[DepFunType[NatKind, CommType]]) = (n, loopBody)
+  def unwrap: (Nat, Phrase[DepFunType[NatIdentifier, CommType]]) = (n, loopBody)
 }

--- a/src/main/scala/shine/OpenCL/AdjustArraySizesForAllocations.scala
+++ b/src/main/scala/shine/OpenCL/AdjustArraySizesForAllocations.scala
@@ -57,8 +57,8 @@ object AdjustArraySizesForAllocations {
 
       case Apply(f, _) => visitAndGatherInformation(f, parallInfo)
       case Lambda(_, p) => visitAndGatherInformation(p, parallInfo)
-      case DepApply(f, _) => visitAndGatherInformation(f, parallInfo)
-      case DepLambda(_, p) => visitAndGatherInformation(p, parallInfo)
+      case DepApply(_, f, _) => visitAndGatherInformation(f, parallInfo)
+      case DepLambda(_, _, p) => visitAndGatherInformation(p, parallInfo)
       case Fst(_, _, p) => visitAndGatherInformation(p, parallInfo) match {
         case Nil => Nil
         case RecordInfo(fst, _) :: Nil => fst

--- a/src/main/scala/shine/OpenCL/Compilation/KernelCodeGenerator.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/KernelCodeGenerator.scala
@@ -46,7 +46,7 @@ class KernelCodeGenerator(override val decls: CCodeGenerator.Declarations,
 
     case f: ocl.ParForNat =>
       f.body match {
-        case DepLambda(i: NatIdentifier, Lambda(o, p)) =>
+        case DepLambda(NatKind, i: NatIdentifier, Lambda(o, p)) =>
           OpenCLCodeGen.codeGenOpenCLParForNat(f, f.n, f.out, i, o, p, env)
         case _ => throw new Exception("This should not happen")
       }

--- a/src/main/scala/shine/OpenCL/Compilation/Passes/FlagPrivateArrayLoops.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/Passes/FlagPrivateArrayLoops.scala
@@ -1,7 +1,7 @@
 package shine.OpenCL.Compilation.Passes
 
 import shine.DPIA.Phrases._
-import shine.DPIA.Types.{CommType, PhraseType}
+import shine.DPIA.Types.{CommType, Kind, NatKind, PhraseType}
 import shine.DPIA.primitives.functional.{Idx, NatAsIndex}
 import shine.DPIA.primitives.imperative.{For, ForNat, IdxAcc}
 import shine.DPIA.{ArrayData, Nat, NatIdentifier}
@@ -67,8 +67,8 @@ object FlagPrivateArrayLoops {
           val i = f.loopBody.asInstanceOf[Lambda[_, _]].param
           eliminateVars -= i.name
           Continue(For(unroll = true)(f.n, f.loopBody), this)
-        case f@ForNat(_) if (eliminateVars(f.loopBody.asInstanceOf[DepLambda[_, _]].x.name)) =>
-          val i = f.loopBody.asInstanceOf[DepLambda[_, _]].x
+        case f@ForNat(_) if (eliminateVars(f.loopBody.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x.name)) =>
+          val i = f.loopBody.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x
           eliminateVars -= i.name
           Continue(ForNat(unroll = true)(f.n, f.loopBody), this)
         case pf@ParFor(level, dim, _, name) if (eliminateVars(pf.body.asInstanceOf[Lambda[_, _]].param.name)) =>
@@ -79,9 +79,9 @@ object FlagPrivateArrayLoops {
                 pf.init, pf.n, pf.step, pf.dt, pf.out, pf.body), this)
             case _ => throw new Exception("This should not happen")
           }
-        case pf@ParForNat(level, dim, _, name) if (eliminateVars(pf.body.asInstanceOf[DepLambda[_, _]].x.name)) =>
+        case pf@ParForNat(level, dim, _, name) if (eliminateVars(pf.body.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x.name)) =>
           pf.body match {
-            case DepLambda(i: NatIdentifier, _) =>
+            case DepLambda(NatKind, i: NatIdentifier, _) =>
               eliminateVars -= i.name
               Continue(ParForNat(level, dim, unroll = true, name)(
                 pf.init, pf.n, pf.step, pf.ft, pf.out, pf.body), this)

--- a/src/main/scala/shine/OpenCL/Compilation/Passes/InsertMemoryBarriers.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/Passes/InsertMemoryBarriers.scala
@@ -68,9 +68,9 @@ object InsertMemoryBarriers {
           }
         case f@ForNat(unroll) =>
           f.loopBody match {
-            case DepLambda(x, body) =>
+            case DepLambda(NatKind, x, body) =>
               Stop(ForNat(unroll)(f.n,
-                DepLambda[NatKind, CommType](x, visitLoopBody(body, allocs, metadata))))
+                DepLambda(NatKind, x, visitLoopBody(body, allocs, metadata))))
             case _ => throw new Exception("This should not happen")
           }
         case pf@ocl.ParFor(Local, dim, unroll, name) =>
@@ -92,19 +92,19 @@ object InsertMemoryBarriers {
           }
         case pf@ocl.ParForNat(Local, dim, unroll, name) =>
           pf.body match {
-            case DepLambda(i: NatIdentifier, Lambda(o, p)) =>
+            case DepLambda(NatKind, i: NatIdentifier, Lambda(o, p)) =>
               val outer_wg_writes = mutable.Map[Identifier[_ <: PhraseType], AddressSpace]()
               collectWrites(pf.out, allocs, outer_wg_writes)
               Stop(ocl.ParForNat(Local, dim, unroll, name)(pf.init, pf.n, pf.step, pf.ft, pf.out,
-                DepLambda[NatKind, AccType ->: CommType](i, Lambda(o,
+                DepLambda(NatKind, i, Lambda(o,
                   visitLoopBody(p, allocs, metadata, outer_wg_writes)))))
             case _ => throw new Exception("This should not happen")
           }
         case pf@ocl.ParForNat(level, dim, unroll, name) =>
           pf.body match {
-            case DepLambda(i: NatIdentifier, Lambda(o, p)) =>
+            case DepLambda(NatKind, i: NatIdentifier, Lambda(o, p)) =>
               Stop(ocl.ParForNat(level, dim, unroll, name)(pf.init, pf.n, pf.step, pf.ft, pf.out,
-                DepLambda[NatKind, AccType ->: CommType](i, Lambda(o,
+                DepLambda(NatKind, i, Lambda(o,
                   visitLoopBody(p, allocs, metadata)))))
             case _ => throw new Exception("This should not happen")
           }

--- a/src/main/scala/shine/OpenCL/Compilation/SeparateHostAndKernelCode.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/SeparateHostAndKernelCode.scala
@@ -33,14 +33,14 @@ object SeparateHostAndKernelCode {
         // on the fly beta-reduction
         case Apply(fun, arg) =>
           Stop(VisitAndRebuild(Lifting.liftFunction(fun).reducing(arg), this))
-        case DepApply(fun, arg) => arg match {
+        case DepApply(_, fun, arg) => arg match {
           case a: Nat =>
-            Stop(VisitAndRebuild(Lifting.liftDependentFunction[NatKind, ExpType](
-              fun.asInstanceOf[Phrase[NatKind `()->:` ExpType]])(a)
+            Stop(VisitAndRebuild(Lifting.liftDependentFunction(
+              fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a)
               .asInstanceOf[Phrase[T]], this))
           case a: DataType =>
-            Stop(VisitAndRebuild(Lifting.liftDependentFunction[DataKind, ExpType](
-              fun.asInstanceOf[Phrase[DataKind `()->:` ExpType]])(a)
+            Stop(VisitAndRebuild(Lifting.liftDependentFunction(
+              fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a)
               .asInstanceOf[Phrase[T]], this))
         }
 
@@ -59,7 +59,7 @@ object SeparateHostAndKernelCode {
                 ): (Phrase[_ <: PhraseType], Seq[Phrase[ExpType]]) = {
       freeNats match {
         case v +: rest => iterNats(
-          DepLambda[NatKind](NatIdentifier(v.name, v.range))(definition),
+          DepLambda(NatKind, NatIdentifier(v.name, v.range))(definition),
           Literal(NatAsIntData(v)) +: args, rest)
         case Nil => (definition, args)
       }
@@ -101,9 +101,9 @@ object SeparateHostAndKernelCode {
           Stop(p)
         case Lambda(x, _) =>
           Continue(p, this.copy(boundV = boundV + x))
-        case DepLambda(x: NatIdentifier, _) =>
+        case DepLambda(NatKind, x: NatIdentifier, _) =>
           Continue(p, this.copy(boundN = boundN + x))
-        case DepLambda(x: DataTypeIdentifier, _) =>
+        case DepLambda(DataKind, x: DataTypeIdentifier, _) =>
           Continue(p, this.copy(boundT = boundT + x))
         case _ => Continue(p, this)
       }

--- a/src/main/scala/shine/OpenCL/DSL/package.scala
+++ b/src/main/scala/shine/OpenCL/DSL/package.scala
@@ -26,7 +26,7 @@ package object DSL {
   def parForNat(level: ParallelismLevel,
                 dim: Int,
                 unroll: Boolean
-               ): (Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatKind, FunType[AccType, CommType]]]) => ParForNat =
+               ): (Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) => ParForNat =
     level match {
       case Global =>    ParForNat(level, dim, unroll, "gl_id_")(
         get_global_id(dim), _, get_global_size(dim), _, _, _)
@@ -39,7 +39,7 @@ package object DSL {
 
   private def parForBodyFunction(n:Nat, ft:NatToData,
                                  f:NatIdentifier => Phrase[AccType] => Phrase[CommType]
-                                ): DepLambda[NatKind, AccType ->: CommType] = {
+                                ): DepLambda[Nat, NatIdentifier, AccType ->: CommType] = {
     nFun(idx => λ(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1))
   }
 

--- a/src/main/scala/shine/OpenCL/primitives/functional/DepMap.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/DepMap.scala
@@ -7,16 +7,16 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class DepMap(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMap(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val m = f.t.x
-      DepFunType[NatKind, PhraseType](m, FunType(expT(NatToDataApply(ft1, m), read), expT(NatToDataApply(ft2, m), write)))
+      DepFunType(NatKind, m, FunType(expT(NatToDataApply(ft1, m), read), expT(NatToDataApply(ft2, m), write)))
     })
     array :: expT(DepArrayType(n, ft1), read)
     true
   }
   override val t: ExpType = expT(DepArrayType(n, ft2), write)
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): DepMap = new DepMap(level, dim)(v.nat(n), v.natToData(ft1), v.natToData(ft2), VisitAndRebuild(f, v), VisitAndRebuild(array, v))
-  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
+  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
 }

--- a/src/main/scala/shine/OpenCL/primitives/functional/Iterate.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/Iterate.scala
@@ -7,11 +7,11 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class Iterate(val a: AddressSpace, val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class Iterate(val a: AddressSpace, val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val l = f.t.x
-      DepFunType[NatKind, PhraseType](l, FunType(expT(ArrayType(l * n, dt), read), expT(ArrayType(l, dt), write)))
+      DepFunType(NatKind, l, FunType(expT(ArrayType(l * n, dt), read), expT(ArrayType(l, dt), write)))
     })
     array :: expT(ArrayType(m * n.pow(k), dt), read)
     true

--- a/src/main/scala/shine/OpenCL/primitives/imperative/ParForNat.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/ParForNat.scala
@@ -7,16 +7,16 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class ParForNat(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatKind, FunType[AccType, CommType]]]) extends CommandPrimitive {
+final case class ParForNat(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {
     out :: accT(DepArrayType(n, ft))
     body :: ({
       val i = body.t.x
-      DepFunType[NatKind, PhraseType](i, FunType(accT(NatToDataApply(ft, i)), comm))
+      DepFunType(NatKind, i, FunType(accT(NatToDataApply(ft, i)), comm))
     })
     true
   }
   override val t: CommType = comm
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): ParForNat = new ParForNat(level, dim, unroll, prefix)(v.nat(init), v.nat(n), v.nat(step), v.natToData(ft), VisitAndRebuild(out, v), VisitAndRebuild(body, v))
-  def unwrap: (Nat, Nat, Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatKind, FunType[AccType, CommType]]]) = (init, n, step, ft, out, body)
+  def unwrap: (Nat, Nat, Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) = (init, n, step, ft, out, body)
 }

--- a/src/main/scala/shine/OpenMP/CodeGenerator.scala
+++ b/src/main/scala/shine/OpenMP/CodeGenerator.scala
@@ -8,7 +8,7 @@ import shine.C.Compilation.{CodeGenerator => CCodeGenerator}
 import shine.DPIA.DSL._
 import shine.DPIA.primitives.imperative._
 import shine.DPIA.Phrases._
-import shine.DPIA.Types.{AccType, CommType, DataType, ExpType, PhraseType, ScalarType, VectorType}
+import shine.DPIA.Types.{AccType, CommType, DataType, ExpType, NatKind, PhraseType, ScalarType, VectorType}
 import shine.DPIA.primitives.functional._
 import shine.DPIA.{ArrayData, Compilation, Data, Nat, NatIdentifier, Phrases, VectorData, error, freshName}
 import shine.OpenMP.primitives.imperative.{ParFor, ParForNat}
@@ -38,7 +38,7 @@ class CodeGenerator(override val decls: CCodeGenerator.Declarations,
       OpenMPCodeGen.codeGenParFor(n, dt, a, i, o, p, env)
     case ForVec(n, dt, a, Lambda(i, Lambda(o, p))) =>
       OpenMPCodeGen.codeGenParForVec(n, dt, a, i, o, p, env)
-    case ParForNat(n, _, a, DepLambda(i, Lambda(o, p))) =>
+    case ParForNat(n, _, a, DepLambda(NatKind, i, Lambda(o, p))) =>
       OpenMPCodeGen.codeGenParForNat(n, a, i, o, p, env)
     case phrase => phrase |> super.cmd(env)
   }

--- a/src/main/scala/shine/OpenMP/primitives/functional/DepMapPar.scala
+++ b/src/main/scala/shine/OpenMP/primitives/functional/DepMapPar.scala
@@ -7,11 +7,11 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class DepMapPar(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatKind, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMapPar(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val m = f.t.x
-      DepFunType[NatKind, PhraseType](m, FunType(expT(NatToDataApply(ft1, m), read), expT(NatToDataApply(ft2, m), write)))
+      DepFunType(NatKind, m, FunType(expT(NatToDataApply(ft1, m), read), expT(NatToDataApply(ft2, m), write)))
     })
     array :: expT(DepArrayType(n, ft1), read)
     true

--- a/src/main/scala/shine/OpenMP/primitives/imperative/ParForNat.scala
+++ b/src/main/scala/shine/OpenMP/primitives/imperative/ParForNat.scala
@@ -7,12 +7,12 @@ import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
 import shine.DPIA._
-final case class ParForNat(val n: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatKind, FunType[AccType, CommType]]]) extends CommandPrimitive {
+final case class ParForNat(val n: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {
     out :: accT(DepArrayType(n, ft))
     body :: ({
       val i = body.t.x
-      DepFunType[NatKind, PhraseType](i, FunType(accT(NatToDataApply(ft, i)), comm))
+      DepFunType(NatKind, i, FunType(accT(NatToDataApply(ft, i)), comm))
     })
     true
   }

--- a/src/test/scala/apps/asum.scala
+++ b/src/test/scala/apps/asum.scala
@@ -31,8 +31,8 @@ class asum extends test_util.TestsWithExecutor {
   test("High level asum type inference works") {
     val typed = high_level.toExpr
 
-    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type]].x
-    assertResult(DepFunType[NatKind, Type](N, FunType(inputT(N), f32))) {
+    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
+    assertResult(DepFunType(NatKind, N, FunType(inputT(N), f32))) {
       typed.t
     }
   }

--- a/src/test/scala/apps/dot.scala
+++ b/src/test/scala/apps/dot.scala
@@ -24,9 +24,9 @@ class dot extends test_util.Tests {
   )))
 
   test("Simple dot product type inference works") {
-    val N = simpleDotProduct.t.asInstanceOf[NatDepFunType[_ <: Type]].x
+    val N = simpleDotProduct.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     assertResult(
-      DepFunType[NatKind, Type](N, FunType(xsT(N), FunType(ysT(N), f32)))
+      DepFunType(NatKind, N, FunType(xsT(N), FunType(ysT(N), f32)))
     ) {
       simpleDotProduct.t
     }

--- a/src/test/scala/apps/gemvCheck.scala
+++ b/src/test/scala/apps/gemvCheck.scala
@@ -14,13 +14,13 @@ class gemvCheck extends test_util.Tests {
   test("high-level gemv type inference works") {
     val typed = gemvHighLevel.toExpr
 
-    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type]].x
+    val N = typed.t.asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     val M = typed.t
-      .asInstanceOf[NatDepFunType[_ <: Type]].t
-      .asInstanceOf[NatDepFunType[_ <: Type]].x
+      .asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].t
+      .asInstanceOf[NatDepFunType[_ <: Type, _ <: Kind.Identifier]].x
     assertResult(
-      DepFunType(N,
-        DepFunType(M,
+      DepFunType(NatKind, N,
+        DepFunType(NatKind, M,
           ArrayType(M, ArrayType(N, f32)) ->:
             (ArrayType(N, f32) ->: (ArrayType(M, f32) ->:
             (f32 ->: (f32 ->: ArrayType(M, f32)))))

--- a/src/test/scala/apps/mmAutoTuning.scala
+++ b/src/test/scala/apps/mmAutoTuning.scala
@@ -176,16 +176,16 @@ class mmAutoTuning extends test_util.Tests {
 
   ignore("execute mm"){
     val goodParameters = Map(
-      NatIdentifier("gs0", isExplicit = true) -> (128: Nat),
-      NatIdentifier("gs1", isExplicit = true) -> (64: Nat),
-      NatIdentifier("ls0", isExplicit = true) -> (32: Nat),
-      NatIdentifier("ls1", isExplicit = true) -> (32: Nat),
-      NatIdentifier("v3", isExplicit = true) -> (4: Nat),
-      NatIdentifier("v4", isExplicit = true) -> (8: Nat),
-      NatIdentifier("v5", isExplicit = true) -> (64: Nat),
-      NatIdentifier("v6", isExplicit = true) -> (128: Nat),
-      NatIdentifier("v7", isExplicit = true) -> (128: Nat),
-      NatIdentifier("v8", isExplicit = true) -> (16: Nat),
+      TuningParameter("gs0") -> (128: Nat),
+      TuningParameter("gs1") -> (64: Nat),
+      TuningParameter("ls0") -> (32: Nat),
+      TuningParameter("ls1") -> (32: Nat),
+      TuningParameter("v3") -> (4: Nat),
+      TuningParameter("v4") -> (8: Nat),
+      TuningParameter("v5") -> (64: Nat),
+      TuningParameter("v6") -> (128: Nat),
+      TuningParameter("v7") -> (128: Nat),
+      TuningParameter("v8") -> (16: Nat),
     )
     val e: Expr = mmNVIDIA
 

--- a/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
+++ b/src/test/scala/apps/separableConvolution2DNaiveEqsat.scala
@@ -52,15 +52,15 @@ class separableConvolution2DNaiveEqsat extends test_util.Tests {
       case App(f, e) => everywhere(s)(f).map(App(_, e)(p.t)) ++ everywhere(s)(e).map(App(f, _)(p.t))
       case Identifier(_) => Nil
       case Lambda(x, e) => everywhere(s)(e).map(Lambda(x, _)(p.t))
-      case DepLambda(x, e) => x match {
+      case DepLambda(_, x, e) => x match {
         case n: NatIdentifier =>
-          everywhere(s)(e).map(DepLambda[NatKind](n, _)(p.t))
+          everywhere(s)(e).map(DepLambda(NatKind, n, _)(p.t))
         case n: DataTypeIdentifier =>
-          everywhere(s)(e).map(DepLambda[DataKind](n, _)(p.t))
+          everywhere(s)(e).map(DepLambda(DataKind, n, _)(p.t))
         case n: AddressSpaceIdentifier =>
-          everywhere(s)(e).map(DepLambda[AddressSpaceKind](n, _)(p.t))
+          everywhere(s)(e).map(DepLambda(AddressSpaceKind, n, _)(p.t))
       }
-      case DepApp(f, x) => everywhere(s)(f).map(DepApp(_, x)(p.t))
+      case DepApp(kind, f, x) => everywhere(s)(f).map(DepApp(kind, _, x)(p.t))
       case Literal(_) => Nil
       case _: TypeAnnotation => throw new Exception("Type annotations should be gone.")
       case _: TypeAssertion => throw new Exception("Type assertions should be gone.")

--- a/src/test/scala/rise/autotuning.scala
+++ b/src/test/scala/rise/autotuning.scala
@@ -121,12 +121,12 @@ class autotuning extends test_util.Tests {
 
   test("collect parameters") {
     val params = autotune.collectParameters(convolutionOclGsLsWrap)
-    assert(params.find(_.name == "vec").get.range == RangeAdd(0, 32, 1))
-    assert(params.find(_.name == "tile").get.range == RangeAdd(4, 32, 1))
-    assert(params.find(_.name == "ls0").get.range == RangeUnknown)
-    assert(params.find(_.name == "ls1").get.range == RangeUnknown)
-    assert(params.find(_.name == "gs0").get.range == RangeUnknown)
-    assert(params.find(_.name == "gs1").get.range == RangeUnknown)
+    assert(params.find(IsTuningParameter("vec")).get.range == RangeAdd(0, 32, 1))
+    assert(params.find(IsTuningParameter("tile")).get.range == RangeAdd(4, 32, 1))
+    assert(params.find(IsTuningParameter("ls0")).get.range == RangeUnknown)
+    assert(params.find(IsTuningParameter("ls1")).get.range == RangeUnknown)
+    assert(params.find(IsTuningParameter("gs0")).get.range == RangeUnknown)
+    assert(params.find(IsTuningParameter("gs1")).get.range == RangeUnknown)
     assert(params.size == 6)
   }
 
@@ -141,28 +141,28 @@ class autotuning extends test_util.Tests {
     println("constraints: \n" + constraints)
 
     val badParameters1 = Map(
-      NatIdentifier("vec", isExplicit = true) -> (5: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (15: Nat)
+      TuningParameter("vec") -> (5: Nat),
+      TuningParameter("tile") -> (15: Nat)
     )
     assert(!autotune.checkConstraints(constraints, badParameters1))
 
     val badParameters2 = Map(
-      NatIdentifier("vec", isExplicit = true) -> (4: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (13: Nat)
+      TuningParameter("vec") -> (4: Nat),
+      TuningParameter("tile") -> (13: Nat)
     )
     assert(!autotune.checkConstraints(constraints, badParameters2))
 
     /* FIXME: there is no `n >= tile` constraint collected
     val badParameters3 = Map(
-      NatIdentifier("vec", isExplicit = true) -> (8: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (64: Nat)
+      TuningParameter("vec") -> (8: Nat),
+      TuningParameter("tile") -> (64: Nat)
     )
     assert(!autotune.checkConstraints(constraints, badParameters3))
     */
 
     val goodParameters = Map(
-      NatIdentifier("vec", isExplicit = true) -> (4: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (16: Nat)
+      TuningParameter("vec") -> (4: Nat),
+      TuningParameter("tile") -> (16: Nat)
     )
     assert(autotune.checkConstraints(constraints, goodParameters))
     rise.core.substitute.natsInExpr(goodParameters, e)
@@ -241,7 +241,7 @@ class autotuning extends test_util.Tests {
           wrapOclRun(LocalSize(ls0, ls1), GlobalSize(gs0, gs1))(mmKernel)
         ))))
     val (nIdent, mIdent, oIdent) = e match {
-      case DepLambda(n: NatIdentifier, DepLambda(m: NatIdentifier, DepLambda(o: NatIdentifier, _))) =>
+      case DepLambda(NatKind, n: NatIdentifier, DepLambda(NatKind, m: NatIdentifier, DepLambda(NatKind, o: NatIdentifier, _))) =>
         (n, m, o)
       case _ => ???
     }
@@ -333,16 +333,16 @@ class autotuning extends test_util.Tests {
           nIdent -> n,
           mIdent -> m,
           oIdent -> o,
-          NatIdentifier("v3", isExplicit = true) -> v3,
-          NatIdentifier("v4", isExplicit = true) -> v4,
-          NatIdentifier("v5", isExplicit = true) -> v5,
-          NatIdentifier("v6", isExplicit = true) -> v6,
-          NatIdentifier("v7", isExplicit = true) -> v7,
-          NatIdentifier("v8", isExplicit = true) -> v8,
-          NatIdentifier("ls0", isExplicit = true) -> ls0,
-          NatIdentifier("ls1", isExplicit = true) -> ls1,
-          NatIdentifier("gs0", isExplicit = true) -> gs0,
-          NatIdentifier("gs1", isExplicit = true) -> gs1,
+          TuningParameter("v3") -> v3,
+          TuningParameter("v4") -> v4,
+          TuningParameter("v5") -> v5,
+          TuningParameter("v6") -> v6,
+          TuningParameter("v7") -> v7,
+          TuningParameter("v8") -> v8,
+          TuningParameter("ls0") -> ls0,
+          TuningParameter("ls1") -> ls1,
+          TuningParameter("gs0") -> gs0,
+          TuningParameter("gs1") -> gs1,
         )
         if (autotune.checkConstraints(constraints, map) != isGood) {
           val (sat, notSat) = constraints.partition(c =>
@@ -463,8 +463,8 @@ class autotuning extends test_util.Tests {
 
   test("execute convolution") {
     val goodParameters = Map(
-      NatIdentifier("vec", isExplicit = true) -> (4: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (16: Nat)
+      TuningParameter("vec") -> (4: Nat),
+      TuningParameter("tile") -> (16: Nat)
     )
 
     val e: Expr = convolutionOcl(32)
@@ -573,12 +573,12 @@ class autotuning extends test_util.Tests {
 
     // define parameters to break the code-gen
     val parameters = Map(
-      NatIdentifier("vec", isExplicit = true) -> (16: Nat),
-      NatIdentifier("tile", isExplicit = true) -> (32: Nat),
-      NatIdentifier("gs0", isExplicit = true) -> (1: Nat),
-      NatIdentifier("gs1", isExplicit = true) -> (512: Nat),
-      NatIdentifier("ls0", isExplicit = true) -> (1: Nat),
-      NatIdentifier("ls1", isExplicit = true) -> (64: Nat)
+      TuningParameter("vec") -> (16: Nat),
+      TuningParameter("tile") -> (32: Nat),
+      TuningParameter("gs0") -> (1: Nat),
+      TuningParameter("gs1") -> (512: Nat),
+      TuningParameter("ls0") -> (1: Nat),
+      TuningParameter("ls1") -> (64: Nat)
     )
 
     // substitute parameters

--- a/src/test/scala/rise/core/dependentTypes.scala
+++ b/src/test/scala/rise/core/dependentTypes.scala
@@ -153,12 +153,13 @@ class dependentTypes extends test_util.Tests {
     function.asStringFromExpr(inferred)
   }
 
-  test("Simple nested") {
+  // Relies on the explicitly dependent work
+  ignore("Simple nested") {
     val e = depFun((n: Nat) => fun(n `*.` (i => (i+1) `.` f32))(array =>
         depMapSeq(depFun((_: Nat) => mapSeq(fun(x => x))))(array)
       ))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     assert(inferred.t =~=
@@ -167,12 +168,13 @@ class dependentTypes extends test_util.Tests {
     function.asStringFromExpr(inferred)
   }
 
-  test("Simple reduce") {
+  // Relies on the explicitly dependent work
+  ignore("Simple reduce") {
     val e = depFun((n: Nat) => fun(n `*.` (i => (i+1) `.` f32))(array =>
       depMapSeq(depFun((_: Nat) => reduceSeq(fun(x => fun(y => x + y)))(lf32(0.0f))))(array)
     ))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     assert(inferred.t =~=
@@ -201,7 +203,7 @@ class dependentTypes extends test_util.Tests {
       }
     ))))
 
-    val inferred: Expr = inferDependent(e)
+    val inferred: Expr = infer(e)
     logger.debug(inferred)
     logger.debug(inferred.t)
     function.asStringFromExpr(inferred)

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -57,9 +57,8 @@ class showRise extends test_util.Tests {
         case i: Identifier => line(i.name)
         case Lambda(x, e)  => block(s"λ${x.name}", drawASTSimp(e))
         case App(f, e)     => drawASTSimp(f) :+> drawASTSimp(e)
-        case dl @ DepLambda(x, e) =>
-          block(s"Λ${x.name}:${dl.kindName}", drawASTSimp(e))
-        case DepApp(f, x)     => line(x.toString) <+: drawASTSimp(f)
+        case DepLambda(kind, x, e) => block(s"Λ${Kind.idName(kind, x)}:${kind.name}", drawASTSimp(e))
+        case DepApp(_, f, x)     => line(x.toString) <+: drawASTSimp(f)
         case Literal(d)       => line(d.toString)
         case TypeAnnotation(e, _) => drawASTSimp(e)
         case TypeAssertion(e, _) => drawASTSimp(e)
@@ -87,15 +86,15 @@ class showRise extends test_util.Tests {
           val es = lessBrackets(e, wrapped = true)
           if (wrapped) s"($fs $es)" else s"$fs $es"
 
-        case dl @ DepLambda(x, e) =>
-          val xs = s"${x.name}:${dl.kindName}"
+        case DepLambda(kind, x, e) =>
+          val xs = s"${Kind.idName(kind, x)}:${kind.name}"
           val es = lessBrackets(e)
           if (wrapped) s"[Λ$xs. $es]" else s"Λ$xs. $es"
 
-        case DepApp(f, x) =>
+        case DepApp(_, f, x) =>
           val fs = f match {
-            case _: DepLambda[_] => lessBrackets(f, wrapped = true)
-            case _               => lessBrackets(f)
+            case _: DepLambda[_, _, _] => lessBrackets(f, wrapped = true)
+            case _                     => lessBrackets(f)
           }
           if (wrapped) s"($fs $x)" else s"$fs $x"
 

--- a/src/test/scala/rise/core/traverseTest.scala
+++ b/src/test/scala/rise/core/traverseTest.scala
@@ -22,7 +22,7 @@ class traverseTest extends test_util.Tests {
 
   class TypeTraceVisitor extends PureAccumulatorTraversal[Seq[Any]] {
     override val accumulator = SeqMonoid[Any]
-    override def typeIdentifier[I <: Kind.Identifier] : VarType => I => Pair[I] =
+    override def typeIdentifier[I <: Kind.Identifier]: VarType => I => Pair[I] =
       vt => i => accumulate(Seq(i))(i)
   }
 

--- a/src/test/scala/rise/elevate/algorithmic.scala
+++ b/src/test/scala/rise/elevate/algorithmic.scala
@@ -63,17 +63,17 @@ class algorithmic extends test_util.Tests {
   // Swap Nesting of map and reduce
 
   test("lift reduce") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
 
     val addTuple = fun(x => fst(x) + snd(x))
 
-    val mapReduce = depLambda[NatKind](M, depLambda[NatKind](N,
+    val mapReduce = depLambda(NatKind, M, depLambda(NatKind, N,
       fun(ArrayType(M, ArrayType(N, f32)))(i =>
         map(reduce(fun(x => fun(a => x + a)))(lf32(0.0f))) $ i)))
 
     val reduceMap: Rise =
-      depLambda[NatKind](M, depLambda[NatKind](N,
+      depLambda(NatKind, M, depLambda(NatKind, N,
         fun(ArrayType(M, ArrayType(N, f32)))(i =>
           reduce(fun((acc, y) =>
             map(addTuple) $ zip(acc)(y)))(generate(fun(IndexType(M) ->: f32)(_ => lf32(0.0f)))) $ transpose(i))))
@@ -90,11 +90,11 @@ class algorithmic extends test_util.Tests {
   // Tests and Expressions related to loop reordering in Matrix Multiplication
 
   test("MM to MM-LoopMKN") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
-    val mm = depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+    val mm = depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
       fun(ArrayType(M, ArrayType(K, f32)))(a =>
         fun(ArrayType(K, ArrayType(N, f32)))(b =>
           a |> map(fun(ak =>
@@ -104,7 +104,7 @@ class algorithmic extends test_util.Tests {
                   lf32(0.0f)))))))))))
 
     def goldMKN(reduceFun: ToBeTyped[Rise]): ToBeTyped[Rise] = {
-      depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+      depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>
             a |> map(fun(ak =>
@@ -140,12 +140,12 @@ class algorithmic extends test_util.Tests {
 
   // This one just serves as documentation for different mm-rise-expressions
   ignore("MM-LoopMKN to MM-LoopKMN") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
     val mmMKN = {
-      depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+      depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>
             map(fun(ak =>
@@ -197,7 +197,7 @@ class algorithmic extends test_util.Tests {
 
     // this one is constructed more similar to what the rewrite rules will create
     val goldKMNAlternative =
-      depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+      depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>
             reduceSeq(
@@ -216,7 +216,7 @@ class algorithmic extends test_util.Tests {
 
     // unfortunately, the order of zip arguments is important
     val goldKMNAlternative2 =
-      depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+      depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
         fun(ArrayType(M, ArrayType(K, f32)))(a =>
           fun(ArrayType(K, ArrayType(N, f32)))(b =>
             reduceSeq(
@@ -268,12 +268,12 @@ class algorithmic extends test_util.Tests {
 
   // todo remove once PLDI-TVM tests are in
   ignore("mm tile + reorder") {
-    val M = NatIdentifier("M", isExplicit = true)
-    val N = NatIdentifier("N", isExplicit = true)
-    val K = NatIdentifier("K", isExplicit = true)
+    val M = NatIdentifier("M")
+    val N = NatIdentifier("N")
+    val K = NatIdentifier("K")
 
     val mm =
-      DFNF(depLambda[NatKind](M, depLambda[NatKind](N, depLambda[NatKind](K,
+      DFNF(depLambda(NatKind, M, depLambda(NatKind, N, depLambda(NatKind, K,
       fun(ArrayType(M, ArrayType(K, f32)))(a =>
         fun(ArrayType(K, ArrayType(N, f32)))(b =>
           map(fun(ak =>

--- a/src/test/scala/rise/elevate/tiling.scala
+++ b/src/test/scala/rise/elevate/tiling.scala
@@ -249,7 +249,7 @@ class tiling extends test_util.Tests {
   def wrapInLambda[T <: Expr](dim: Int,
                               f: ToBeTyped[Identifier] => ToBeTyped[T],
                               genInputType: List[Nat] => ArrayType,
-                              natIds: List[Nat] = List()): ToBeTyped[DepLambda[NatKind]] = {
+                              natIds: List[Nat] = List()): ToBeTyped[DepLambda[Nat, NatIdentifier, _]] = {
     dim match {
       case 1 => depFun((n: Nat) => fun(genInputType( natIds :+ n))(f))
       case d => depFun((n: Nat) => wrapInLambda(d - 1, f, genInputType, natIds :+ n))

--- a/src/test/scala/rise/elevate/traversals.scala
+++ b/src/test/scala/rise/elevate/traversals.scala
@@ -6,7 +6,8 @@ import rise.elevate.util._
 import rise.core.DSL._
 import rise.core.makeClosed
 import rise.core.primitives._
-import rise.core.types.NatKind
+import rise.core.types.Kind.INat
+import rise.core.types.{Nat, NatKind}
 import rise.elevate.meta.fission.bodyFission
 import rise.elevate.meta.traversal.inBody
 import rise.elevate.rules.algorithmic._
@@ -69,8 +70,8 @@ class traversals extends test_util.Tests {
   }
 
   test("RNF did not normalize") {
-    val expr2 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η125"), app(app(map, lambda(identifier("ee3"), app(join, app(app(map, lambda(identifier("η124"), app(app(map, lambda(identifier("η123"), app(identifier("ee2"), identifier("η123")))), identifier("η124")))), app(depApp[NatKind](split, 4), identifier("ee3")))))), identifier("η125")))), app(depApp[NatKind](split, 4), identifier("ee1"))))))
-    val expr5 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η141"), app(app(map, lambda(identifier("η140"), app(join, identifier("η140")))), identifier("η141")))), app(app(map, lambda(identifier("η145"), app(app(map, lambda(identifier("η144"), app(app(map, lambda(identifier("η143"), app(app(map, lambda(identifier("η142"), app(identifier("ee2"), identifier("η142")))), identifier("η143")))), identifier("η144")))), identifier("η145")))), app(app(map, lambda(identifier("η147"), app(app(map, lambda(identifier("η146"), app(depApp[NatKind](split, 4), identifier("η146")))), identifier("η147")))), app(depApp[NatKind](split, 4), identifier("ee1"))))))))
+    val expr2 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η125"), app(app(map, lambda(identifier("ee3"), app(join, app(app(map, lambda(identifier("η124"), app(app(map, lambda(identifier("η123"), app(identifier("ee2"), identifier("η123")))), identifier("η124")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee3")))))), identifier("η125")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee1"))))))
+    val expr5 = lambda(identifier("ee1"), lambda(identifier("ee2"), app(join, app(app(map, lambda(identifier("η141"), app(app(map, lambda(identifier("η140"), app(join, identifier("η140")))), identifier("η141")))), app(app(map, lambda(identifier("η145"), app(app(map, lambda(identifier("η144"), app(app(map, lambda(identifier("η143"), app(app(map, lambda(identifier("η142"), app(identifier("ee2"), identifier("η142")))), identifier("η143")))), identifier("η144")))), identifier("η145")))), app(app(map, lambda(identifier("η147"), app(app(map, lambda(identifier("η146"), app(depApp[Nat, INat](NatKind, split, 4), identifier("η146")))), identifier("η147")))), app(depApp[Nat, INat](NatKind, split, 4), identifier("ee1"))))))))
 
     assert(makeClosed(RNF(expr2).get) =~= makeClosed(toExpr(expr5)))
   }

--- a/src/test/scala/rise/elevate/util/package.scala
+++ b/src/test/scala/rise/elevate/util/package.scala
@@ -19,7 +19,7 @@ package object util {
 
   // notation
   def T: ToBeTyped[Rise] = transpose
-  def S: ToBeTyped[DepApp[NatKind]] = split(tileSize) //slide(3)(1)
+  def S: ToBeTyped[DepApp[Nat, _]] = split(tileSize) //slide(3)(1)
   def J: ToBeTyped[Rise] = join
   def *(x: ToBeTyped[Rise]): ToBeTyped[App] = map(x)
   def **(x: ToBeTyped[Rise]): ToBeTyped[App] = map(map(x))

--- a/src/test/scala/shine/DPIA/InferAccessTypes.scala
+++ b/src/test/scala/shine/DPIA/InferAccessTypes.scala
@@ -102,7 +102,7 @@ class InferAccessTypes extends test_util.Tests {
     val splitArray = (depFun((n: Nat) => fun(8`.`rt.f32)(arr =>
       arr |> split(n)))).toExpr
     val infPt = inferAccess(splitArray).get(splitArray).asInstanceOf[
-      DepFunType[NatKind, FunType[ExpType, ExpType]]
+      DepFunType[NatIdentifier, FunType[ExpType, ExpType]]
     ]
     assertResult(read)(infPt.t.outT.accessType)
   }

--- a/src/test/scala/shine/cuda/MMTest.scala
+++ b/src/test/scala/shine/cuda/MMTest.scala
@@ -98,7 +98,7 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Kernel
     val simpleMatMulTile =
-      DepLambda[NatKind](k)(
+      DepLambda(NatKind, k)(
         Lambda[ExpType, FunType[ExpType, ExpType]](matrixATile,
           Lambda[ExpType, ExpType](matrixBTile,
             AsMatrix(mTile, nTile, kTile, f32,
@@ -196,9 +196,9 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Kernel
     val simpleMatMul =
-      DepLambda[NatKind](m)(
-        DepLambda[NatKind](n)(
-          DepLambda[NatKind](k)(
+      DepLambda(NatKind, m)(
+        DepLambda(NatKind, n)(
+          DepLambda(NatKind, k)(
             //Input: matrixA
             Lambda[ExpType, FunType[ExpType, ExpType]](matrixA,
               //And matrixB

--- a/src/test/scala/shine/cuda/basic.scala
+++ b/src/test/scala/shine/cuda/basic.scala
@@ -1,7 +1,6 @@
 package shine.cuda
 
 import shine.DPIA.DSL.{depFun, λ}
-import shine.DPIA.Types.Kind.NatIdentifierMaker
 import shine.DPIA.Types.{NatKind, _}
 import shine.OpenCL.{Global, Local}
 import util.gen
@@ -9,7 +8,7 @@ import util.gen
 class basic extends test_util.Tests {
 
   test("id with mapThreads compiles to syntactically correct Cuda") {
-    val mapId = depFun[NatKind]()(n =>
+    val mapId = depFun(NatKind)(n =>
       λ(ExpType(ArrayType(n, f32), read))(array =>
         shine.cuda.primitives.functional.Map(Local, 'x')(n, f32, f32, λ(ExpType(f32, read))(x => x), array))
     )
@@ -19,7 +18,7 @@ class basic extends test_util.Tests {
   }
 
   test("id with mapGlobal compiles to syntactically correct CUDA") {
-    val mapId = depFun[NatKind]()(n =>
+    val mapId = depFun(NatKind)(n =>
       λ(ExpType(ArrayType(n, f32), read))(array =>
         shine.cuda.primitives.functional.Map(Global, 'x')(n, f32, f32, λ(ExpType(f32, read))(x => x), array))
     )


### PR DESCRIPTION
Gets rid of `NatIdentifier.isTuningParam` which cannot be used anymore and replaces it with a name prefix instead as a quick fix.
On my laptop all the autotuning tests are passing except the auto-tuning search one because of my python/hypermapper setup I believe. On the CI there is also some failing although I am not sure what is failing exactly.
Easiest way to review the changes: https://github.com/rise-lang/shine/pull/187/commits/fdbf71d13dc9cf64f0f90eb2ab140f9b85ff527a