### PR TITLE
Do not extend `NamedVar` with `Kind.Identifier` in DPIA

### DIFF
--- a/meta/src/main/scala/meta/generator/DPIAPrimitives.scala
+++ b/meta/src/main/scala/meta/generator/DPIAPrimitives.scala
@@ -42,6 +42,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{Identifier => _, _}
 import shine.DPIA._
 
 ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), params, returnType)}
@@ -140,7 +141,7 @@ ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), param
     case DPIA.Type.AST.CommType               => t"CommType"
     case DPIA.Type.AST.PairType(lhs, rhs) => t"PhrasePairType[${generatePhraseType(lhs)}, ${generatePhraseType(rhs)}]"
     case DPIA.Type.AST.FunType(inT, outT) => t"FunType[${generatePhraseType(inT)}, ${generatePhraseType(outT)}]"
-    case DPIA.Type.AST.DepFunType(id, kind, t) => t"DepFunType[${generateKindIdentifierType(kind)}, ${generatePhraseType(t)}]"
+    case DPIA.Type.AST.DepFunType(id, kind, t) => t"DepFunType[${generateKindIdentifierType(kind)}, ${generateKindIdentifierConstr(kind)}, ${generatePhraseType(t)}]"
     case DPIA.Type.AST.Identifier(name) => Type.Name(name)
     case DPIA.Type.AST.VariadicType(_, _) => throw new Exception("Can not generate Phrase Type for Variadic Type")
   }
@@ -156,6 +157,20 @@ ${generateCaseClass(Type.Name(name), toParamList(definition, scalaParams), param
       case rise.Kind.AST.MatrixLayout => throw new Exception("Can not generate Kind for Matrix Layout")
     }
     case DPIA.Kind.AST.Access =>        Type.Name("AccessTypeIdentifier")
+    case DPIA.Kind.AST.VariadicKind(_, _) => throw new Exception("Can not generate Kind for Variadic Kind")
+  }
+
+  def generateKindIdentifierConstr(kindAST: DPIA.Kind.AST): scala.meta.Type = kindAST match {
+    case DPIA.Kind.AST.RiseKind(riseKind) => riseKind match {
+      case rise.Kind.AST.Data =>      Type.Name("IDataType")
+      case rise.Kind.AST.Address =>   Type.Name("IAddressSpace")
+      case rise.Kind.AST.Nat2Nat =>   Type.Name("INatToNat")
+      case rise.Kind.AST.Nat2Data =>  Type.Name("INatToData")
+      case rise.Kind.AST.Nat =>       Type.Name("INat")
+      case rise.Kind.AST.Fragment => throw new Exception("Can not generate Kind for Fragment")
+      case rise.Kind.AST.MatrixLayout => throw new Exception("Can not generate Kind for Matrix Layout")
+    }
+    case DPIA.Kind.AST.Access =>        Type.Name("IAccessType")
     case DPIA.Kind.AST.VariadicKind(_, _) => throw new Exception("Can not generate Kind for Variadic Kind")
   }
 

--- a/src/main/scala/rise/core/types/Kinds.scala
+++ b/src/main/scala/rise/core/types/Kinds.scala
@@ -6,7 +6,7 @@ sealed trait Kind[+T, +I, +KI <: Kind.Identifier] {
 
 
 object Kind {
-  trait Identifier { def name: String }
+  sealed trait Identifier { def name: String }
   case class IType(id : TypeIdentifier) extends Identifier { def name : String = id.name }
   case class IDataType(id : DataTypeIdentifier) extends Identifier { def name : String = id.name }
   case class INat(id : NatIdentifier) extends Identifier { def name : String = id.name }

--- a/src/main/scala/shine/C/Compilation/CodeGenerator.scala
+++ b/src/main/scala/shine/C/Compilation/CodeGenerator.scala
@@ -136,9 +136,9 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
       case Apply(fun, arg) => Lifting.liftFunction(fun).reducing(arg) |> cmd(env)
       case DepApply(kind, fun, arg) => arg match {
         case a: Nat =>
-          Lifting.liftDependentFunction(fun.asInstanceOf[Phrase[NatIdentifier `()->:` CommType]])(a) |> cmd(env)
+          Lifting.liftDependentFunction(fun.asInstanceOf[Phrase[`(nat)->:`[CommType]]])(a) |> cmd(env)
         case a: DataType =>
-          Lifting.liftDependentFunction(fun.asInstanceOf[Phrase[NatIdentifier `()->:` CommType]])(a) |> cmd(env)
+          Lifting.liftDependentFunction(fun.asInstanceOf[Phrase[`(nat)->:`[CommType]]])(a) |> cmd(env)
       }
 
       case DMatchI(x, inT, _, f, dPair) =>
@@ -638,7 +638,7 @@ class CodeGenerator(val decls: CodeGenerator.Declarations,
         case None => error("Parameter missing")
         case Some(Left(param)) => generateInlinedCall(l(param), env, args.tail, cont)
       }
-      case ndl: DepLambda[Nat, NatIdentifier, _]@unchecked => args.headOption match {
+      case ndl: DepLambda[Nat, NatIdentifier, Kind.INat, _]@unchecked => args.headOption match {
         case Some(Right(nat)) => generateInlinedCall(ndl(nat), env, args.tail, cont)
         case None => error("Parameter missing")
         case Some(Left(_)) => error("Expression phrase argument passed but nat expected")

--- a/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
@@ -28,10 +28,10 @@ object AcceptorTranslation {
       case DepApply(kind, fun, arg) => arg match {
         case a: Nat =>
           acc(Lifting.liftDependentFunction(
-            fun.asInstanceOf[ Phrase[NatIdentifier `()->:` ExpType]])(a))(A)
+            fun.asInstanceOf[ Phrase[`(nat)->:`[ExpType]]])(a))(A)
         case a: DataType =>
           acc(Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(A)
+            fun.asInstanceOf[Phrase[`(dt)->:`[ExpType]]])(a))(A)
       }
 
       case e

--- a/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
@@ -47,10 +47,10 @@ object ContinuationTranslation {
       case DepApply(kind, fun, arg) => arg match {
         case a: Nat =>
           con(Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a))(C)
+            fun.asInstanceOf[Phrase[`(nat)->:`[ExpType]]])(a))(C)
         case a: DataType =>
           con(Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(C)
+            fun.asInstanceOf[Phrase[`(dt)->:`[ExpType]]])(a))(C)
       }
 
       case IfThenElse(cond, thenP, elseP) =>

--- a/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
@@ -29,10 +29,10 @@ object FedeTranslation {
       case DepApply(kind, fun, arg) => arg match {
         case a: Nat => fedAcc(env)(
           Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a))(C)
+            fun.asInstanceOf[Phrase[`(nat)->:`[ExpType]]])(a))(C)
         case a: DataType => fedAcc(env)(
           Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a))(C)
+            fun.asInstanceOf[Phrase[`(dt)->:`[ExpType]]])(a))(C)
       }
 
       case IfThenElse(cond, thenP, elseP) => ???

--- a/src/main/scala/shine/DPIA/Compilation/FunDef.scala
+++ b/src/main/scala/shine/DPIA/Compilation/FunDef.scala
@@ -30,9 +30,9 @@ class FunDef(val name: String,
         splitBodyAndParams(Lifting.liftDependentFunction(f)(a), ps, defs)
       case l: Lambda[ExpType, _]@unchecked =>
         splitBodyAndParams(l.body, l.param +: ps, defs)
-      case ndl: DepLambda[_, _, _] =>
+      case ndl: DepLambda[_, _, _, _] =>
         splitBodyAndParams(ndl.body,
-          Identifier(ndl.x.name, ExpType(int, read)) +: ps, defs)
+          Identifier(Kind.idName(ndl.kind, ndl.x), ExpType(int, read)) +: ps, defs)
       case ln:LetNat[ExpType, _]@unchecked =>
         splitBodyAndParams(ln.body, ps, (ln.binder, ln.defn) +: defs)
       case ep: Phrase[ExpType]@unchecked => (ep, ps.reverse, defs.reverse)

--- a/src/main/scala/shine/DPIA/Compilation/StreamTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/StreamTranslation.scala
@@ -26,11 +26,11 @@ object StreamTranslation {
       case DepApply(_, fun, arg) => arg match {
         case a: Nat => str(
           Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a)
+            fun.asInstanceOf[Phrase[`(nat)->:`[ExpType]]])(a)
         )(C)
         case a: DataType => str(
           Lifting.liftDependentFunction(
-            fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a)
+            fun.asInstanceOf[Phrase[`(dt)->:`[ExpType]]])(a)
         )(C)
       }
 

--- a/src/main/scala/shine/DPIA/DSL/Core.scala
+++ b/src/main/scala/shine/DPIA/DSL/Core.scala
@@ -26,17 +26,17 @@ object λ extends funDef
 
 object nFun {
   def apply[T <: PhraseType](f: NatIdentifier => Phrase[T],
-                             range: arithexpr.arithmetic.Range): DepLambda[Nat, NatIdentifier, T] = {
+                             range: arithexpr.arithmetic.Range): DepLambda[Nat, NatIdentifier, Kind.INat, T] = {
     val x = NatIdentifier(freshName("n"), range)
     DepLambda(NatKind, x, f(x))
   }
 }
 
 trait depFunDef {
-  def apply[T, I <: Kind.Identifier](kind: Kind[T, I]): Object {
-    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U]
+  def apply[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI]): Object {
+    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, KI, U]
   } = new {
-    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U] = {
+    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, KI, U] = {
       val x = kind.makeIdentifier
       DepLambda(kind, x, f(x))
     }

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -207,7 +207,7 @@ private class InferAccessAnnotation {
     val depLambdaType =
       depLambda.x match {
         case n: rt.NatIdentifier =>
-          DepFunType(NatKind, natIdentifier(n), eType)
+          DepFunType(NatKind, n, eType)
         case dt: rt.DataTypeIdentifier =>
           DepFunType(DataKind, dataTypeIdentifier(dt), eType)
         case ad: rt.AddressSpaceIdentifier =>
@@ -304,8 +304,8 @@ private class InferAccessAnnotation {
           (gs1 `(Nat)->:` (gs2 `(Nat)->:` (gs3 `(Nat)->:`
           ((t: rt.DataType) ->: (_: rt.DataType))
         ))))) =>
-          nFunT(fromRise.natIdentifier(ls1), nFunT(fromRise.natIdentifier(ls2), nFunT(fromRise.natIdentifier(ls3),
-            nFunT(fromRise.natIdentifier(gs1), nFunT(fromRise.natIdentifier(gs2), nFunT(fromRise.natIdentifier(gs3),
+          nFunT(ls1, nFunT(ls2, nFunT(ls3,
+            nFunT(gs1, nFunT(gs2, nFunT(gs3,
               expT(t, write) ->: expT(t, write)))))))
         case _ => error()
       }
@@ -350,7 +350,7 @@ private class InferAccessAnnotation {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(fromRise.natIdentifier(n), expT(dt1, ai) ->: expT(dt2, ai))
+          nFunT(n, expT(dt1, ai) ->: expT(dt2, ai))
         case _ => error()
       }
 
@@ -377,7 +377,7 @@ private class InferAccessAnnotation {
 
       case rp.natAsIndex() | rp.take() | rp.drop() => p.t match {
         case n `(Nat)->:` ((dt1: rt.DataType) ->: (dt2: rt.DataType)) =>
-          nFunT(fromRise.natIdentifier(n), expT(dt1, read) ->: expT(dt2, read))
+          nFunT(n, expT(dt1, read) ->: expT(dt2, read))
         case _ => error()
       }
 
@@ -414,7 +414,7 @@ private class InferAccessAnnotation {
         case tile `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(fromRise.natIdentifier(tile),
+          nFunT(tile,
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, write))
         case _ => error()
@@ -425,7 +425,7 @@ private class InferAccessAnnotation {
         case  sz `(Nat)->:`
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)) =>
-          nFunT(fromRise.natIdentifier(sz),
+          nFunT(sz,
             (expT(s, read) ->: expT(s, write)) ->:
             expT(inT, read) ->: expT(outT, read))
         case _ => error()
@@ -435,7 +435,7 @@ private class InferAccessAnnotation {
         case alloc `(Nat)->:` (sz `(Nat)->:`
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
-          nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
+          nFunT(alloc, nFunT(sz,
             (expT(s, read) ->: expT(t, write)) ->:
             expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -446,7 +446,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (_: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType))) =>
           aFunT(a,
-            nFunT(fromRise.natIdentifier(sz),
+            nFunT(sz,
               (expT(s, read) ->: expT(s, write)) ->:
               expT(inT, read) ->: expT(outT, read)))
         case _ => error()
@@ -457,7 +457,7 @@ private class InferAccessAnnotation {
           (((s: rt.DataType) ->: (t: rt.DataType)) ->:
             (inT: rt.ArrayType) ->: (outT: rt.ArrayType)))) =>
 
-          aFunT(a, nFunT(fromRise.natIdentifier(alloc), nFunT(fromRise.natIdentifier(sz),
+          aFunT(a, nFunT(alloc, nFunT(sz,
             (expT(s, read) ->: expT(t, write)) ->:
               expT(inT, read) ->: expT(outT, read))))
         case _ => error()
@@ -466,7 +466,7 @@ private class InferAccessAnnotation {
       case rp.slide() | rp.padClamp() => p.t match {
         case sz `(Nat)->:` (sp `(Nat)->:`
           ((dt1: rt.DataType) ->: (dt2: rt.DataType))) =>
-          nFunT(fromRise.natIdentifier(sz), nFunT(fromRise.natIdentifier(sp),
+          nFunT(sz, nFunT(sp,
             expT(dt1, read) ->: expT(dt2, read)))
         case _ => error()
       }
@@ -475,8 +475,8 @@ private class InferAccessAnnotation {
         case k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType)) =>
-          nFunT(fromRise.natIdentifier(k),
-            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
+          nFunT(k,
+            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
             expT(at3, read) ->: expT(at4, write) )
         case _ => error()
       }
@@ -485,8 +485,8 @@ private class InferAccessAnnotation {
         case a `(Addr)->:` (k `(Nat)->:`
           ((l `(Nat)->:` ((at1: rt.ArrayType) ->: (at2: rt.ArrayType))) ->:
             (at3: rt.ArrayType) ->: (at4: rt.ArrayType))) =>
-          aFunT(a, nFunT(fromRise.natIdentifier(k),
-            nFunT(fromRise.natIdentifier(l), expT(at1, read) ->: expT(at2, write)) ->:
+          aFunT(a, nFunT(k,
+            nFunT(l, expT(at1, read) ->: expT(at2, write)) ->:
               expT(at3, read) ->: expT(at4, write) ))
         case _ => error()
       }
@@ -502,7 +502,7 @@ private class InferAccessAnnotation {
 
       case rp.padEmpty() => p.t match {
         case r `(Nat)->:` ((n`.`t) ->: (_`.`_)) =>
-          nFunT(fromRise.natIdentifier(r), expT(n`.`t, write) ->: expT((n + r)`.`t, write))
+          nFunT(r, expT(n`.`t, write) ->: expT((n + r)`.`t, write))
         case _ => error()
       }
 
@@ -510,7 +510,7 @@ private class InferAccessAnnotation {
         case l `(Nat)->:` (q `(Nat)->:`
           ((t: rt.DataType) ->: (n`.`_) ->: (_`.`_))) =>
 
-          nFunT(fromRise.natIdentifier(l), nFunT(fromRise.natIdentifier(q),
+          nFunT(l, nFunT(q,
             expT(t, read) ->: expT(n`.`t, read) ->:
               expT((l + n + q)`.`t, read)))
         case _ => error()
@@ -527,7 +527,7 @@ private class InferAccessAnnotation {
         case (n `(Nat)->:` (idxF `(NatToNat)->:` (idxFinv `(NatToNat)->:` ((_`.`t) ->: (_`.`_) )))) =>
 
           val ai = accessTypeIdentifier()
-          nFunT(fromRise.natIdentifier(n), n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
+          nFunT(n, n2nFunT(idxF, n2nFunT(idxFinv, expT(n`.`t, ai) ->: expT(n`.`t, ai))))
         case _ => error()
       }
 
@@ -556,8 +556,7 @@ private class InferAccessAnnotation {
         def buildType(t: rt.Type): PhraseType = t match {
           case rt.FunType(rt.DepFunType(rt.NatKind, i: rt.NatIdentifier, rt.FunType(elemInT:rt.DataType, elemOutT:rt.DataType)),
             rt.FunType(inArr@rt.DepArrayType(_, _), outArr@rt.DepArrayType(_, _))) =>
-            val iNat = natIdentifier(i)
-            nFunT(iNat, expT(dataType(elemInT), read) ->: expT(dataType(elemOutT), write)) ->:
+            nFunT(i, expT(dataType(elemInT), read) ->: expT(dataType(elemOutT), write)) ->:
               expT(dataType(inArr), read) ->: expT(dataType(outArr), write)
           case _ => error("did not expect t")
         }
@@ -570,9 +569,8 @@ private class InferAccessAnnotation {
             rt.FunType(rt.DepFunType(rt.NatKind, i: rt.NatIdentifier,
               rt.FunType(app1:rt.DataType, outT:rt.DataType)), retT:rt.DataType)) =>
 
-            val i_ = natIdentifier(i.asInstanceOf[rt.NatIdentifier])
-            expT(DepPairType(natIdentifier(x), dataType(elemT)), read) ->:
-              nFunT(i_, expT(dataType(app1), read) ->: expT(dataType(outT), a)) ->:
+            expT(DepPairType(x, dataType(elemT)), read) ->:
+              nFunT(i, expT(dataType(app1), read) ->: expT(dataType(outT), a)) ->:
                 expT(dataType(retT), a)
           case _ => error(s"did not expect t")
         }
@@ -582,8 +580,7 @@ private class InferAccessAnnotation {
         def buildType(t: rt.Type): PhraseType = t match {
           case rt.DepFunType(rt.NatKind, fst: rt.NatIdentifier, rt.FunType(sndT:rt.DataType, outT:rt.DataType)) =>
             val a1 = accessTypeIdentifier()
-            val fst_ = natIdentifier(fst)
-            nFunT(fst_, expT(dataType(sndT), a1) ->: expT(dataType(outT), a1))
+            nFunT(fst, expT(dataType(sndT), a1) ->: expT(dataType(outT), a1))
 
           case _ => error(s"did not expect $t")
         }
@@ -667,7 +664,7 @@ private class InferAccessAnnotation {
       case dt: rt.DataTypeIdentifier =>
         dataTypeIdentifier(dt) ->: `type`(t)
       case n: rt.NatIdentifier =>
-        natIdentifier(n) ->: `type`(t)
+        n ->: `type`(t)
       case n2n: rt.NatToNatIdentifier =>
         natToNatIdentifier(n2n) ->: `type`(t)
       case n2d: rt.NatToDataIdentifier =>

--- a/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
+++ b/src/main/scala/shine/DPIA/InferAccessAnnotation.scala
@@ -681,8 +681,8 @@ private class InferAccessAnnotation {
     case (rt.FunType(inT, outT), FunType(inPT, outPT)) =>
       checkConsistency(inT, inPT)
       checkConsistency(outT, outPT)
-    case (rt.DepFunType(k, x, t), DepFunType(_, y, pt)) =>
-      if (rt.Kind.idName(k, x) != y.name) error(s"Identifiers $x and $y differ")
+    case (rt.DepFunType(kx, x, t), DepFunType(ky, y, pt)) =>
+      if (rt.Kind.idName(kx, x) != Kind.idName(ky, y)) error(s"Identifiers $x and $y differ")
       checkConsistency(t, pt)
     case (dt: rt.DataType, ExpType(dpt: DataType, _)) =>
 

--- a/src/main/scala/shine/DPIA/Phrases/Phrase.scala
+++ b/src/main/scala/shine/DPIA/Phrases/Phrase.scala
@@ -38,21 +38,21 @@ final case class Apply[T1 <: PhraseType, T2 <: PhraseType](fun: Phrase[T1 ->: T2
   override def toString: String = s"($fun $arg)"
 }
 
-final case class DepLambda[T, I <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I], x: I, body: Phrase[U])
-  extends Phrase[I `()->:` U] {
-  override val t: DepFunType[I, U] = DepFunType[I, U](kind, x, body.t)
-  override def toString: String = s"Λ(${x.name} : ${kind.name}). $body"
+final case class DepLambda[T, I, KI <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I, KI], x: I, body: Phrase[U])
+  extends Phrase[DepFunType[I, KI, U]] {
+  override val t: DepFunType[I, KI, U] = DepFunType[I, KI, U](kind, x, body.t)
+  override def toString: String = s"Λ(${Kind.idName(kind, x)} : ${kind.name}). $body"
 }
 
 object DepLambda {
-  def apply[T, I <: Kind.Identifier](kind: Kind[T, I], x: I): Object {
-    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U]
+  def apply[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I): Object {
+    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, KI, U]
   } = new {
-    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
+    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, KI, U] = DepLambda(kind, x, body)
   }
 }
 
-final case class DepApply[T, I <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I], fun: Phrase[I `()->:` U], arg: T)
+final case class DepApply[T, I, KI <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I, KI], fun: Phrase[DepFunType[I, KI, U]], arg: T)
   extends Phrase[U] {
 
   override val t: U = PhraseType.substitute(kind, arg, `for`=fun.t.x, in=fun.t.t).asInstanceOf[U]
@@ -141,8 +141,9 @@ object Phrase {
             case l @ Lambda(x, _) =>
               val newMap = idMap + (x.name -> freshName(x.name.takeWhile(_.isLetter)))
               Continue(l, Renaming(newMap))
-            case dl @ DepLambda(_, x, _) =>
-              val newMap = idMap + (x.name -> freshName(x.name.takeWhile(_.isLetter)))
+            case dl @ DepLambda(k, x, _) =>
+              val name = Kind.idName(k, x)
+              val newMap = idMap + (name -> freshName(name.takeWhile(_.isLetter)))
               Continue(dl, Renaming(newMap))
             case _ => Continue(p, this)
           }
@@ -248,7 +249,7 @@ object Phrase {
         }
         case DepApply(_, fun, arg) => (fun, arg) match {
           case (f, a: Nat) =>
-            transientNatFromExpr(liftDependentFunction(f.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a))
+            transientNatFromExpr(liftDependentFunction(f.asInstanceOf[Phrase[`(nat)->:`[ExpType]]])(a))
           case _ => ???
         }
         case Proj1(pair) => transientNatFromExpr(liftPair(pair)._1)

--- a/src/main/scala/shine/DPIA/Phrases/Phrase.scala
+++ b/src/main/scala/shine/DPIA/Phrases/Phrase.scala
@@ -130,44 +130,10 @@ object Phrase {
   def substitute[T1 <: PhraseType, T2 <: PhraseType](ph: Phrase[T1],
                                                      `for`: Phrase[T1],
                                                      in: Phrase[T2]): Phrase[T2] = {
-    var substCounter = 0
     object Visitor extends VisitAndRebuild.Visitor {
-      def renaming[X <: PhraseType](p: Phrase[X]): Phrase[X] = {
-        case class Renaming(idMap: Map[String, String]) extends VisitAndRebuild.Visitor {
-          override def phrase[T <: PhraseType](p: Phrase[T]): Result[Phrase[T]] = p match {
-            case Identifier(name, t) => Stop(
-              Identifier(idMap.getOrElse(name, name),
-                VisitAndRebuild.visitPhraseTypeAndRebuild(t, this)).asInstanceOf[Phrase[T]])
-            case l @ Lambda(x, _) =>
-              val newMap = idMap + (x.name -> freshName(x.name.takeWhile(_.isLetter)))
-              Continue(l, Renaming(newMap))
-            case dl @ DepLambda(k, x, _) =>
-              val name = Kind.idName(k, x)
-              val newMap = idMap + (name -> freshName(name.takeWhile(_.isLetter)))
-              Continue(dl, Renaming(newMap))
-            case _ => Continue(p, this)
-          }
-
-          override def nat[N <: Nat](n: N): N = n.visitAndRebuild({
-            case i: NatIdentifier =>
-              NatIdentifier(idMap.getOrElse(i.name, i.name))
-            case ae => ae
-          }).asInstanceOf[N]
-
-          override def data[T <: DataType](dt: T): T = (dt match {
-            case i: DataTypeIdentifier =>
-              DataTypeIdentifier(idMap.getOrElse(i.name, i.name))
-            case dt => dt
-          }).asInstanceOf[T]
-        }
-        VisitAndRebuild(p, Renaming(Map()))
-      }
       override def phrase[T <: PhraseType](p: Phrase[T]): Result[Phrase[T]] = {
         p match {
-          case `for` =>
-            val newPh = if (substCounter == 0) ph else renaming(ph)
-            substCounter += 1
-            Stop(newPh.asInstanceOf[Phrase[T]])
+          case `for` => Stop(ph.asInstanceOf[Phrase[T]])
           case Natural(n) =>
             val v = NatIdentifier(`for` match {
               case Identifier(name, _) => name

--- a/src/main/scala/shine/DPIA/Phrases/PrettyPhrasePrinter.scala
+++ b/src/main/scala/shine/DPIA/Phrases/PrettyPhrasePrinter.scala
@@ -8,7 +8,7 @@ object PrettyPhrasePrinter {
     p match {
       case app: Apply[a, T] => s"(${apply(app.fun)})(${apply(app.arg)})"
 
-      case app: DepApply[_, _, T] => s"(${apply(app.fun)})(${app.arg})"
+      case app: DepApply[_, _, _, T] => s"(${apply(app.fun)})(${app.arg})"
 
       case p1: Proj1[a, b] => s"π1(${apply(p1.pair)})"
 
@@ -25,7 +25,7 @@ object PrettyPhrasePrinter {
 
       case Lambda(param, body) => s"λ ${apply(param)}: ${param.t} -> ${apply(body)}"
 
-      case DepLambda(kind, param, body) => s"Λ (${param.name}: ${kind.name}) -> ${apply(body)}"
+      case DepLambda(kind, param, body) => s"Λ (${Kind.idName(kind, param)}: ${kind.name}) -> ${apply(body)}"
 
       case LetNat(binder, defn, body) => s"nLet ${binder.name} = ${apply(defn)} in ${apply(body)}"
 

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -84,27 +84,27 @@ object VisitAndRebuild {
           case DepApply(_, p, a) => a match {
             case n: Nat =>
               DepApply(NatKind,
-                apply(p, v).asInstanceOf[Phrase[NatIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(nat)->:`[T]]],
                 v.nat(n))
             case dt: DataType =>
               DepApply(DataKind,
-                apply(p, v).asInstanceOf[Phrase[DataTypeIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(dt)->:`[T]]],
                 visitDataTypeAndRebuild(dt, v))
             case ad: AddressSpace =>
               DepApply(AddressSpaceKind,
-                apply(p, v).asInstanceOf[Phrase[AddressSpaceIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(add)->:`[T]]],
                 v.addressSpace(ad))
             case ac: AccessType =>
               DepApply(AccessKind,
-                apply(p, v).asInstanceOf[Phrase[AccessTypeIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(acc)->:`[T]]],
                 v.access(ac))
             case n2n: NatToNat =>
               DepApply(NatToNatKind,
-                apply(p, v).asInstanceOf[Phrase[NatToNatIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(n2n)->:`[T]]],
                 v.natToNat(n2n))
             case n2d: NatToData =>
               DepApply(NatToDataKind,
-                apply(p, v).asInstanceOf[Phrase[NatToDataIdentifier `()->:` T]],
+                apply(p, v).asInstanceOf[Phrase[`(n2d)->:`[T]]],
                 v.natToData(n2d))
             case ph: PhraseType => ???
           }

--- a/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
+++ b/src/main/scala/shine/DPIA/Phrases/VisitAndRebuild.scala
@@ -123,7 +123,7 @@ object VisitAndRebuild {
 
           case Literal(d) => Literal(d)
 
-          case Natural(n) => Natural(n)
+          case Natural(n) => Natural(v.nat(n))
 
           case UnaryOp(op, x) => UnaryOp(op, apply(x, v))
 

--- a/src/main/scala/shine/DPIA/Types/AccessType.scala
+++ b/src/main/scala/shine/DPIA/Types/AccessType.scala
@@ -6,7 +6,6 @@ object write extends AccessType { override def toString = "write" }
 
 object read extends AccessType { override def toString = "read" }
 
-final case class AccessTypeIdentifier(name: String)
-  extends AccessType with Kind.Identifier {
+final case class AccessTypeIdentifier(name: String) extends AccessType {
   override def toString: String = name
 }

--- a/src/main/scala/shine/DPIA/Types/AddressSpace.scala
+++ b/src/main/scala/shine/DPIA/Types/AddressSpace.scala
@@ -17,6 +17,6 @@ object AddressSpace {
   //}
 }
 
-final case class AddressSpaceIdentifier(name: String) extends AddressSpace with Kind.Identifier {
+final case class AddressSpaceIdentifier(name: String) extends AddressSpace {
   override def toString: String = name
 }

--- a/src/main/scala/shine/DPIA/Types/DataType.scala
+++ b/src/main/scala/shine/DPIA/Types/DataType.scala
@@ -20,7 +20,7 @@ object MatrixLayout {
   object None extends MatrixLayout
 }
 
-final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout with Kind.Identifier {
+final case class MatrixLayoutIdentifier(name: String) extends MatrixLayout {
   var layout: MatrixLayout = MatrixLayout.None
 
   override def toString: String = name
@@ -169,8 +169,7 @@ object NatToDataApply {
     Some((arg.f, arg.n))
 }
 
-final case class DataTypeIdentifier(name: String)
-  extends DataType with Kind.Identifier {
+final case class DataTypeIdentifier(name: String) extends DataType {
   override def toString: String = name
 }
 

--- a/src/main/scala/shine/DPIA/Types/Kind.scala
+++ b/src/main/scala/shine/DPIA/Types/Kind.scala
@@ -9,7 +9,7 @@ sealed trait Kind[+T, +I, +KI <: Kind.Identifier] {
 }
 
 object Kind {
-  trait Identifier { def name: String }
+  sealed trait Identifier { def name: String }
   case class IPhraseType(id : Identifier) extends Identifier { def name : String = id.name }
   case class IDataType(id : DataTypeIdentifier) extends Identifier { def name : String = id.name }
   case class INat(id : NatIdentifier) extends Identifier { def name : String = id.name }

--- a/src/main/scala/shine/DPIA/Types/Kind.scala
+++ b/src/main/scala/shine/DPIA/Types/Kind.scala
@@ -3,48 +3,83 @@ package shine.DPIA.Types
 import shine.DPIA
 import shine.DPIA.NatIdentifier
 
-sealed trait Kind[+T, +I <: Kind.Identifier] {
+sealed trait Kind[+T, +I, +KI <: Kind.Identifier] {
   def name: String
   def makeIdentifier: I
 }
 
 object Kind {
-  trait Identifier {
-    def name: String
+  trait Identifier { def name: String }
+  case class IPhraseType(id : Identifier) extends Identifier { def name : String = id.name }
+  case class IDataType(id : DataTypeIdentifier) extends Identifier { def name : String = id.name }
+  case class INat(id : NatIdentifier) extends Identifier { def name : String = id.name }
+  case class IAddressSpace(id : AddressSpaceIdentifier) extends Identifier { def name : String = id.name }
+  case class IAccessType(id : AccessTypeIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToNat(id : NatToNatIdentifier) extends Identifier { def name : String = id.name }
+  case class INatToData(id : NatToDataIdentifier) extends Identifier { def name : String = id.name }
+
+  def idName[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : String = kind match {
+    case PhraseKind => i.asInstanceOf[Kind.Identifier].name
+    case DataKind => i.asInstanceOf[DataTypeIdentifier].name
+    case NatKind => i.asInstanceOf[NatIdentifier].name
+    case AddressSpaceKind => i.asInstanceOf[AddressSpaceIdentifier].name
+    case AccessKind => i.asInstanceOf[AccessTypeIdentifier].name
+    case NatToNatKind => i.asInstanceOf[NatToNatIdentifier].name
+    case NatToDataKind => i.asInstanceOf[NatToDataIdentifier].name
+  }
+
+  def toIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : I) : KI = kind match {
+    case PhraseKind => IPhraseType(i.asInstanceOf[Kind.Identifier]).asInstanceOf[KI]
+    case DataKind => IDataType(i.asInstanceOf[DataTypeIdentifier]).asInstanceOf[KI]
+    case NatKind => INat(i.asInstanceOf[NatIdentifier]).asInstanceOf[KI]
+    case AddressSpaceKind => IAddressSpace(i.asInstanceOf[AddressSpaceIdentifier]).asInstanceOf[KI]
+    case AccessKind => IAccessType(i.asInstanceOf[AccessTypeIdentifier]).asInstanceOf[KI]
+    case NatToNatKind => INatToNat(i.asInstanceOf[NatToNatIdentifier]).asInstanceOf[KI]
+    case NatToDataKind => INatToData(i.asInstanceOf[NatToDataIdentifier]).asInstanceOf[KI]
+  }
+
+  def fromIdentifier[T, I, KI <: Kind.Identifier](kind : Kind[T, I, KI], i : KI) : I = kind match {
+    case PhraseKind => i.asInstanceOf[IPhraseType].id.asInstanceOf[I]
+    case DataKind => i.asInstanceOf[IDataType].id.asInstanceOf[I]
+    case NatKind => i.asInstanceOf[INat].id.asInstanceOf[I]
+    case AddressSpaceKind => i.asInstanceOf[IAddressSpace].id.asInstanceOf[I]
+    case AccessKind => i.asInstanceOf[IAccessType].id.asInstanceOf[I]
+    case NatToNatKind => i.asInstanceOf[INatToNat].id.asInstanceOf[I]
+    case NatToDataKind => i.asInstanceOf[INatToData].id.asInstanceOf[I]
   }
 }
 
-case object PhraseKind extends Kind[PhraseType, Kind.Identifier] {
+case object PhraseKind extends Kind[PhraseType, Kind.Identifier, Kind.IPhraseType] {
   override def name: String = "phrase"
   override def makeIdentifier: Kind.Identifier = ???
 }
 
-case object DataKind extends Kind[DataType, DataTypeIdentifier] {
+case object DataKind extends Kind[DataType, DataTypeIdentifier, Kind.IDataType] {
   override def name: String = "data"
   override def makeIdentifier: DataTypeIdentifier = DataTypeIdentifier(DPIA.freshName("dt"))
 }
 
-case object NatKind extends Kind[DPIA.Nat, DPIA.NatIdentifier] {
+case object NatKind extends Kind[DPIA.Nat, DPIA.NatIdentifier, Kind.INat] {
   override def name: String = "nat"
   override def makeIdentifier: NatIdentifier = NatIdentifier(DPIA.freshName("n"))
 }
 
-case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier] {
+case object AddressSpaceKind extends Kind[AddressSpace, AddressSpaceIdentifier, Kind.IAddressSpace] {
   override def name: String = "addressSpace"
   override def makeIdentifier: AddressSpaceIdentifier = AddressSpaceIdentifier(DPIA.freshName("addr"))
 }
 
-case object AccessKind extends Kind[AccessType, AccessTypeIdentifier] {
+case object AccessKind extends Kind[AccessType, AccessTypeIdentifier, Kind.IAccessType] {
   override def name: String = "access"
   override def makeIdentifier: AccessTypeIdentifier = AccessTypeIdentifier(DPIA.freshName("access"))
 }
 
-case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier] {
+case object NatToNatKind extends Kind[NatToNat, NatToNatIdentifier, Kind.INatToNat] {
   override def name: String = "nat->nat"
   override def makeIdentifier: NatToNatIdentifier = NatToNatIdentifier(DPIA.freshName("n2n"))
 }
 
-case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier] {
+case object NatToDataKind extends Kind[NatToData, NatToDataIdentifier, Kind.INatToData] {
   override def name: String = "nat->data"
   override def makeIdentifier: NatToDataIdentifier = NatToDataIdentifier(DPIA.freshName("n2d"))
 }

--- a/src/main/scala/shine/DPIA/Types/NatToData.scala
+++ b/src/main/scala/shine/DPIA/Types/NatToData.scala
@@ -28,7 +28,7 @@ object NatToDataLambda {
   }
 }
 
-final case class NatToDataIdentifier(name: String) extends NatToData with Kind.Identifier {
+final case class NatToDataIdentifier(name: String) extends NatToData {
   override def toString: String = name
 }
 

--- a/src/main/scala/shine/DPIA/Types/NatToNat.scala
+++ b/src/main/scala/shine/DPIA/Types/NatToNat.scala
@@ -44,7 +44,7 @@ object NatToNatLambda {
   }
 }
 
-final case class NatToNatIdentifier(name: String) extends NatToNat with Kind.Identifier {
+final case class NatToNatIdentifier(name: String) extends NatToNat {
   override lazy val toString: String = name
 }
 

--- a/src/main/scala/shine/DPIA/Types/PhraseType.scala
+++ b/src/main/scala/shine/DPIA/Types/PhraseType.scala
@@ -41,14 +41,14 @@ final case class PassiveFunType[T <: PhraseType, +R <: PhraseType](inT: T, outT:
   override def toString = s"($inT) ->p $outT"
 }
 
-final case class DepFunType[I <: Kind.Identifier, +R <: PhraseType](kind: Kind[_, I], x: I, t: R)
+final case class DepFunType[I, KI <: Kind.Identifier, +R <: PhraseType](kind: Kind[_, I, KI], x: I, t: R)
   extends PhraseType {
-  override def toString = s"(${x.name}: ${kind.name}) -> $t"
+  override def toString = s"(${Kind.idName(kind, x)}: ${kind.name}) -> $t"
 }
 
 object PhraseType {
 
-  def substitute[T, I <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I], x: T, `for`: I, in: Phrase[U]): Phrase[U] =
+  def substitute[T, I, KI <: Kind.Identifier, U <: PhraseType](kind: Kind[T, I, KI], x: T, `for`: I, in: Phrase[U]): Phrase[U] =
     (x, `for`) match {
       case (dt: DataType, forDt: DataTypeIdentifier)        => substitute(dt, forDt, in)
       case (n: Nat, forN: NatIdentifier)                    => substitute(n, forN, in)
@@ -59,7 +59,7 @@ object PhraseType {
       case _ => throw new Exception(s"could not substitute $x for ${`for`} in $in")
     }
 
-  def substitute[T, I <: Kind.Identifier](kind: Kind[T, I], x: T, `for`: I, in: PhraseType): PhraseType =
+  def substitute[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: T, `for`: I, in: PhraseType): PhraseType =
     (x, `for`) match {
       case (dt: DataType, forDt: DataTypeIdentifier)        => substitute(dt, forDt, in)
       case (n: Nat, forN: NatIdentifier)                    => substitute(n, forN, in)
@@ -97,7 +97,7 @@ object PhraseType {
         FunType(substitute(dt, `for`, f.inT), substitute(dt, `for`, f.outT))
       case pf: PassiveFunType[_, _] =>
         PassiveFunType(substitute(dt, `for`, pf.inT), substitute(dt, `for`, pf.outT))
-      case df: DepFunType[_, _] =>
+      case df: DepFunType[_, _, _] =>
         DepFunType(df.kind, df.x, substitute(dt, `for`, df.t))
     }
   }
@@ -149,7 +149,7 @@ object PhraseType {
         FunType(substitute(n, `for`, f.inT), substitute(n, `for`, f.outT))
       case pf: PassiveFunType[_, _] =>
         PassiveFunType(substitute(n, `for`, pf.inT), substitute(n, `for`, pf.outT))
-      case df: DepFunType[_, _] =>
+      case df: DepFunType[_, _, _] =>
         DepFunType(df.kind, df.x, substitute(n, `for`, df.t))
     }
   }

--- a/src/main/scala/shine/DPIA/Types/package.scala
+++ b/src/main/scala/shine/DPIA/Types/package.scala
@@ -26,41 +26,31 @@ package object Types {
     def `:`[T <: PhraseType](p: Phrase[T]): Unit = typeAssert(p, pt)
   }
 
-  type NatDependentFunctionType[T <: PhraseType] = DepFunType[NatIdentifier, T]
+  type NatDependentFunctionType[T <: PhraseType] = `(nat)->:`[T]
 
   object NatDependentFunctionType {
-    def apply[T <: PhraseType](n: NatIdentifier, t: T): DepFunType[NatIdentifier, T] =
+    def apply[T <: PhraseType](n: NatIdentifier, t: T): `(nat)->:`[T] =
       DepFunType(NatKind, n, t)
   }
 
-  type TypeDependentFunctionType[T <: PhraseType] = DepFunType[DataTypeIdentifier, T]
+  type TypeDependentFunctionType[T <: PhraseType] = `(dt)->:`[T]
 
   object TypeDependentFunctionType {
-    def apply[T <: PhraseType](
-      dt: DataTypeIdentifier,
-      t: T
-    ): DepFunType[DataTypeIdentifier, T] =
+    def apply[T <: PhraseType](dt: DataTypeIdentifier, t: T): `(dt)->:`[T] =
       DepFunType(DataKind, dt, t)
   }
 
-  type AddrSpaceDependentFunctionType[T <: PhraseType] =
-    DepFunType[AddressSpaceIdentifier, T]
+  type AddrSpaceDependentFunctionType[T <: PhraseType] = `(add)->:`[T]
 
   object AddrSpaceDependentFunctionType {
-    def apply[T <: PhraseType](
-      addr: AddressSpaceIdentifier,
-      t: T
-    ): DepFunType[AddressSpaceIdentifier, T] =
+    def apply[T <: PhraseType](addr: AddressSpaceIdentifier, t: T): `(add)->:`[T] =
       DepFunType(AddressSpaceKind, addr, t)
   }
 
-  type AccessDependentFunctionType[T <: PhraseType] = DepFunType[AccessTypeIdentifier, T]
+  type AccessDependentFunctionType[T <: PhraseType] = `(acc)->:`[T]
 
   object AccessDependentFunctionType {
-    def apply[T <: PhraseType](
-      at: AccessTypeIdentifier,
-      t: T
-    ): DepFunType[AccessTypeIdentifier, T] =
+    def apply[T <: PhraseType](at: AccessTypeIdentifier, t: T): `(acc)->:`[T] =
       DepFunType(AccessKind, at, t)
   }
 

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -42,7 +42,7 @@ object fromRise {
 
     case r.DepLambda(kind, x, e) => x match {
       case ni: rt.NatIdentifier =>
-        DepLambda(NatKind, natIdentifier(ni))(expression(e, ptMap))
+        DepLambda(NatKind, ni)(expression(e, ptMap))
       case dti: rt.DataTypeIdentifier =>
         DepLambda(DataKind, dataTypeIdentifier(dti))(expression(e, ptMap))
       case addri: rt.AddressSpaceIdentifier =>
@@ -964,7 +964,7 @@ object fromRise {
     case rt.NatToDataApply(f, n) => NatToDataApply(ntd(f), n)
     case rt.DepPairType(_, x, t) =>
       x match {
-      case x:rt.NatIdentifier => DepPairType(natIdentifier(x), dataType(t))
+      case x:rt.NatIdentifier => DepPairType(x, dataType(t))
       case _ => ???
     }
     case f: rt.FragmentType =>
@@ -1009,26 +1009,18 @@ object fromRise {
 
   def ntd(ntd: rt.NatToData): NatToData= ntd match {
     case rt.NatToDataLambda(n, body) =>
-      NatToDataLambda(natIdentifier(n), dataType(body))
+      NatToDataLambda(n, dataType(body))
     case rt.NatToDataIdentifier(x) => NatToDataIdentifier(x)
   }
 
   def ntn(ntn: rt.NatToNat): NatToNat= ntn match {
-    case rt.NatToNatLambda(n, body) => NatToNatLambda(natIdentifier(n), body)
+    case rt.NatToNatLambda(n, body) => NatToNatLambda(n, body)
     case rt.NatToNatIdentifier(x) => NatToNatIdentifier(x)
   }
 
-  def dataTypeIdentifier(dt: rt.DataTypeIdentifier): DataTypeIdentifier =
-    DataTypeIdentifier(dt.name)
-  def natIdentifier(n: rt.NatIdentifier): NatIdentifier =
-    NatIdentifier(n.name, n.range)
-  def addressSpaceIdentifier(
-    a: rt.AddressSpaceIdentifier
-  ): AddressSpaceIdentifier = AddressSpaceIdentifier(a.name)
-  def natToNatIdentifier(n: rt.NatToNatIdentifier): NatToNatIdentifier =
-    NatToNatIdentifier(n.name)
-  def natToDataIdentifier(n: rt.NatToDataIdentifier): NatToDataIdentifier =
-    NatToDataIdentifier(n.name)
-  def accessTypeIdentifier(): AccessTypeIdentifier =
-    AccessTypeIdentifier(freshName("access"))
+  def dataTypeIdentifier(dt: rt.DataTypeIdentifier): DataTypeIdentifier = DataTypeIdentifier(dt.name)
+  def addressSpaceIdentifier(a: rt.AddressSpaceIdentifier): AddressSpaceIdentifier = AddressSpaceIdentifier(a.name)
+  def natToNatIdentifier(n: rt.NatToNatIdentifier): NatToNatIdentifier = NatToNatIdentifier(n.name)
+  def natToDataIdentifier(n: rt.NatToDataIdentifier): NatToDataIdentifier = NatToDataIdentifier(n.name)
+  def accessTypeIdentifier(): AccessTypeIdentifier = AccessTypeIdentifier(freshName("access"))
 }

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -50,9 +50,9 @@ object fromRise {
     }
 
     case r.DepApp(kind, f, x) =>
-      def depApp[T, I <: Kind.Identifier](kind: Kind[T, I], f: r.Expr, arg: T): DepApply[T, I, PhraseType] =
-        DepApply[T, I, PhraseType](kind,
-          expression(f, ptMap).asInstanceOf[Phrase[DepFunType[I, PhraseType]]],
+      def depApp[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], f: r.Expr, arg: T): DepApply[T, I, KI, PhraseType] =
+        DepApply[T, I, KI, PhraseType](kind,
+          expression(f, ptMap).asInstanceOf[Phrase[DepFunType[I, KI, PhraseType]]],
           arg)
 
       x match {
@@ -98,10 +98,10 @@ object fromRise {
   }
 
   object depFun {
-    def apply[T, I <: Kind.Identifier](kind: Kind[T, I], x: I): Object {
-      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U]
+    def apply[T, I, KI <: Kind.Identifier](kind: Kind[T, I, KI], x: I): Object {
+      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, KI, U]
     } = new {
-      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
+      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, KI, U] = DepLambda(kind, x, body)
     }
   }
 

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -16,7 +16,7 @@ package object DPIA {
   }
 
   type Nat = ArithExpr
-  type NatIdentifier = NamedVar with Kind.Identifier
+  type NatIdentifier = NamedVar
 
   object Nat {
     def substitute[N <: Nat](ae: Nat, `for`: NatIdentifier, in: N): N =
@@ -24,8 +24,8 @@ package object DPIA {
   }
 
   object NatIdentifier {
-    def apply(name: String): NatIdentifier = new NamedVar(name) with Kind.Identifier
-    def apply(name: String, range: Range): NatIdentifier = new NamedVar(name, range) with Kind.Identifier
+    def apply(name: String): NatIdentifier = NamedVar(name)
+    def apply(name: String, range: Range): NatIdentifier = NamedVar(name, range)
   }
 
   // note: this is an easy fix to avoid name conflicts between lift and dpia

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -34,9 +34,12 @@ package object DPIA {
   type x[T1 <: PhraseType, T2 <: PhraseType] = PhrasePairType[T1, T2]
   type ->:[T <: PhraseType, R <: PhraseType] = FunType[T, R]
   type `->p:`[T <: PhraseType, R <: PhraseType] = PassiveFunType[T, R]
-  type `()->:`[I <: Kind.Identifier, R <: PhraseType] = DepFunType[I, R]
-  type `(nat)->:`[R <: PhraseType] = DepFunType[NatIdentifier, R]
-  type `(dt)->:`[R <: PhraseType] = DepFunType[DataTypeIdentifier, R]
+  type `(nat)->:`[R <: PhraseType] = DepFunType[NatIdentifier, Kind.INat, R]
+  type `(dt)->:`[R <: PhraseType] = DepFunType[DataTypeIdentifier, Kind.IDataType, R]
+  type `(add)->:`[R <: PhraseType] = DepFunType[AddressSpaceIdentifier, Kind.IAddressSpace, R]
+  type `(acc)->:`[R <: PhraseType] = DepFunType[AccessTypeIdentifier, Kind.IAccessType, R]
+  type `(n2n)->:`[R <: PhraseType] = DepFunType[NatToNatIdentifier, Kind.INatToNat, R]
+  type `(n2d)->:`[R <: PhraseType] = DepFunType[NatToDataIdentifier, Kind.INatToData, R]
   type VarType = ExpType x AccType
 
   object VarType {
@@ -94,10 +97,10 @@ package object DPIA {
   }
 
   implicit class DepFunTypeConstructor[R <: PhraseType](r: R) {
-    def ->:(i: DataTypeIdentifier): `()->:`[DataTypeIdentifier, R] = DepFunType(DataKind, i, r)
-    def ->:(n: NatIdentifier): `()->:`[NatIdentifier, R] = DepFunType(NatKind, n, r)
-    def ->:(n: NatToNatIdentifier): `()->:`[NatToNatIdentifier, R] = DepFunType(NatToNatKind, n, r)
-    def ->:(n: NatToDataIdentifier): `()->:`[NatToDataIdentifier, R] = DepFunType(NatToDataKind, n, r)
+    def ->:(i: DataTypeIdentifier): DepFunType[DataTypeIdentifier, Kind.IDataType, R] = DepFunType(DataKind, i, r)
+    def ->:(n: NatIdentifier): DepFunType[NatIdentifier, Kind.INat, R] = DepFunType(NatKind, n, r)
+    def ->:(n: NatToNatIdentifier): DepFunType[NatToNatIdentifier, Kind.INatToNat, R] = DepFunType(NatToNatKind, n, r)
+    def ->:(n: NatToDataIdentifier): DepFunType[NatToDataIdentifier, Kind.INatToData, R] = DepFunType(NatToDataKind, n, r)
   }
 
   object expT {
@@ -129,7 +132,7 @@ package object DPIA {
       DepFunType(NatKind, n, t)
     }
 
-    def unapply[I <: Kind.Identifier, U <: PhraseType](funType: DepFunType[I, U]): Option[(NatIdentifier, U)] = {
+    def unapply[KI <: Kind.Identifier, U <: PhraseType](funType: DepFunType[_, KI, U]): Option[(NatIdentifier, U)] = {
       funType.x match {
         case n: NatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected Nat DepFunType")
@@ -152,8 +155,8 @@ package object DPIA {
       DepFunType(AddressSpaceKind, a, t)
     }
 
-    def unapply[I <: Kind.Identifier, T <: PhraseType](funType: DepFunType[I, T]
-                                                      ): Option[(AddressSpaceIdentifier, T)] = {
+    def unapply[KI <: Kind.Identifier, T <: PhraseType](funType: DepFunType[_, KI, T]
+                                                       ): Option[(AddressSpaceIdentifier, T)] = {
       funType.x match {
         case a: AddressSpaceIdentifier => Some((a, funType.t))
         case _ => throw new Exception("Expected AddressSpace DepFunType")
@@ -170,8 +173,8 @@ package object DPIA {
       DepFunType(NatToNatKind, n, t)
     }
 
-    def unapply[I <: Kind.Identifier, T <: PhraseType](funType: DepFunType[I, T]
-                                                      ): Option[(NatToNatIdentifier, T)] = {
+    def unapply[KI <: Kind.Identifier, T <: PhraseType](funType: DepFunType[_, KI, T]
+                                                       ): Option[(NatToNatIdentifier, T)] = {
       funType.x match {
         case n: NatToNatIdentifier => Some((n, funType.t))
         case _ => throw new Exception("Expected Nat DepFunType")

--- a/src/main/scala/shine/DPIA/primitives/functional/AsScalar.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/AsScalar.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsScalar(val n: Nat, val m: Nat, val dt: DataType, val a: AccessType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/AsVector.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/AsVector.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsVector(val n: Nat, val m: Nat, val dt: DataType, val a: AccessType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/AsVectorAligned.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/AsVectorAligned.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsVectorAligned(val n: Nat, val m: Nat, val dt: DataType, val a: AccessType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Cast.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Cast.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Cast(val dt1: DataType, val dt2: DataType, val e: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/CircularBuffer.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/CircularBuffer.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class CircularBuffer(val n: Nat, val alloc: Nat, val sz: Nat, val dt1: DataType, val dt2: DataType, val load: Phrase[FunType[ExpType, ExpType]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Cycle.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Cycle.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Cycle(val n: Nat, val m: Nat, val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/DepIdx.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/DepIdx.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DepIdx(val n: Nat, val ft: NatToData, val index: Nat, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/DepJoin.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/DepJoin.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DepJoin(val n: Nat, val lenF: NatToNat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/DepMapSeq.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/DepMapSeq.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class DepMapSeq(unroll: Boolean)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMapSeq(unroll: Boolean)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val k = f.t.x
@@ -18,5 +19,5 @@ final case class DepMapSeq(unroll: Boolean)(val n: Nat, val ft1: NatToData, val 
   }
   override val t: ExpType = expT(DepArrayType(n, ft2), write)
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): DepMapSeq = new DepMapSeq(unroll)(v.nat(n), v.natToData(ft1), v.natToData(ft2), VisitAndRebuild(f, v), VisitAndRebuild(array, v))
-  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
+  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
 }

--- a/src/main/scala/shine/DPIA/primitives/functional/DepZip.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/DepZip.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DepZip(val n: Nat, val ft1: NatToData, val ft2: NatToData, val e1: Phrase[ExpType], val e2: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Drop.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Drop.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Drop(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/ForeignFunctionCall.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/ForeignFunctionCall.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ForeignFunctionCall(funDecl: rise.core.ForeignFunction.Decl, n: Int)(val inTs: Seq[DataType], val outT: DataType, val args: Seq[Phrase[ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Fst.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Fst.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Fst(val dt1: DataType, val dt2: DataType, val pair: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Gather.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Gather.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Gather(val n: Nat, val m: Nat, val dt: DataType, val indices: Phrase[ExpType], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Generate.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Generate.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Generate(val n: Nat, val dt: DataType, val f: Phrase[FunType[ExpType, ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Idx.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Idx.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Idx(val n: Nat, val dt: DataType, val index: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/IdxVec.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/IdxVec.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IdxVec(val n: Nat, val dt: DataType, val index: Phrase[ExpType], val vector: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/IndexAsNat.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/IndexAsNat.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IndexAsNat(val n: Nat, val e: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Iterate.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Iterate.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class Iterate(val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class Iterate(val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val l = f.t.x

--- a/src/main/scala/shine/DPIA/primitives/functional/IterateStream.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/IterateStream.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IterateStream(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Join.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Join.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Join(val n: Nat, val m: Nat, val a: AccessType, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Let.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Let.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Let(val dt1: DataType, val dt2: DataType, val a: AccessType, val value: Phrase[ExpType], val f: Phrase[FunType[ExpType, ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MakeArray.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MakeArray.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MakeArray(n: Int)(val dt: DataType, val elements: Seq[Phrase[ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MakePair.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MakePair.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MakePair(val dt1: DataType, val dt2: DataType, val a: AccessType, val fst: Phrase[ExpType], val snd: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Map.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Map.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Map(val n: Nat, val dt1: DataType, val dt2: DataType, val a: AccessType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MapFst.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MapFst.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapFst(val a: AccessType, val dt1: DataType, val dt2: DataType, val dt3: DataType, val f: Phrase[FunType[ExpType, ExpType]], val pair: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MapSeq.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MapSeq.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapSeq(unroll: Boolean)(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MapSnd.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MapSnd.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapSnd(val a: AccessType, val dt1: DataType, val dt2: DataType, val dt3: DataType, val f: Phrase[FunType[ExpType, ExpType]], val pair: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MapStream.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MapStream.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapStream(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/MapVec.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/MapVec.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapVec(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/NatAsIndex.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/NatAsIndex.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class NatAsIndex(val n: Nat, val e: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/PadClamp.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/PadClamp.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PadClamp(val n: Nat, val l: Nat, val r: Nat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/PadCst.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/PadCst.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PadCst(val n: Nat, val l: Nat, val r: Nat, val dt: DataType, val padExp: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/PadEmpty.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/PadEmpty.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PadEmpty(val n: Nat, val r: Nat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Partition.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Partition.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Partition(val n: Nat, val m: Nat, val lenF: NatToNat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/ReduceSeq.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/ReduceSeq.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ReduceSeq(unroll: Boolean)(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, FunType[ExpType, ExpType]]], val init: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Reorder.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Reorder.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Reorder(val n: Nat, val dt: DataType, val a: AccessType, val idxF: NatToNat, val idxFiv: NatToNat, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/RotateValues.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/RotateValues.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class RotateValues(val n: Nat, val sz: Nat, val dt: DataType, val wrt: Phrase[FunType[ExpType, ExpType]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/ScanSeq.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/ScanSeq.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ScanSeq(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, FunType[ExpType, ExpType]]], val init: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Scatter.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Scatter.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Scatter(val n: Nat, val m: Nat, val dt: DataType, val indices: Phrase[ExpType], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Slide.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Slide.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Slide(val n: Nat, val sz: Nat, val sp: Nat, val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Snd.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Snd.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Snd(val dt1: DataType, val dt2: DataType, val pair: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Split.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Split.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Split(val n: Nat, val m: Nat, val a: AccessType, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Take.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Take.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Take(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/ToMem.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/ToMem.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ToMem(val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Transpose.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Transpose.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Transpose(val n: Nat, val m: Nat, val dt: DataType, val a: AccessType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/TransposeDepArray.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/TransposeDepArray.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class TransposeDepArray(val n: Nat, val m: Nat, val ft: NatToData, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Unzip.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Unzip.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Unzip(val n: Nat, val dt1: DataType, val dt2: DataType, val a: AccessType, val e: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/VectorFromScalar.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/VectorFromScalar.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class VectorFromScalar(val n: Nat, val dt: DataType, val arg: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/functional/Zip.scala
+++ b/src/main/scala/shine/DPIA/primitives/functional/Zip.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Zip(val n: Nat, val dt1: DataType, val dt2: DataType, val a: AccessType, val e1: Phrase[ExpType], val e2: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/AsScalarAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/AsScalarAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsScalarAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/AsVectorAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/AsVectorAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsVectorAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/Assign.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/Assign.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Assign(val dt: DataType, val lhs: Phrase[AccType], val rhs: Phrase[ExpType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/Comment.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/Comment.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Comment(comment: String)() extends CommandPrimitive {
   override val t: CommType = comm

--- a/src/main/scala/shine/DPIA/primitives/imperative/CycleAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/CycleAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class CycleAcc(val n: Nat, val m: Nat, val dt: DataType, val input: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/DepIdxAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/DepIdxAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DepIdxAcc(val n: Nat, val ft: NatToData, val index: Nat, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/DepJoinAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/DepJoinAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DepJoinAcc(val n: Nat, val lenF: NatToNat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/DropAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/DropAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class DropAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/For.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/For.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class For(unroll: Boolean)(val n: Nat, val loopBody: Phrase[FunType[ExpType, CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/ForNat.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ForNat.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class ForNat(unroll: Boolean)(val n: Nat, val loopBody: Phrase[DepFunType[NatIdentifier, CommType]]) extends CommandPrimitive {
+final case class ForNat(unroll: Boolean)(val n: Nat, val loopBody: Phrase[DepFunType[NatIdentifier, INat, CommType]]) extends CommandPrimitive {
   assert {
     loopBody :: ({
       val i = loopBody.t.x
@@ -17,5 +18,5 @@ final case class ForNat(unroll: Boolean)(val n: Nat, val loopBody: Phrase[DepFun
   }
   override val t: CommType = comm
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): ForNat = new ForNat(unroll)(v.nat(n), VisitAndRebuild(loopBody, v))
-  def unwrap: (Nat, Phrase[DepFunType[NatIdentifier, CommType]]) = (n, loopBody)
+  def unwrap: (Nat, Phrase[DepFunType[NatIdentifier, INat, CommType]]) = (n, loopBody)
 }

--- a/src/main/scala/shine/DPIA/primitives/imperative/ForVec.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ForVec.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ForVec(val n: Nat, val dt: DataType, val out: Phrase[AccType], val loopBody: Phrase[FunType[ExpType, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/GenerateCont.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/GenerateCont.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class GenerateCont(val n: Nat, val dt: DataType, val f: Phrase[FunType[ExpType, FunType[FunType[ExpType, CommType], CommType]]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/IdxAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/IdxAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IdxAcc(val n: Nat, val dt: DataType, val index: Phrase[ExpType], val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/IdxVecAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/IdxVecAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IdxVecAcc(val n: Nat, val dt: DataType, val index: Phrase[ExpType], val vector: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/JoinAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/JoinAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class JoinAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/MapAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/MapAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapAcc(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[AccType, AccType]], val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/MapFstAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/MapFstAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapFstAcc(val dt1: DataType, val dt2: DataType, val dt3: DataType, val f: Phrase[FunType[AccType, AccType]], val record: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/MapRead.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/MapRead.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapRead(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, FunType[FunType[ExpType, CommType], CommType]]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/MapSndAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/MapSndAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapSndAcc(val dt1: DataType, val dt2: DataType, val dt3: DataType, val f: Phrase[FunType[AccType, AccType]], val record: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/New.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/New.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class New(val dt: DataType, val f: Phrase[FunType[PhrasePairType[ExpType, AccType], CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/NewDoubleBuffer.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/NewDoubleBuffer.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class NewDoubleBuffer(val dt1: DataType, val dt2: DataType, val dt3: DataType, val n: Nat, val in: Phrase[ExpType], val out: Phrase[AccType], val f: Phrase[FunType[PhrasePairType[PhrasePairType[PhrasePairType[ExpType, AccType], CommType], CommType], CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/PairAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/PairAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PairAcc(val dt1: DataType, val dt2: DataType, val fst: Phrase[AccType], val snd: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/PairAcc1.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/PairAcc1.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PairAcc1(val dt1: DataType, val dt2: DataType, val pair: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/PairAcc2.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/PairAcc2.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class PairAcc2(val dt1: DataType, val dt2: DataType, val pair: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/ReorderAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ReorderAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ReorderAcc(val n: Nat, val dt: DataType, val idxF: NatToNat, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/ScatterAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ScatterAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ScatterAcc(val n: Nat, val m: Nat, val dt: DataType, val indices: Phrase[ExpType], val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/Seq.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/Seq.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Seq(val c1: Phrase[CommType], val c2: Phrase[CommType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/Skip.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/Skip.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Skip() extends CommandPrimitive {
   override val t: CommType = comm

--- a/src/main/scala/shine/DPIA/primitives/imperative/SplitAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/SplitAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class SplitAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/TakeAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/TakeAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class TakeAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/TransposeAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/TransposeAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class TransposeAcc(val n: Nat, val m: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/UnzipAcc.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/UnzipAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class UnzipAcc(val n: Nat, val dt1: DataType, val dt2: DataType, val a: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/ZipAcc1.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ZipAcc1.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ZipAcc1(val n: Nat, val dt1: DataType, val dt2: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/DPIA/primitives/imperative/ZipAcc2.scala
+++ b/src/main/scala/shine/DPIA/primitives/imperative/ZipAcc2.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ZipAcc2(val n: Nat, val dt1: DataType, val dt2: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/Compilation/Passes/FlagPrivateArrayLoops.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/Passes/FlagPrivateArrayLoops.scala
@@ -67,9 +67,11 @@ object FlagPrivateArrayLoops {
           val i = f.loopBody.asInstanceOf[Lambda[_, _]].param
           eliminateVars -= i.name
           Continue(For(unroll = true)(f.n, f.loopBody), this)
-        case f@ForNat(_) if (eliminateVars(f.loopBody.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x.name)) =>
-          val i = f.loopBody.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x
-          eliminateVars -= i.name
+        case f@ForNat(_) if (eliminateVars(Kind.idName(
+          f.loopBody.asInstanceOf[DepLambda[_, _, _ <: Kind.Identifier, _]].kind,
+          f.loopBody.asInstanceOf[DepLambda[_, _, _ <: Kind.Identifier, _]].x))) =>
+          val b = f.loopBody.asInstanceOf[DepLambda[_, _, _ <: Kind.Identifier, _]]
+          eliminateVars -= Kind.idName(b.kind, b.x)
           Continue(ForNat(unroll = true)(f.n, f.loopBody), this)
         case pf@ParFor(level, dim, _, name) if (eliminateVars(pf.body.asInstanceOf[Lambda[_, _]].param.name)) =>
           pf.body match {
@@ -79,7 +81,9 @@ object FlagPrivateArrayLoops {
                 pf.init, pf.n, pf.step, pf.dt, pf.out, pf.body), this)
             case _ => throw new Exception("This should not happen")
           }
-        case pf@ParForNat(level, dim, _, name) if (eliminateVars(pf.body.asInstanceOf[DepLambda[_, _ <: Kind.Identifier, _]].x.name)) =>
+        case pf@ParForNat(level, dim, _, name) if (eliminateVars(Kind.idName(
+          pf.body.asInstanceOf[DepLambda[_, _, _ <: Kind.Identifier, _]].kind,
+          pf.body.asInstanceOf[DepLambda[_, _, _ <: Kind.Identifier, _]].x))) =>
           pf.body match {
             case DepLambda(NatKind, i: NatIdentifier, _) =>
               eliminateVars -= i.name

--- a/src/main/scala/shine/OpenCL/Compilation/SeparateHostAndKernelCode.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/SeparateHostAndKernelCode.scala
@@ -36,11 +36,11 @@ object SeparateHostAndKernelCode {
         case DepApply(_, fun, arg) => arg match {
           case a: Nat =>
             Stop(VisitAndRebuild(Lifting.liftDependentFunction(
-              fun.asInstanceOf[Phrase[NatIdentifier `()->:` ExpType]])(a)
+              fun.asInstanceOf[Phrase[`(nat)->:`[ExpType]]])(a)
               .asInstanceOf[Phrase[T]], this))
           case a: DataType =>
             Stop(VisitAndRebuild(Lifting.liftDependentFunction(
-              fun.asInstanceOf[Phrase[DataTypeIdentifier `()->:` ExpType]])(a)
+              fun.asInstanceOf[Phrase[`(dt)->:`[ExpType]]])(a)
               .asInstanceOf[Phrase[T]], this))
         }
 

--- a/src/main/scala/shine/OpenCL/DSL/package.scala
+++ b/src/main/scala/shine/OpenCL/DSL/package.scala
@@ -26,7 +26,7 @@ package object DSL {
   def parForNat(level: ParallelismLevel,
                 dim: Int,
                 unroll: Boolean
-               ): (Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) => ParForNat =
+               ): (Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, Kind.INat, FunType[AccType, CommType]]]) => ParForNat =
     level match {
       case Global =>    ParForNat(level, dim, unroll, "gl_id_")(
         get_global_id(dim), _, get_global_size(dim), _, _, _)
@@ -39,7 +39,7 @@ package object DSL {
 
   private def parForBodyFunction(n:Nat, ft:NatToData,
                                  f:NatIdentifier => Phrase[AccType] => Phrase[CommType]
-                                ): DepLambda[Nat, NatIdentifier, AccType ->: CommType] = {
+                                ): DepLambda[Nat, NatIdentifier, Kind.INat, AccType ->: CommType] = {
     nFun(idx => λ(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1))
   }
 

--- a/src/main/scala/shine/OpenCL/primitives/functional/CircularBuffer.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/CircularBuffer.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class CircularBuffer(val a: AddressSpace, val n: Nat, val alloc: Nat, val sz: Nat, val dt1: DataType, val dt2: DataType, val load: Phrase[FunType[ExpType, ExpType]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/DepMap.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/DepMap.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class DepMap(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMap(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val m = f.t.x
@@ -18,5 +19,5 @@ final case class DepMap(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: N
   }
   override val t: ExpType = expT(DepArrayType(n, ft2), write)
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): DepMap = new DepMap(level, dim)(v.nat(n), v.natToData(ft1), v.natToData(ft2), VisitAndRebuild(f, v), VisitAndRebuild(array, v))
-  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
+  def unwrap: (Nat, NatToData, NatToData, Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], Phrase[ExpType]) = (n, ft1, ft2, f, array)
 }

--- a/src/main/scala/shine/OpenCL/primitives/functional/Iterate.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/Iterate.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class Iterate(val a: AddressSpace, val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class Iterate(val a: AddressSpace, val n: Nat, val m: Nat, val k: Nat, val dt: DataType, val f: Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val l = f.t.x

--- a/src/main/scala/shine/OpenCL/primitives/functional/KernelCall.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/KernelCall.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class KernelCall(name: String, localSize: shine.OpenCL.LocalSize, globalSize: shine.OpenCL.GlobalSize, n: Int)(val inTs: Seq[DataType], val outT: DataType, val args: Seq[Phrase[ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/Map.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/Map.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Map(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/OpenCLFunctionCall.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/OpenCLFunctionCall.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class OpenCLFunctionCall(name: String, n: Int)(val inTs: Seq[DataType], val outT: DataType, val args: Seq[Phrase[ExpType]]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/ReduceSeq.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/ReduceSeq.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ReduceSeq(unroll: Boolean)(val n: Nat, val a: AddressSpace, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, FunType[ExpType, ExpType]]], val init: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/RotateValues.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/RotateValues.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class RotateValues(val a: AddressSpace, val n: Nat, val sz: Nat, val dt: DataType, val wrt: Phrase[FunType[ExpType, ExpType]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/Run.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/Run.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Run(localSize: shine.OpenCL.LocalSize, globalSize: shine.OpenCL.GlobalSize)(val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/functional/ToMem.scala
+++ b/src/main/scala/shine/OpenCL/primitives/functional/ToMem.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ToMem(val a: AddressSpace, val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/Barrier.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/Barrier.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Barrier(local: Boolean, global: Boolean)() extends CommandPrimitive {
   override val t: CommType = comm

--- a/src/main/scala/shine/OpenCL/primitives/imperative/HostExecution.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/HostExecution.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class HostExecution(params: Map[Identifier[_ <: PhraseType], shine.OpenCL.AccessFlags])(val body: Phrase[CommType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/IdxDistribute.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/IdxDistribute.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IdxDistribute(parallelismLevel: shine.OpenCL.ParallelismLevel)(val m: Nat, val n: Nat, val stride: Nat, val dt: DataType, val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/IdxDistributeAcc.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/IdxDistributeAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class IdxDistributeAcc(parallelismLevel: shine.OpenCL.ParallelismLevel)(val m: Nat, val n: Nat, val stride: Nat, val dt: DataType, val array: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/KernelCallCmd.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/KernelCallCmd.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class KernelCallCmd(name: String, localSize: shine.OpenCL.LocalSize, globalSize: shine.OpenCL.GlobalSize, n: Int)(val inTs: Seq[DataType], val dt: DataType, val args: Seq[Phrase[ExpType]], val output: Phrase[AccType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/New.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/New.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class New(val a: AddressSpace, val dt: DataType, val f: Phrase[FunType[PhrasePairType[ExpType, AccType], CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/NewDoubleBuffer.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/NewDoubleBuffer.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class NewDoubleBuffer(val a: AddressSpace, val dt1: DataType, val dt2: DataType, val dt3: DataType, val n: Nat, val in: Phrase[ExpType], val out: Phrase[AccType], val f: Phrase[FunType[PhrasePairType[PhrasePairType[PhrasePairType[ExpType, AccType], CommType], CommType], CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/NewManagedBuffer.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/NewManagedBuffer.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class NewManagedBuffer(access: shine.OpenCL.AccessFlags)(val dt: DataType, val k: Phrase[FunType[PhrasePairType[ExpType, AccType], CommType]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/ParFor.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/ParFor.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ParFor(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val dt: DataType, val out: Phrase[AccType], val body: Phrase[FunType[ExpType, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenCL/primitives/imperative/ParForNat.scala
+++ b/src/main/scala/shine/OpenCL/primitives/imperative/ParForNat.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class ParForNat(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) extends CommandPrimitive {
+final case class ParForNat(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, INat, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {
     out :: accT(DepArrayType(n, ft))
     body :: ({
@@ -18,5 +19,5 @@ final case class ParForNat(level: shine.OpenCL.ParallelismLevel, dim: Int, unrol
   }
   override val t: CommType = comm
   override def visitAndRebuild(v: VisitAndRebuild.Visitor): ParForNat = new ParForNat(level, dim, unroll, prefix)(v.nat(init), v.nat(n), v.nat(step), v.natToData(ft), VisitAndRebuild(out, v), VisitAndRebuild(body, v))
-  def unwrap: (Nat, Nat, Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) = (init, n, step, ft, out, body)
+  def unwrap: (Nat, Nat, Nat, NatToData, Phrase[AccType], Phrase[DepFunType[NatIdentifier, INat, FunType[AccType, CommType]]]) = (init, n, step, ft, out, body)
 }

--- a/src/main/scala/shine/OpenMP/primitives/functional/DepMapPar.scala
+++ b/src/main/scala/shine/OpenMP/primitives/functional/DepMapPar.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class DepMapPar(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
+final case class DepMapPar(val n: Nat, val ft1: NatToData, val ft2: NatToData, val f: Phrase[DepFunType[NatIdentifier, INat, FunType[ExpType, ExpType]]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {
     f :: ({
       val m = f.t.x

--- a/src/main/scala/shine/OpenMP/primitives/functional/MapPar.scala
+++ b/src/main/scala/shine/OpenMP/primitives/functional/MapPar.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapPar(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenMP/primitives/functional/ReducePar.scala
+++ b/src/main/scala/shine/OpenMP/primitives/functional/ReducePar.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ReducePar(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, FunType[ExpType, ExpType]]], val init: Phrase[ExpType], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/OpenMP/primitives/imperative/ParFor.scala
+++ b/src/main/scala/shine/OpenMP/primitives/imperative/ParFor.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ParFor(val n: Nat, val dt: DataType, val out: Phrase[AccType], val body: Phrase[FunType[ExpType, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/OpenMP/primitives/imperative/ParForNat.scala
+++ b/src/main/scala/shine/OpenMP/primitives/imperative/ParForNat.scala
@@ -6,8 +6,9 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
-final case class ParForNat(val n: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, FunType[AccType, CommType]]]) extends CommandPrimitive {
+final case class ParForNat(val n: Nat, val ft: NatToData, val out: Phrase[AccType], val body: Phrase[DepFunType[NatIdentifier, INat, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {
     out :: accT(DepArrayType(n, ft))
     body :: ({

--- a/src/main/scala/shine/cuda/primitives/functional/AsFragment.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/AsFragment.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsFragment(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/AsMatrix.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/AsMatrix.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class AsMatrix(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/GenerateFragment.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/GenerateFragment.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class GenerateFragment(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val fill: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/GlobalToShared.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/GlobalToShared.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class GlobalToShared(val dt: DataType, val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/Map.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/Map.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class Map(level: shine.OpenCL.ParallelismLevel, dim: Int)(val n: Nat, val dt1: DataType, val dt2: DataType, val f: Phrase[FunType[ExpType, ExpType]], val array: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/MapFragment.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/MapFragment.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class MapFragment(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val f: Phrase[FunType[ExpType, ExpType]], val input: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/functional/TensorMatMultAdd.scala
+++ b/src/main/scala/shine/cuda/primitives/functional/TensorMatMultAdd.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class TensorMatMultAdd(val m: Nat, val n: Nat, val k: Nat, val layoutA: MatrixLayout, val layoutB: MatrixLayout, val dt1: DataType, val dt2: DataType, val aMatrix: Phrase[ExpType], val bMatrix: Phrase[ExpType], val cMatrix: Phrase[ExpType]) extends ExpPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/ForFragment.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/ForFragment.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ForFragment(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val in: Phrase[ExpType], val out: Phrase[AccType], val fun: Phrase[FunType[ExpType, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/GlobalToSharedAcc.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/GlobalToSharedAcc.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class GlobalToSharedAcc(val dt: DataType, val pipe: Phrase[ExpType], val outputShared: Phrase[AccType]) extends AccPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/ParFor.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/ParFor.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class ParFor(level: shine.OpenCL.ParallelismLevel, dim: Int, unroll: Boolean, prefix: String)(val init: Nat, val n: Nat, val step: Nat, val dt: DataType, val out: Phrase[AccType], val body: Phrase[FunType[ExpType, FunType[AccType, CommType]]]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/SyncPipeline.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/SyncPipeline.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class SyncPipeline(val pipe: Phrase[ExpType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/SyncThreads.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/SyncThreads.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class SyncThreads() extends CommandPrimitive {
   override val t: CommType = comm

--- a/src/main/scala/shine/cuda/primitives/imperative/SyncWarp.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/SyncWarp.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class SyncWarp() extends CommandPrimitive {
   override val t: CommType = comm

--- a/src/main/scala/shine/cuda/primitives/imperative/WmmaFill.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/WmmaFill.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class WmmaFill(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val fill: Phrase[ExpType], val target: Phrase[AccType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/WmmaLoad.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/WmmaLoad.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class WmmaLoad(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val frag: FragmentKind, val layout: MatrixLayout, val matrixTile: Phrase[ExpType], val target: Phrase[AccType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/WmmaMMA.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/WmmaMMA.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class WmmaMMA(val m: Nat, val n: Nat, val k: Nat, val layoutA: MatrixLayout, val layoutB: MatrixLayout, val dt1: DataType, val dt2: DataType, val aMatrix: Phrase[ExpType], val bMatrix: Phrase[ExpType], val cMatrix: Phrase[ExpType], val resultMatrix: Phrase[AccType]) extends CommandPrimitive {
   assert {

--- a/src/main/scala/shine/cuda/primitives/imperative/WmmaStore.scala
+++ b/src/main/scala/shine/cuda/primitives/imperative/WmmaStore.scala
@@ -6,6 +6,7 @@ import arithexpr.arithmetic._
 import shine.DPIA.Phrases._
 import shine.DPIA.Types.DataType._
 import shine.DPIA.Types._
+import shine.DPIA.Types.Kind.{ Identifier => _, _ }
 import shine.DPIA._
 final case class WmmaStore(val rows: Nat, val columns: Nat, val layers: Nat, val dt: DataType, val value: Phrase[ExpType], val matrixTile: Phrase[AccType]) extends CommandPrimitive {
   assert {

--- a/src/test/scala/shine/DPIA/InferAccessTypes.scala
+++ b/src/test/scala/shine/DPIA/InferAccessTypes.scala
@@ -102,7 +102,7 @@ class InferAccessTypes extends test_util.Tests {
     val splitArray = (depFun((n: Nat) => fun(8`.`rt.f32)(arr =>
       arr |> split(n)))).toExpr
     val infPt = inferAccess(splitArray).get(splitArray).asInstanceOf[
-      DepFunType[NatIdentifier, FunType[ExpType, ExpType]]
+      DepFunType[NatIdentifier, Kind.INat, FunType[ExpType, ExpType]]
     ]
     assertResult(read)(infPt.t.outT.accessType)
   }


### PR DESCRIPTION
This way `NamedVar`s are uniform across RISE, DPIA, and arithexpr. This accomplishes two things:
- it is a first step towards the unification of types across RISE and DPIA
- it renders the set of bugs product of `DPIA -> arithexpr -> DPIA` translations irrelevant.