### PR TITLE
Preparation for Scala 3 migration

### DIFF
--- a/src/main/scala/apps/cameraPipeline.scala
+++ b/src/main/scala/apps/cameraPipeline.scala
@@ -281,7 +281,7 @@ object cameraPipeline {
       (lf32(1.0f) / kelvin - lf32(1.0f / 3200)) / lf32(1.0f / 7000 - 1.0f / 3200)
     (
       zipND(2)(matrix_3200, matrix_7000) |>
-        map(map(fun(p => p._1 * alpha + p._2 * (lf32(1.0f) - alpha)))) >>
+        map(map(fun(p => p.`1` * alpha + p.`2` * (lf32(1.0f) - alpha)))) >>
           map(map(fun(v => cast(v * lf32(256.0f)) :: i16))) // Q8.8 fixed point
       ) |> fun(matrix =>
         input |> transpose >>
@@ -380,11 +380,11 @@ object cameraPipeline {
           blur121(u8)(u16)),
           unsharp => {
           letImage(mapImage(zipImage(plane, unsharp), fun(p =>
-            (cast(p._1) :: i16) - (cast(p._2) :: i16)
+            (cast(p.`1`) :: i16) - (cast(p.`2`) :: i16)
           )), mask => {
             mapImage(zipImage(plane, mask), fun(p =>
-              u8_sat(i16)((cast(p._1) :: i16)
-                + (p._2 * (cast(strength_x32) :: i16)) / li16(32))
+              u8_sat(i16)((cast(p.`1`) :: i16)
+                + (p.`2` * (cast(strength_x32) :: i16)) / li16(32))
             )).expr
           })
         }))

--- a/src/main/scala/apps/convolution.scala
+++ b/src/main/scala/apps/convolution.scala
@@ -23,8 +23,8 @@ object convolution {
 
   private val dotElemWeightsSeq = fun((weights, elem) =>
     oclReduceSeqUnroll(AddressSpace.Private)(fun((acc, pair) => {
-      val pixel = pair._1
-      val weight = pair._2
+      val pixel = pair.`1`
+      val weight = pair.`2`
       acc + (pixel * weight)
     }))(lf32(0.0f))(zip(join(elem))(weights)))
 
@@ -143,9 +143,7 @@ object convolution {
     matrix: Array[Array[Float]],
     weights: Array[Float]
   ): (Array[Float], TimeSpan[Time.ms]) = {
-    val f = k.as[ScalaFunction `(`
-      Array[Array[Float]] `,` Array[Float]
-      `)=>` Array[Float]]
+    val f = k.as[Args `(` Array[Array[Float]] `,` Array[Float], Array[Float]]
     f(localSize, globalSize)(matrix `,` weights)
   }
 }

--- a/src/main/scala/apps/gemv.scala
+++ b/src/main/scala/apps/gemv.scala
@@ -10,7 +10,7 @@ import HighLevelConstructs.reorderWithStride
 
 object gemv {
   // we can use implicit type parameters and type annotations to specify the function type of mult
-  val mult = impl{ dt: DataType => fun(x => x._1 * x._2) :: ((dt x dt) ->: dt) }
+  val mult = impl{ dt: DataType => fun(x => x.`1` * x.`2`) :: ((dt x dt) ->: dt) }
   val add = fun(x => fun(y => x + y))
   val scal = impl { n: Nat =>
     fun(xs => fun(a =>
@@ -30,7 +30,7 @@ object gemv {
       (m`.`f32)
   )((mat, xs, ys, alpha, beta) =>
     zip(map(fun(row => alpha * dot(row, xs)))(mat))(scal(ys, beta)) |>
-    map(fun(x => x._1 + x._2))
+    map(fun(x => x.`1` + x.`2`))
   ))
 
   val gemvSequential = depFun((n: Nat, m: Nat) => fun(
@@ -38,7 +38,7 @@ object gemv {
       (m`.`f32)
   )((mat, xs, ys, alpha, beta) =>
     toMem(zip(mapSeq(fun(row => alpha * dotSeq(row, xs)))(mat))(scalSeq(ys, beta))) |>
-    mapSeq(fun(x => x._1 + x._2))
+    mapSeq(fun(x => x.`1` + x.`2`))
   ))
 
   object ocl {
@@ -81,12 +81,12 @@ object gemv {
     )((mat, xs, ys, alpha, beta) =>
       zip(mat)(ys) |>
         mapWorkGroup(fun(t =>
-          zip(xs)(t._1) |>
+          zip(xs)(t.`1`) |>
             split(n) |>
             toLocalFun(mapLocal(
               reduceSeq(fun(a => fun(x => mult(x) + a)))(lf32(0.0f))
             )) |>
-            mapLocal(fun(x => (alpha * x) + (t._2 * beta)))
+            mapLocal(fun(x => (alpha * x) + (t.`2` * beta)))
         )) |> join
     ))
 
@@ -95,7 +95,7 @@ object gemv {
     )((mat, xs, ys, alpha, beta) =>
       zip(mat)(ys) |>
         mapWorkGroup(fun(t =>
-          zip(xs)(t._1) |>
+          zip(xs)(t.`1`) |>
             reorderWithStride(128) |>
             split(n /^ 128) |>
             toLocalFun(mapLocal(
@@ -103,7 +103,7 @@ object gemv {
             )) |>
             split(128) |>
             toLocalFun(mapLocal(reduceSeq(add)(lf32(0.0f)))) |>
-            mapLocal(fun(x => (alpha * x) + (t._2 * beta)))
+            mapLocal(fun(x => (alpha * x) + (t.`2` * beta)))
         )) |> join
     ))
 
@@ -113,14 +113,14 @@ object gemv {
     )((mat, xs, ys, alpha, beta) =>
       zip(mat)(ys) |>
         mapWorkGroup(fun(t =>
-          zip(xs)(t._1) |>
+          zip(xs)(t.`1`) |>
             reorderWithStride(128) |>
             split(n /^ 128) |>
             toLocalFun(mapLocal(
               reduceSeq(fun(a => fun(x => mult(x) + a)))(lf32(0.0f))
             )) |>
             toLocalFun(reduceSeq(add)(lf32(0.0f))) |>
-            fun(x => (alpha * x) + (t._2 * beta))
+            fun(x => (alpha * x) + (t.`2` * beta))
         ))
     ))
   }
@@ -134,10 +134,10 @@ object gemv {
     )((mat, xs, ys, alpha, beta) =>
       zip(mat)(ys) |>
         mapPar(fun(t =>
-          zip(xs)(t._1) |>
+          zip(xs)(t.`1`) |>
             split(n) |>
             toMemFun(mapSeq(reduceSeq(fun(a => fun(x => mult(x) + a)))(lf32(0.0f)))) |>
-            mapSeq(fun(x => (alpha * x) + (t._2 * beta)))
+            mapSeq(fun(x => (alpha * x) + (t.`2` * beta)))
         )) |> join
     ))
   }
@@ -208,10 +208,10 @@ object gemv {
     val localSize = cgo17_localSize
     val globalSize = GlobalSize(M)
 
-    val run = kernel.as[ScalaFunction `(`
+    val run = kernel.as[Args `(`
       Int `,` Int `,` Array[Array[Float]] `,`
-      Array[Float] `,` Array[Float] `,` Float `,` Float
-    `)=>` Array[Float]]
+      Array[Float] `,` Array[Float] `,` Float `,` Float,
+      Array[Float]]
     run(localSize, globalSize)(N `,` M `,` mat `,` xs `,` ys `,` alpha `,` beta)
   }
 }

--- a/src/main/scala/apps/kmeans.scala
+++ b/src/main/scala/apps/kmeans.scala
@@ -12,7 +12,7 @@ import shine.OpenCL.KernelExecutor._
 
 object kmeans {
   private val update = fun(f32 ->: (f32 x f32) ->: f32)((dist, pair) =>
-    dist + (pair._1 - pair._2) * (pair._1 - pair._2)
+    dist + (pair.`1` - pair.`2`) * (pair.`1` - pair.`2`)
   )
 
   private val testF = foreignFun("test",
@@ -29,7 +29,7 @@ object kmeans {
       }""".stripMargin,
     f32 ->: (f32 x (int x int)) ->: (f32 x (int x int)))
 
-  private val select = fun(tuple => tuple._2._2)
+  private val select = fun(tuple => tuple.`2`.`2`)
 
   // FIXME: could not find original Lift expression, this is made up
   val kmeansHighLevel: Expr = depFun((p: Nat, c: Nat, f: Nat) => fun(
@@ -116,9 +116,9 @@ object kmeans {
     val localSize = LocalSize(256)
     val globalSize = GlobalSize(P)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]]
-      `)=>` Array[Int]]
+    val f = k.as[Args `(`
+      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]],
+      Array[Int]]
     f(localSize, globalSize)(P `,` C `,` F `,` features `,` clusters)
   }
 }

--- a/src/main/scala/apps/mm.scala
+++ b/src/main/scala/apps/mm.scala
@@ -53,14 +53,14 @@ object mm {
         mapGlobal(0)(fun(v3`.`o`.`f32)(p4 =>
           zip(transpose(p3))(transpose(p4)) |> // o.(Mi.f x Ni.f)
           oclReduceSeq(AddressSpace.Private)(fun((p6, p7) =>
-            let (toPrivate(makePair(mapSeq(id)(p7._1))(
-              asScalar o mapSeq(id) o asVectorAligned(vw) $ p7._2)))
+            let (toPrivate(makePair(mapSeq(id)(p7.`1`))(
+              asScalar o mapSeq(id) o asVectorAligned(vw) $ p7.`2`)))
             be (x =>
               mapSeq(fun(p8 =>
                 mapSeq(fun(p9 =>
-                  p9._1 + (p8._2 * p9._2)
-                ))(zip(p8._1)(x._2))
-              ))(zip(p6)(x._1))
+                  p9.`1` + (p8.`2` * p9.`2`)
+                ))(zip(p8.`1`)(x.`2`))
+              ))(zip(p6)(x.`1`))
             )
           ))(mapSeq(mapSeq(id))(generate(fun(_ => generate(fun(_ => lf32(0.0f)))))) :: (v4`.`v3`.`f32)) |> //
           mapSeq(asScalar o mapSeq(id) o asVector(vw)) |>
@@ -98,32 +98,32 @@ object mm {
                 oclReduceSeq(AddressSpace.Local)(fun((p13, p14) =>
                   // (v5/^v4).(v7/^v3).v4.v3.f x (v8.v5.f x v8.v7.f)
                   let (toLocal(makePair(
-                    p14._1 |> join |> split(v6) |> // ((v8 x v5) /^ v6).v6.f
+                    p14.`1` |> join |> split(v6) |> // ((v8 x v5) /^ v6).v6.f
                       mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4)) |>
                       join |> split(v5)
                   )( // v8.v5.f
-                    p14._2 |> // v8.v7.f
+                    p14.`2` |> // v8.v7.f
                       mapLocal(1)(asScalar o mapLocal(0)(id) o asVectorAligned(4))
                   )))
                     be (p15 =>
-                    zip(p13)(split(v4)(transpose(p15._1))) |> // (v5/^v4).((v7/^v3).v4.v3.f x v4.v8.f)
+                    zip(p13)(split(v4)(transpose(p15.`1`))) |> // (v5/^v4).((v7/^v3).v4.v3.f x v4.v8.f)
                       mapLocal(1)(fun(p16 =>
-                        zip(p16._1)(split(v3)(transpose(p15._2))) |> // (v7/^v3).(v4.v3.f x v3.v8.f)
+                        zip(p16.`1`)(split(v3)(transpose(p15.`2`))) |> // (v7/^v3).(v4.v3.f x v3.v8.f)
                           mapLocal(0)(fun(p17 =>
-                            zip(transpose(p16._2))(transpose(p17._2)) |> // v8.(v4.f x v3.f)
+                            zip(transpose(p16.`2`))(transpose(p17.`2`)) |> // v8.(v4.f x v3.f)
                               oclReduceSeq(AddressSpace.Private)(fun((p19, p20) =>
                                 // v4.v3.f x (v4.f x v3.f)
-                                let (toPrivate(makePair(mapSeq(id)(p20._1))(mapSeq(id)(p20._2))))
+                                let (toPrivate(makePair(mapSeq(id)(p20.`1`))(mapSeq(id)(p20.`2`))))
                                   be (p21 =>
-                                  zip(p19)(p21._1) |> // v4.(v3.f x f)
+                                  zip(p19)(p21.`1`) |> // v4.(v3.f x f)
                                     mapSeq(fun(p22 =>
-                                      zip(p22._1)(p21._2) |> // v3.(f x f)
+                                      zip(p22.`1`)(p21.`2`) |> // v3.(f x f)
                                         mapSeq(fun(p23 =>
-                                          p23._1 + (p22._2 * p23._2)
+                                          p23.`1` + (p22.`2` * p23.`2`)
                                         ))
                                     ))
                                   )
-                              ))(p17._1 // v4.v3.f
+                              ))(p17.`1` // v4.v3.f
                                 |> mapSeq(mapSeq(id)) // TODO: think about that
                               ) |> mapSeq(mapSeq(id)) // TODO: think about that
                           ))
@@ -219,9 +219,9 @@ object mm {
     val N = At(0).length
     val M = B(0).length
 
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]]
-      `)=>` Array[Float]]
+    val run = kernel.as[Args `(`
+      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]],
+      Array[Float]]
     run(localSize, globalSize)(N `,` M `,` O `,` At `,` B)
   }
 }

--- a/src/main/scala/apps/mriQ.scala
+++ b/src/main/scala/apps/mriQ.scala
@@ -35,13 +35,13 @@ object mriQ {
   val computePhiMagHighLevel: Expr = depFun((k: Nat) => fun(
     (k `.` f32) ->: (k `.` f32) ->: (k `.` f32)
   )((phiR, phiI) =>
-    map(fun(t => phiMag(t._1)(t._2)))(zip(phiR)(phiI))
+    map(fun(t => phiMag(t.`1`)(t.`2`)))(zip(phiR)(phiI))
   ))
 
   val computePhiMagOcl: Expr = depFun((k: Nat) => fun(
     (k `.` f32) ->: (k `.` f32) ->: (k `.` f32)
   )((phiR, phiI) =>
-    mapGlobal(fun(t => phiMag(t._1)(t._2)))(zip(phiR)(phiI))
+    mapGlobal(fun(t => phiMag(t.`1`)(t.`2`)))(zip(phiR)(phiI))
   ))
 
   // FIXME: could not find original Lift expression, this is made up
@@ -51,8 +51,8 @@ object mriQ {
     zip(x)(zip(y)(zip(z)(zip(Qr)(Qi)))) |>
       map(fun(t =>
           kvalues |> reduceSeq(fun((acc, p) =>
-            qFun(t._1)(t._2._1)(t._2._2._1)(p._1._1._1)(p._1._1._2)(p._1._2)(p._2)(acc)
-          ))(makePair(t._2._2._2._1)(t._2._2._2._2))
+            qFun(t.`1`)(t.`2`.`1`)(t.`2`.`2`.`1`)(p.`1`.`1`.`1`)(p.`1`.`1`.`2`)(p.`1`.`2`)(p.`2`)(acc)
+          ))(makePair(t.`2`.`2`.`2`.`1`)(t.`2`.`2`.`2`.`2`))
       ))
   ))
 
@@ -61,15 +61,15 @@ object mriQ {
   )((x, y, z, Qr, Qi, kvalues) =>
     zip(x)(zip(y)(zip(z)(zip(Qr)(Qi)))) |>
     mapGlobal(fun(t =>
-      let (toPrivate(t._1))
+      let (toPrivate(t.`1`))
       be (sX =>
-        let (toPrivate(t._2._1))
+        let (toPrivate(t.`2`.`1`))
         be (sY =>
-          let (toPrivate(t._2._2._1))
+          let (toPrivate(t.`2`.`2`.`1`))
           be (sZ =>
             kvalues |> oclReduceSeq(AddressSpace.Private)(fun((acc, p) =>
-              qFun(sX)(sY)(sZ)(p._1._1._1)(p._1._1._2)(p._1._2)(p._2)(acc)
-            ))(makePair(t._2._2._2._1)(t._2._2._2._2))
+              qFun(sX)(sY)(sZ)(p.`1`.`1`.`1`)(p.`1`.`1`.`2`)(p.`1`.`2`)(p.`2`)(acc)
+            ))(makePair(t.`2`.`2`.`2`.`1`)(t.`2`.`2`.`2`.`2`))
           )
         )
       )
@@ -126,9 +126,9 @@ object mriQ {
     val localSize = LocalSize(256)
     val globalSize = GlobalSize(K)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Array[Float]
-      `)=>` Array[Float]]
+    val f = k.as[Args `(`
+      Int `,` Array[Float] `,` Array[Float],
+      Array[Float]]
     f(localSize, globalSize)(K `,` phiR `,` phiI)
   }
 
@@ -196,11 +196,11 @@ object mriQ {
     val localSize = LocalSize(256 / 4)
     val globalSize = GlobalSize(X)
 
-    val f = k.as[ScalaFunction `(`
+    val f = k.as[Args `(`
       Int `,` Int `,`
       Array[Float] `,` Array[Float] `,` Array[Float] `,`
-      Array[Float] `,` Array[Float] `,` Array[Float]
-      `)=>` Array[Float]]
+      Array[Float] `,` Array[Float] `,` Array[Float],
+      Array[Float]]
     f(localSize, globalSize)(
       K `,` X `,` x `,` y `,` z `,` Qr `,` Qi `,` kvalues
     )

--- a/src/main/scala/apps/nbody.scala
+++ b/src/main/scala/apps/nbody.scala
@@ -122,7 +122,7 @@ object nbody {
         fun(tileX`.`(vec(4, f32) x vec(4, f32)))(newP1Chunk =>
           mapLocal(1)(fun(tileX`.`vec(4, f32))(bla =>
             mapLocal(0)(fun((vec(4, f32) x vec(4, f32)) x vec(4, f32))(p1 =>
-              update(p1._1._1)(p1._1._2)(deltaT)(p1._2)
+              update(p1.`1`.`1`)(p1.`1`.`2`)(deltaT)(p1.`2`)
             ))(zip(newP1Chunk)(bla)))) o
             // TODO: is this the correct address space?
             oclReduceSeq(AddressSpace.Local)(
@@ -132,15 +132,15 @@ object nbody {
                   mapLocal(1)(fun(((tileX`.`vec(4, f32)) x (tileX`.`vec(4, f32))) ->: (tileX`.`vec(4, f32)))(accDim2 =>
                     mapLocal(0)(fun(((vec(4, f32) x vec(4, f32)) x vec(4, f32)) ->: vec(4, f32))(p1 =>
                       oclReduceSeq(AddressSpace.Private)(fun(vec(4, f32) ->: vec(4, f32) ->: vec(4, f32))((acc, p2) =>
-                        calcAcc(p1._1._1)(p2)(deltaT)(espSqr)(acc)
-                      ))(p1._2)(accDim2._1)
-                    )) $ zip(newP1Chunk)(accDim2._2)
+                        calcAcc(p1.`1`.`1`)(p2)(deltaT)(espSqr)(acc)
+                      ))(p1.`2`)(accDim2.`1`)
+                    )) $ zip(newP1Chunk)(accDim2.`2`)
                   )) $ zip(p2Local)(acc)
                 )
               )))(mapLocal(1)(mapLocal(0)(id))(generate(fun(_ => generate(fun(_ => vectorFromScalar(lf32(0.0f))))))))
             o split(tileY) o split(tileX) $ pos
           // TODO: toPrivate when it works..
-        ) $ zip(toLocal(mapLocal(id)(unzip(p1Chunk)._1)))(unzip(p1Chunk)._2)
+        ) $ zip(toLocal(mapLocal(id)(unzip(p1Chunk).`1`)))(unzip(p1Chunk).`2`)
       )) o split(tileX)
     ) o split(n) $ zip(pos)(vel)
   ))
@@ -198,9 +198,9 @@ object nbody {
     assert(pos.length % 4 == 0)
     val N = pos.length / 4
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Array[Float] `,` Float `,` Float
-      `)=>` Array[Float]]
+    val f = k.as[Args `(`
+      Int `,` Array[Float] `,` Array[Float] `,` Float `,` Float,
+      Array[Float]]
     f(localSize, globalSize)(N `,` pos `,` vel `,` espSqr `,` deltaT)
   }
 

--- a/src/main/scala/apps/nearestNeighbour.scala
+++ b/src/main/scala/apps/nearestNeighbour.scala
@@ -82,9 +82,9 @@ object nearestNeighbour {
     val localSize = LocalSize(128)
     val globalSize = GlobalSize(N)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Float `,` Float
-      `)=>` Array[Float]]
+    val f = k.as[Args `(`
+      Int `,` Array[Float] `,` Float `,` Float,
+      Array[Float]]
     f(localSize, globalSize)(N `,` locations `,` lat `,` lng)
   }
 

--- a/src/main/scala/apps/sgemm.scala
+++ b/src/main/scala/apps/sgemm.scala
@@ -16,11 +16,11 @@ import scala.collection.parallel.CollectionConverters._
 
 object sgemm {
   // we can use implicit type parameters and type annotations to specify the function type of mult
-  val mult: ToBeTyped[Expr] = impl{ dt: DataType => fun(x => x._1 * x._2) :: ((dt x dt) ->: dt) }
+  val mult: ToBeTyped[Expr] = impl{ dt: DataType => fun(x => x.`1` * x.`2`) :: ((dt x dt) ->: dt) }
   val add: ToBeTyped[Expr] = fun(x => fun(y => x + y))
   val scal: ToBeTyped[Expr] = impl{ n: Nat =>
     fun(xs => fun(a => mapSeq(fun(x => a * x))(xs))) :: (ArrayType(n, f32) ->: f32 ->: ArrayType(n, f32)) }
-  val dot: ToBeTyped[Expr] = fun(x => foreignFun("dot", vec(4, f32) ->: vec(4, f32) ->: f32)(x._1, x._2))
+  val dot: ToBeTyped[Expr] = fun(x => foreignFun("dot", vec(4, f32) ->: vec(4, f32) ->: f32)(x.`1`, x.`2`))
   def id: ToBeTyped[Expr] = fun(x => x)
 
   object c {
@@ -30,10 +30,10 @@ object sgemm {
         ((a, b, c, alpha, beta) =>
 
           zip(a)(c) |> mapSeq(fun(ac =>
-            zip(transpose(b))(ac._2) |> mapSeq(fun(bc =>
-              zip(ac._1)(bc._1) |>
-                reduceSeq(fun( (acc, y) => acc + (y._1 * y._2)))(lf32(0.0f)) |>
-                fun(x => (x * alpha) + (beta * bc._2))
+            zip(transpose(b))(ac.`2`) |> mapSeq(fun(bc =>
+              zip(ac.`1`)(bc.`1`) |>
+                reduceSeq(fun( (acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f)) |>
+                fun(x => (x * alpha) + (beta * bc.`2`))
             ))
           ))
         )
@@ -46,10 +46,10 @@ object sgemm {
       ((a, b, c, alpha, beta) =>
 
         zip(a)(c) |> mapSeq(fun(ac =>
-          zip(transpose(b))(ac._2) |> mapSeq(fun(bc =>
-            zip(ac._1)(bc._1) |>
-              oclReduceSeq(AddressSpace.Private)(fun( (acc, y) => acc + (y._1 * y._2)))(lf32(0.0f)) |>
-              fun(x => (x * alpha) + (beta * bc._2))
+          zip(transpose(b))(ac.`2`) |> mapSeq(fun(bc =>
+            zip(ac.`1`)(bc.`1`) |>
+              oclReduceSeq(AddressSpace.Private)(fun( (acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f)) |>
+              fun(x => (x * alpha) + (beta * bc.`2`))
           ))
         ))
       )
@@ -75,24 +75,24 @@ object sgemm {
 
         zip(split(p2)(A))(split(p2)(C)) |>
           mapGlobal(0)(fun(ac =>
-            zip(split(p2)(B))(split(p1)(transpose(ac._2))) |>
+            zip(split(p2)(B))(split(p1)(transpose(ac.`2`))) |>
               mapGlobal(1)(fun(bc =>
-                zip(split(p3)(transpose(ac._1)))(split(p3)(transpose(bc._1))) |>
+                zip(split(p3)(transpose(ac.`1`)))(split(p3)(transpose(bc.`1`))) |>
                   oclReduceSeq(AddressSpace.Private)(fun((p67, p236) =>
-                    zip(p67)(transpose(p236._1)) |>
+                    zip(p67)(transpose(p236.`1`)) |>
                       mapSeq(fun(p54 =>
-                        zip(p54._1)(transpose(p236._2)) |>
+                        zip(p54.`1`)(transpose(p236.`2`)) |>
                           mapSeq(fun(p157 =>
-                            zip(asVectorAligned(vw)(p54._2))(asVectorAligned(vw)(p157._2)) |>
-                              mapSeq(fun(x => p157._1 + dot(x)))
+                            zip(asVectorAligned(vw)(p54.`2`))(asVectorAligned(vw)(p157.`2`)) |>
+                              mapSeq(fun(x => p157.`1` + dot(x)))
                           )) |> join
                       ))
                   ), write_zeros) |>
                   fun(p235 =>
-                    zip(p235)(transpose(bc._2)) |>
+                    zip(p235)(transpose(bc.`2`)) |>
                       mapSeq(fun(p237 =>
-                        zip(p237._1)(p237._2) |>
-                          mapSeq(fun(p64 => (p64._1 * alpha) + (p64._2 * beta)))
+                        zip(p237.`1`)(p237.`2`) |>
+                          mapSeq(fun(p64 => (p64.`1` * alpha) + (p64.`2` * beta)))
                       ))
                   ) |> transpose
               )) |> join |> transpose
@@ -122,23 +122,23 @@ object sgemm {
 
     def redOp: ToBeTyped[Expr] = fun((8`.`32`.`8`.`4`.`f32) ->: ( (8`.`64`.`f32) x (8`.`128`.`f32) ) ->: (8`.`32`.`8`.`4`.`f32) )((p14, p15) =>
       let(p15 |> fun(p29 =>
-          zip (p29._1) (p29._2)
-            |> toLocalFun(mapLocal(1) (fun(p31 => makePair (mapLocal(0) (id) (p31._1)) (mapLocal(0) (id) (p31._2)) )))
+          zip (p29.`1`) (p29.`2`)
+            |> toLocalFun(mapLocal(1) (fun(p31 => makePair (mapLocal(0) (id) (p31.`1`)) (mapLocal(0) (id) (p31.`2`)) )))
             |> unzip
         ))
       be (p16 =>
-        zip (p14) (split (v5) (transpose (p16._1)))
+        zip (p14) (split (v5) (transpose (p16.`1`)))
           |> mapLocal(1) (fun(p17 =>
-          zip (p17._1) (split (v4) (reorderWithStride (v3/v4) (transpose (p16._2))))
+          zip (p17.`1`) (split (v4) (reorderWithStride (v3/v4) (transpose (p16.`2`))))
             |> mapLocal(0) (fun(p18 =>
-            zip (transpose (p17._2)) (transpose (p18._2))
+            zip (transpose (p17.`2`)) (transpose (p18.`2`))
               |> oclReduceSeq (AddressSpace.Private) (fun( (p20, p21) =>
-                let (makePair (toPrivate(mapSeq (id) (p21._1))) (toPrivate(mapSeq (id) (p21._2))))
+                let (makePair (toPrivate(mapSeq (id) (p21.`1`))) (toPrivate(mapSeq (id) (p21.`2`))))
                 be (fun(p22 =>
-                    zip (p20) (p22._1) |> mapSeq (fun(p23 =>
-                      zip (p23._1) (p22._2) |> mapSeq (fun(p24 =>
-                        p24._1 + (p23._2 * p24._2) )) )) ))
-              )) (p18._1 |> mapSeq (mapSeq (fun(x => x))) )
+                    zip (p20) (p22.`1`) |> mapSeq (fun(p23 =>
+                      zip (p23.`1`) (p22.`2`) |> mapSeq (fun(p24 =>
+                        p24.`1` + (p23.`2` * p24.`2`) )) )) ))
+              )) (p18.`1` |> mapSeq (mapSeq (fun(x => x))) )
               |> mapSeq (mapSeq (fun(x => x)))
           ))
         ))
@@ -154,22 +154,22 @@ object sgemm {
         |> mapWorkGroup(1)(
           //BEGIN mapWorkGroup(1) Function
           fun(p2 =>
-          zip (tile2 (v7) (v3) (B)) (p2._2)
+          zip (tile2 (v7) (v3) (B)) (p2.`2`)
           |> mapWorkGroup(0)(
             //BEGIN mapWorkGroup(0) Function
             fun(p3 =>
-            zip (p2._1) (p3._1)
+            zip (p2.`1`) (p3.`1`)
             |> oclReduceSeq (AddressSpace.Private) (redOp)
               (zeros (v4) (v5) (v3 * Cst(1) /^ v4) (v6 * Cst(1) /^ v5)
                 |> mapLocal(1) (mapLocal(0) (mapSeq (mapSeq (id)))))
             //mapSeq was removed because reduce does not wrap reduced results in arrays anymore
             |> fun(x =>
-              zip (x) (split (v5) (p3._2))
+              zip (x) (split (v5) (p3.`2`))
                 |> mapLocal(1) (fun(y =>
-                zip (y._1) (split (v4) (reorderWithStride (v3/v4) (transpose (y._2)))) |> mapLocal(0) (fun(z =>
-                  zip (z._1) (transpose (z._2)) |> mapSeq (fun(a =>
-                    zip (a._1) (a._2) |> mapSeq (fun(x =>
-                      (x._1 * alpha) + (x._2 * beta) )))))))))
+                zip (y.`1`) (split (v4) (reorderWithStride (v3/v4) (transpose (y.`2`)))) |> mapLocal(0) (fun(z =>
+                  zip (z.`1`) (transpose (z.`2`)) |> mapSeq (fun(a =>
+                    zip (a.`1`) (a.`2`) |> mapSeq (fun(x =>
+                      (x.`1` * alpha) + (x.`2` * beta) )))))))))
             |> map (fun(p4 => p4
               |> map (transpose)
               |> join
@@ -292,13 +292,14 @@ object sgemm {
                      alpha: Float, beta: Float,
                      M: Int, N: Int, K: Int): (Array[Float], TimeSpan[Time.ms]) = {
 
-    val runKernel = kernel.as[ScalaFunction `(`
+    val runKernel = kernel.as[Args `(`
       Int `,` Int `,` Int `,`
       Array[Array[Float]] `,`
       Array[Array[Float]] `,`
       Array[Array[Float]] `,`
       Float `,`
-      Float `)=>` Array[Float]]
+      Float,
+      Array[Float]]
 
     runKernel(N `,` M `,` K `,` A `,` B `,` C `,` alpha `,` beta)
   }

--- a/src/main/scala/rise/autotune/errors.scala
+++ b/src/main/scala/rise/autotune/errors.scala
@@ -8,5 +8,3 @@ case object SUBSTITUTION_ERROR extends AutoTuningErrorLevel
 case object CODE_GENERATION_ERROR extends AutoTuningErrorLevel
 case object COMPILATION_ERROR extends AutoTuningErrorLevel
 case object EXECUTION_ERROR extends AutoTuningErrorLevel
-
-case class AutoTuningError(errorLevel: AutoTuningErrorLevel, message: Option[String])

--- a/src/main/scala/rise/core/DSL/Type.scala
+++ b/src/main/scala/rise/core/DSL/Type.scala
@@ -187,7 +187,7 @@ object Type {
 
   object ->: {
     def unapply[T <: ExprType, U <: ExprType](funType: FunType[T, U]): Option[(T, U)] = {
-      FunType.unapply(funType)
+      Some((funType.inT, funType.outT))
     }
   }
 

--- a/src/main/scala/rise/core/DSL/package.scala
+++ b/src/main/scala/rise/core/DSL/package.scala
@@ -37,13 +37,12 @@ package object DSL {
   def toMemFun(f: ToBeTyped[Expr]): ToBeTyped[Expr] = fun(x => toMem(f(x)))
 
   case class `if`(b: ToBeTyped[Expr]) {
-    def `then`(tE: ToBeTyped[Expr]): Object {
-      def `else` (eE: ToBeTyped[Expr] ): ToBeTyped[Expr]
-    } = {
-      new {
-        def `else`(eE: ToBeTyped[Expr]): ToBeTyped[Expr] = {
-          select(b)(tE)(eE)
-        }
+    def `then`(tE: ToBeTyped[Expr]): `if`.`then` = `if`.`then`(b, tE)
+  }
+  object `if` {
+    case class `then`(b: ToBeTyped[Expr], tE: ToBeTyped[Expr]) {
+      def `else`(eE: ToBeTyped[Expr]): ToBeTyped[Expr] = {
+        select(b)(tE)(eE)
       }
     }
   }
@@ -69,8 +68,8 @@ package object DSL {
     // scalastyle:on disallow.space.before.token
 
     // pair accesses
-    def _1: ToBeTyped[App] = fst(lhs)
-    def _2: ToBeTyped[App] = snd(lhs)
+    def `1`: ToBeTyped[App] = fst(lhs)
+    def `2`: ToBeTyped[App] = snd(lhs)
   }
 
   implicit class Indexing(e: ToBeTyped[Expr]) {
@@ -264,140 +263,78 @@ package object DSL {
       lambda(e, fun((e1, e2, e3, e4, e5, e6, e7, e8) => f(e, e1, e2, e3, e4, e5, e6, e7, e8)))
     }
 
-    // noinspection TypeAnnotation
-    // scalastyle:off structural.type
-    def apply(ft: FunType[ExprType, ExprType]): Object {
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier]) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
+    def apply(ft: FunType[ExprType, ExprType]): WithFunType = WithFunType(ft)
 
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier]
-        ) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier]) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier]
-        ) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier]) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier], ToBeTyped[Identifier]
-        ) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier],
-        ToBeTyped[Identifier]) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier]
-        ) => ToBeTyped[Expr]
-               ): ToBeTyped[Expr]
-
-      def apply(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Expr]
-    } = new {
+    case class WithFunType(ft: FunType[ExprType, ExprType]) {
       def apply(f: ToBeTyped[Identifier] => ToBeTyped[Expr]): ToBeTyped[Expr] =
         fun(f) :: ft
 
-      def apply(
-                 f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier], ToBeTyped[Identifier]) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
 
-      def apply(
-                 f: (
-                   ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier],
-                     ToBeTyped[Identifier]
-                   ) => ToBeTyped[Expr]
+      def apply(f: (ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier],
+        ToBeTyped[Identifier]
+        ) => ToBeTyped[Expr]
                ): ToBeTyped[Expr] = fun(f) :: ft
     }
-    // scalastyle:on structural.type
   }
 
   object depFun {
@@ -470,20 +407,12 @@ package object DSL {
     }
   }
 
-  // noinspection ScalaUnusedSymbol
-  // scalastyle:off structural.type
-  object let {
-    def apply(e: ToBeTyped[Expr]): Object {
-      def be(in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr]
-      def be(in: ToBeTyped[Expr]): ToBeTyped[Expr]
-    } = new {
-      def be(in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] =
-        primitives.let(e)(fun(in))
-      def be(in: ToBeTyped[Expr]): ToBeTyped[Expr] =
-        primitives.let(e)(in)
-    }
+  case class  let(e: ToBeTyped[Expr]) {
+    def be(in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] =
+      primitives.let(e)(fun(in))
+    def be(in: ToBeTyped[Expr]): ToBeTyped[Expr] =
+      primitives.let(e)(in)
   }
-  // scalastyle:on structural.type
 
   object letf {
     def apply(in: ToBeTyped[Expr] => ToBeTyped[Expr]): ToBeTyped[Expr] = {

--- a/src/main/scala/rise/core/IsClosedForm.scala
+++ b/src/main/scala/rise/core/IsClosedForm.scala
@@ -69,25 +69,37 @@ object IsClosedForm {
 
     override def natToData: NatToData => Pair[NatToData] = {
       case NatToDataLambda(x, e) =>
-        for { p <- this.copy(boundT = boundT + NatKind.IDWrapper(x)).`type`(e)}
-          yield (p._1, NatToDataLambda(x, e))
+//        for { p <- this.copy(boundT = boundT + NatKind.IDWrapper(x)).`type`(e)}
+//          yield (p._1, NatToDataLambda(x, e))
+        val pp: Pure[((OrderedSet[Identifier], OrderedSet[Kind.Identifier]), DataType)] =
+          this.copy(boundT = boundT + NatKind.IDWrapper(x)).`type`(e)
+        pp.map(p => (p._1, NatToDataLambda(x, e)))
       case t => super.natToData(t)
     }
 
     override def natToNat: NatToNat => Pair[NatToNat] = {
       case NatToNatLambda(x, n) =>
-        for { p <- this.copy(boundT = boundT + NatKind.IDWrapper(x)).nat(n)}
-          yield (p._1, NatToNatLambda(x, n))
+//        for { p <- this.copy(boundT = boundT + NatKind.IDWrapper(x)).nat(n)}
+//          yield (p._1, NatToNatLambda(x, n))
+        val pp: Pure[((OrderedSet[Identifier], OrderedSet[Kind.Identifier]), Nat)] =
+          this.copy(boundT = boundT + NatKind.IDWrapper(x)).nat(n)
+        pp.map(p => (p._1, NatToNatLambda(x, n)))
       case n => super.natToNat(n)
     }
 
     override def `type`[T <: ExprType]: T => Pair[T] = {
       case d@DepFunType(k, x, t) =>
-        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).`type`(t) }
-          yield (p._1, d.asInstanceOf[T])
+//        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).`type`(t) }
+//          yield (p._1, d.asInstanceOf[T])
+        val pp: Pure[((OrderedSet[Identifier], OrderedSet[Kind.Identifier]), ExprType)] =
+          this.copy(boundT = boundT + Kind.toIdentifier(k, x)).`type`(t)
+        pp.map(p => (p._1, d.asInstanceOf[T]))
       case d@DepPairType(k, x, dt) =>
-        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).datatype(dt) }
-          yield (p._1, d.asInstanceOf[T])
+//        for { p <- this.copy(boundT = boundT + Kind.toIdentifier(k, x)).datatype(dt) }
+//          yield (p._1, d.asInstanceOf[T])
+        val pp: Pure[((OrderedSet[Identifier], OrderedSet[Kind.Identifier]), DataType)] =
+          this.copy(boundT = boundT + Kind.toIdentifier(k, x)).datatype(dt)
+        pp.map(p => (p._1, d.asInstanceOf[T]))
       case t => super.`type`(t)
     }
   }

--- a/src/main/scala/rise/elevate/meta/traversal.scala
+++ b/src/main/scala/rise/elevate/meta/traversal.scala
@@ -21,7 +21,7 @@ object traversal {
     override def oneUsingState: Strategy[Strategy[Rise]] => Strategy[Strategy[Rise]] = oneHandlingState(true)
 
     def oneHandlingState: Boolean => Strategy[Strategy[Rise]] => Strategy[Strategy[Rise]] = carryOverState => s => {
-      case Seq(first,second) => s(first) match {
+      case Seq(first: Strategy[Rise]@unchecked, second: Strategy[Rise]@unchecked) => s(first) match {
         case Success(x: Strategy[Rise]) => Success(seq(x)(second))
         case Failure(state) => if (carryOverState)
           state(second).mapSuccess(seq(first)(_)) else

--- a/src/main/scala/rise/elevate/rules/lowering.scala
+++ b/src/main/scala/rise/elevate/rules/lowering.scala
@@ -280,7 +280,7 @@ object lowering {
           dt match {
             case _ if typeHasTrivialCopy(dt) => asVectorAligned(n)
             case PairType(aT, bT) => fun(x =>
-              zip(generateUnZips(aT) $ x._1)(generateUnZips(bT) $ x._2)) o unzip
+              zip(generateUnZips(aT) $ x.`1`)(generateUnZips(bT) $ x.`2`)) o unzip
             case x => println(x) ; ???
           }
         }

--- a/src/main/scala/rise/elevate/rules/movement.scala
+++ b/src/main/scala/rise/elevate/rules/movement.scala
@@ -309,10 +309,10 @@ object movement {
 
       val result: ToBeTyped[Rise] = (fun(x =>
         (reduceSeq(fun((acc, y) =>
-          map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
-        ))(x._1 !: resultT) o // x._1 :: 2D array
+          map(fun(a => preserveType(op)(a.`1`)(a.`2`))) $ zip(acc)(y)
+        ))(x.`1` !: resultT) o // x._1 :: 2D array
           // transpose2D
-          transpose o map(transpose) $ x._2)) o
+          transpose o map(transpose) $ x.`2`)) o
         // unzip2D
         unzip o map(unzip)) !: e.t
 
@@ -339,10 +339,10 @@ object movement {
         (fun(x =>
           reduceSeq(
             fun((acc, y) => // acc::32.float, y::32.(float,float)
-              map(fun(a => preserveType(op)(a._1)(a._2))) $ zip(acc)(y)
+              map(fun(a => preserveType(op)(a.`1`)(a.`2`))) $ zip(acc)(y)
             )
-          )(x._1 !: resultT) o
-            transpose $ x._2) o unzip) !: e.t
+          )(x.`1` !: resultT) o
+            transpose $ x.`2`) o unzip) !: e.t
 
       Success(result)
 

--- a/src/main/scala/rise/eqsat/Analysis.scala
+++ b/src/main/scala/rise/eqsat/Analysis.scala
@@ -23,9 +23,9 @@ trait Analysis[Data] {
   def preUnion(egraph: EGraph[Data], id1: EClassId, id2: EClassId): Unit = {}
 }
 
-object NoAnalysis extends Analysis[()] {
-  override def make(egraph: EGraph[()], enode: ENode, t: Type): () = ()
-  override def merge(to: (), from: ()): Option[Order] = Some(Equal)
+object NoAnalysis extends Analysis[Unit] {
+  override def make(egraph: EGraph[Unit], enode: ENode, t: Type): Unit = ()
+  override def merge(to: Unit, from: Unit): Option[Order] = Some(Equal)
 }
 
 class DefaultAnalysisData(var free: HashSet[Int],

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -414,7 +414,7 @@ object NamedRewriteDSL {
 
   import scala.language.implicitConversions
 
-  val `_`: rct.TypePlaceholder.type = rct.TypePlaceholder
+  val `__`: rct.TypePlaceholder.type = rct.TypePlaceholder
 
   implicit final class RewriteArrow(private val lhs: Pattern) extends AnyVal {
     @inline def -->(rhs: Pattern): (Pattern, Pattern) = lhs -> rhs
@@ -448,12 +448,12 @@ object NamedRewriteDSL {
   def drop: Pattern = rcp.drop.primitive
   def take: Pattern = rcp.take.primitive
 
-  implicit def placeholderAsNatPattern(p: `_`.type): NatPattern =
+  implicit def placeholderAsNatPattern(p: `__`.type): NatPattern =
     rct.NatIdentifier(rc.freshName("n"))
   implicit def stringAsNatPattern(name: String): NatPattern =
     rct.NatIdentifier(name)
 
-  implicit def placeholderAsDataTypePattern(p: `_`.type): DataTypePattern =
+  implicit def placeholderAsDataTypePattern(p: `__`.type): DataTypePattern =
     rcdt.DataTypeIdentifier(rc.freshName("dt"))
   implicit def stringAsDataTypePattern(name: String): DataTypePattern =
     rcdt.DataTypeIdentifier(name)

--- a/src/main/scala/rise/eqsat/ematching.scala
+++ b/src/main/scala/rise/eqsat/ematching.scala
@@ -133,9 +133,9 @@ object ematching {
   }
 
   /** A node without children for matching purposes */
-  type MNode = Node[(), (), ()]
-  type MNatNode = NatNode[()]
-  type MTypeNode = TypeNode[(), (), ()]
+  type MNode = Node[Unit, Unit, Unit]
+  type MNatNode = NatNode[Unit]
+  type MTypeNode = TypeNode[Unit, Unit, Unit]
 
   def forEachMatchingNode[D](eclass: EClass[D], node: MNode, f: ENode => Unit): Unit = {
     import scala.math.Ordering.Implicits._

--- a/src/main/scala/rise/eqsat/rules.scala
+++ b/src/main/scala/rise/eqsat/rules.scala
@@ -81,10 +81,10 @@ object rules {
     ("x": Pattern) --> app(lam("y", "y"), "x")
   )
   val transposePairAfter: Rule = NamedRewrite.init("transpose-pair-after",
-    ("x" :: ((`_`: Nat)`.`((`_`: Nat)`.``_`))) --> app(transpose, app(transpose, "x"))
+    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`))) --> app(transpose, app(transpose, "x"))
   )
   val createTransposePair: Rule = NamedRewrite.init("create-transpose-pair",
-    app(lam("y", "y"), "x" :: ((`_`: Nat)`.`((`_`: Nat)`.``_`)))
+    app(lam("y", "y"), "x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))
       -->
     app(lam("y", app(transpose, app(transpose, "y"))), "x")
   )
@@ -97,7 +97,7 @@ object rules {
     app(app(map, nApp(drop, "l")), app(nApp(nApp(slide, ("n": Nat) + ("l": Nat)), 1), "in"))
   )
   val takeInSlide: Rule = NamedRewrite.init("take-in-slide",
-    app(nApp(take, "r") :: ((("s": Nat)`.``_`) ->: `_`), app(nApp(nApp(slide, "n"), 1), "in"))
+    app(nApp(take, "r") :: ((("s": Nat)`.``__`) ->: `__`), app(nApp(nApp(slide, "n"), 1), "in"))
       -->
     app(app(map, nApp(take, "n")), app(nApp(nApp(slide, ("n": Nat) + ("s": Nat) - ("r": Nat)), 1), "in"))
   )
@@ -165,12 +165,12 @@ object rules {
 
   // TODO: condition typeHasTrivialCopy(t) / or synthesise trivial write function
   val mapSeqUnrollWrite: Rule = NamedRewrite.init("map-seq-unroll-write",
-    ("x" :: ((`_`: Nat)`.`"dt"))
+    ("x" :: ((`__`: Nat)`.`"dt"))
       -->
     app(app(rcp.mapSeqUnroll.primitive, lam("y", "y")), "x")
   )
   val mapSeqUnrollMapSeqWrite: Rule = NamedRewrite.init("map-seq-unroll-map-seq-write",
-    ("x" :: ((`_`: Nat)`.`((`_`: Nat)`.`"dt")))
+    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.`"dt")))
       -->
       app(app(rcp.mapSeqUnroll.primitive, app(rcp.mapSeq.primitive, lam("y", "y"))), "x")
   )

--- a/src/main/scala/shine/C/Compilation/TranslationContext.scala
+++ b/src/main/scala/shine/C/Compilation/TranslationContext.scala
@@ -25,8 +25,8 @@ class TranslationContext() extends shine.DPIA.Compilation.TranslationContext {
       //TODO makes a decision. Not allowed!
       case DepArrayType(n, ft) =>
         DepMapSeqI(unroll = false)(n, ft, ft,
-          depFun(NatKind)(k =>
-            λ(ExpType(ft(k), read))(x => λ(AccType( ft(k) ))(a => assign(ft(k), a, x) ))),
+          depFun[Nat, NatIdentifier](NatKind)(k =>
+            fun(ExpType(ft(k), read))(x => fun(AccType( ft(k) ))(a => assign(ft(k), a, x) ))),
           rhs, lhs)
 
       case x => throw new Exception(s"Don't know how to assign value of type $x")

--- a/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/AcceptorTranslation.scala
@@ -50,7 +50,7 @@ object AcceptorTranslation {
             acc(fst)(pairAcc1(dt1, dt2, A)) `;`
               acc(snd)(pairAcc2(dt1, dt2, A))
           case _ =>
-            con(e)(λ(e.t)(a => A :=| e.t.dataType | a))
+            con(e)(fun(e.t)(a => A :=| e.t.dataType | a))
         }
 
       case c: Literal => A :=|c.t.dataType| c
@@ -60,13 +60,13 @@ object AcceptorTranslation {
       case n: Natural => A :=|n.t.dataType| n
 
       case u@UnaryOp(op, e) =>
-        con(e)(λ(u.t)(x =>
+        con(e)(fun(u.t)(x =>
           A :=|u.t.dataType| UnaryOp(op, x)
         ))
 
       case b@BinOp(op, e1, e2) =>
-        con(e1)(λ(b.t)(x =>
-          con(e2)(λ(b.t)(y =>
+        con(e1)(fun(b.t)(x =>
+          con(e2)(fun(b.t)(y =>
             A :=|b.t.dataType| BinOp(op, x, y)
           ))
         ))
@@ -76,7 +76,7 @@ object AcceptorTranslation {
       case LetNat(binder, defn, body) => LetNat(binder, defn, acc(body)(A))
 
       case IfThenElse(cond, thenP, elseP) =>
-        con(cond)(λ(cond.t) { x =>
+        con(cond)(fun(cond.t) { x =>
           `if` (x) `then` acc(thenP)(A) `else` acc(elseP)(A)
         })
 
@@ -98,7 +98,7 @@ object AcceptorTranslation {
       acc(array)(AsVectorAcc(n, m, dt, A))
 
     case DepIdx(n, ft, index, array) =>
-      con(array)(λ(expT(n`.d`ft, read))(x =>
+      con(array)(fun(expT(n`.d`ft, read))(x =>
         A :=| ft(index) | DepIdx(n, ft, index, x)))
 
     case DepJoin(n, lenF, dt, array) =>
@@ -106,9 +106,9 @@ object AcceptorTranslation {
 
     case depMapSeq@DepMapSeq(unroll) =>
       val (n, ft1, ft2, f, array) = depMapSeq.unwrap
-      con(array)(λ(expT(n`.d`ft1, read))(x =>
-        DepMapSeqI(unroll)(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
-          λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
+      con(array)(fun(expT(n`.d`ft1, read))(x =>
+        DepMapSeqI(unroll)(n, ft1, ft2, depFun(NatKind)((k: NatIdentifier) =>
+          fun(expT(ft1(k), read))(x => fun(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
 
@@ -117,26 +117,26 @@ object AcceptorTranslation {
 
     case DMatch(x, elemT, outT, a, f, input) =>
       // Turn the f imperative by means of forwarding the acceptor translation
-      con(input)(λ(expT(DepPairType(NatKind, x, elemT), read))(pair =>
+      con(input)(fun(expT(DepPairType(NatKind, x, elemT), read))(pair =>
         DMatchI(x, elemT, outT,
-          _Λ_(NatKind)((fst: NatIdentifier) =>
-            λ(expT(substituteNatInType(fst, x, elemT), read))(snd =>
+          depFun(NatKind)((fst: NatIdentifier) =>
+            fun(expT(substituteNatInType(fst, x, elemT), read))(snd =>
               acc(f(fst)(snd))(A)
             )), pair)))
 
     case IdxVec(n, st, index, vector) =>
-      con(vector)(λ(expT(vec(n, st), read))(x =>
+      con(vector)(fun(expT(vec(n, st), read))(x =>
         A :=| st | IdxVec(n, st, index, x)))
 
     case Iterate(n, m, k, dt, f, array) =>
-      con(array)(λ(expT((m * n.pow(k))`.`dt, read))(x =>
+      con(array)(fun(expT((m * n.pow(k))`.`dt, read))(x =>
         IterateIAcc(n, m, k, dt, A,
-          _Λ_(NatKind)(l => λ(accT(l `.` dt))(o =>
-            λ(expT((l * n)`.`dt, read))(x => acc(f(l)(x))(o)))),
+          depFun(NatKind)(l => fun(accT(l `.` dt))(o =>
+            fun(expT((l * n)`.`dt, read))(x => acc(f(l)(x))(o)))),
           x)))
 
     case IterateStream(n, dt1, dt2, f, array) =>
-      val fI = λ(expT(dt1, read))(x => λ(accT(dt2))(o => acc(f(x))(o)))
+      val fI = fun(expT(dt1, read))(x => fun(accT(dt2))(o => acc(f(x))(o)))
       val i = NatIdentifier(freshName("i"))
       str(array)(fun((i: NatIdentifier) ->:
         (expT(dt1, read) ->: (comm: CommType)) ->: (comm: CommType)
@@ -170,7 +170,7 @@ object AcceptorTranslation {
       val o = Identifier(freshName("fede_o"), otype)
 
       acc(array)(MapAcc(n, dt2, dt1,
-        Lambda(o, fedAcc(scala.Predef.Map((x, o)))(f(x))(λ(otype)(x => x))),
+        Lambda(o, fedAcc(scala.Predef.Map((x, o)))(f(x))(fun(otype)(x => x))),
         A))
 
     case MapFst(w, dt1, dt2, dt3, f, record) =>
@@ -185,7 +185,7 @@ object AcceptorTranslation {
 
     case mapSeq@MapSeq(unroll) =>
       val (n, dt1, dt2, f, array) = mapSeq.unwrap
-      con(array)(λ(expT(n`.`dt1, read))(x =>
+      con(array)(fun(expT(n`.`dt1, read))(x =>
         MapSeqI(unroll)(n, dt1, dt2,
           fun(expT(dt1, read))(x =>
             fun(accT(dt2))(o =>
@@ -203,8 +203,8 @@ object AcceptorTranslation {
         A))
 
     case MapVec(n, dt1, dt2, f, array) =>
-      con(array)(λ(expT(vec(n, dt1), read))(x =>
-        MapVecI(n, dt1, dt2, λ(expT(dt1, read))(x => λ(accT(dt2))(o => acc(f(x))(o))), x, A)))
+      con(array)(fun(expT(vec(n, dt1), read))(x =>
+        MapVecI(n, dt1, dt2, fun(expT(dt1, read))(x => fun(accT(dt2))(o => acc(f(x))(o))), x, A)))
 
     case PadEmpty(n, r, dt, array) =>
       acc(array)(TakeAcc(n, r, dt, A))
@@ -214,17 +214,17 @@ object AcceptorTranslation {
 
     case reduceSeq@ReduceSeq(unroll) =>
       val (n, dt1, dt2, f, init, array) = reduceSeq.unwrap
-      con(reduceSeq)(λ(expT(dt2, write))(r =>
+      con(reduceSeq)(fun(expT(dt2, write))(r =>
         acc(r)(A)))
 
     case Reorder(n, dt, access, idxF, idxFinv, input) =>
       acc(input)(ReorderAcc(n, dt, idxFinv, A))
 
     case ScanSeq(n, dt1, dt2, f, init, array) =>
-      con(array)(λ(expT(n`.`dt1, read))(x =>
-        con(init)(λ(expT(dt2, read))(y =>
+      con(array)(fun(expT(n`.`dt1, read))(x =>
+        con(init)(fun(expT(dt2, read))(y =>
           ScanSeqI(n, dt1, dt2,
-            λ(expT(dt1, read))(x => λ(expT(dt2, read))(y => λ(accT(dt2))(o =>
+            fun(expT(dt1, read))(x => fun(expT(dt2, read))(y => fun(accT(dt2))(o =>
               acc(f(x)(y))(o)))),
             y, x, A)))))
 
@@ -233,7 +233,7 @@ object AcceptorTranslation {
         acc(input)(ScatterAcc(n, m, dt, y, A))))
 
     case slide@Slide(n, sz, sp, dt, input) =>
-      con(slide)(λ(expT(n`.`(sz`.`dt), read))(x =>
+      con(slide)(fun(expT(n`.`(sz`.`dt), read))(x =>
         A :=|(n`.`(sz`.`dt))| x ))
 
     case Split(n, m, w, dt, array) =>
@@ -246,7 +246,7 @@ object AcceptorTranslation {
       acc(e)(UnzipAcc(n, dt1, dt2, A))
 
     case VectorFromScalar(n, dt, arg) =>
-      con(arg)(λ(expT(dt, read))(e =>
+      con(arg)(fun(expT(dt, read))(e =>
         A :=|vec(n, dt)| VectorFromScalar(n, dt, e)))
 
     case Zip(n, dt1, dt2, access, e1, e2) =>
@@ -255,36 +255,36 @@ object AcceptorTranslation {
 
     // OpenMP
     case omp.DepMapPar(n, ft1, ft2, f, array) =>
-      con(array)(λ(expT(n`.d`ft1, read))(x =>
-        ompI.DepMapParI(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
-          λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
+      con(array)(fun(expT(n`.d`ft1, read))(x =>
+        ompI.DepMapParI(n, ft1, ft2, depFun(NatKind)((k: NatIdentifier) =>
+          fun(expT(ft1(k), read))(x => fun(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
 
     case omp.MapPar(n, dt1, dt2, f, array) =>
-      con(array)(λ(expT(n`.`dt1, read))(x =>
+      con(array)(fun(expT(n`.`dt1, read))(x =>
         ompI.MapParI(n, dt1, dt2,
-          λ(expT(dt1, read))(x => λ(accT(dt2))(o => acc(f(x))(o))),
+          fun(expT(dt1, read))(x => fun(accT(dt2))(o => acc(f(x))(o))),
           x, A)))
 
     case reducePar@omp.ReducePar(n, dt1, dt2, f, init, array) =>
-      con(reducePar)(λ(expT(dt2, write))(r =>
+      con(reducePar)(fun(expT(dt2, write))(r =>
         acc(r)(A)))
 
     // OpenCL
     case depMap@ocl.DepMap(level, dim) =>
       val (n, ft1, ft2, f, array) = depMap.unwrap
-      con(array)(λ(expT(n`.d`ft1, read))(x =>
-        oclI.DepMapI(level, dim)(n, ft1, ft2, _Λ_(NatKind)((k: NatIdentifier) =>
-          λ(expT(ft1(k), read))(x => λ(accT(ft2(k)))(o => {
+      con(array)(fun(expT(n`.d`ft1, read))(x =>
+        oclI.DepMapI(level, dim)(n, ft1, ft2, depFun(NatKind)((k: NatIdentifier) =>
+          fun(expT(ft1(k), read))(x => fun(accT(ft2(k)))(o => {
             acc(f(k)(x))(o)
           }))), x, A)))
 
     case ocl.Iterate(a, n, m, k, dt, f, array) =>
-      con(array)(λ(expT({m * n.pow(k)}`.`dt, read))(x =>
+      con(array)(fun(expT({m * n.pow(k)}`.`dt, read))(x =>
         oclI.IterateIAcc(a, n, m, k, dt, A,
-          _Λ_(NatKind)(l => λ(accT(l`.`dt))(o =>
-            λ(expT({l * n}`.`dt, read))(x => acc(f(l)(x))(o)))),
+          depFun(NatKind)(l => fun(accT(l`.`dt))(o =>
+            fun(expT({l * n}`.`dt, read))(x => acc(f(l)(x))(o)))),
           x)))
 
     case kc@ocl.KernelCall(name, localSize, globalSize, n) =>
@@ -294,7 +294,7 @@ object AcceptorTranslation {
           case Nil =>
             oclImp.KernelCallCmd(name, localSize, globalSize, n)(kc.inTs, kc.outT, kc.args, A)
           case Seq(arg, tail@_*) =>
-            con(arg)(λ(expT(arg.t.dataType, read))(e => rec(tail, es :+ e)))
+            con(arg)(fun(expT(arg.t.dataType, read))(e => rec(tail, es :+ e)))
         }
       }
 
@@ -302,9 +302,9 @@ object AcceptorTranslation {
 
     case map@ocl.Map(level, dim) =>
       val (n, dt1, dt2, f, array) = map.unwrap
-      con(array)(λ(expT(n `.` dt1, read))(x =>
+      con(array)(fun(expT(n `.` dt1, read))(x =>
         oclI.MapI(level, dim)(n, dt1, dt2,
-          λ(expT(dt1, read))(x => λ(accT(dt2))(o => acc(f(x))(o))),
+          fun(expT(dt1, read))(x => fun(accT(dt2))(o => acc(f(x))(o))),
           x, A)))
 
     case fc@ocl.OpenCLFunctionCall(name, n) =>
@@ -314,11 +314,11 @@ object AcceptorTranslation {
         ts match {
           // with only one argument left to process return the assignment of the OpenCLFunction call
           case Seq( (arg, inT) ) =>
-            con(arg)(λ(expT(inT, read))(e =>
+            con(arg)(fun(expT(inT, read))(e =>
               A :=|fc.outT| ocl.OpenCLFunctionCall(name, n)(inTs :+ inT, fc.outT, exps :+ e) ))
           // with a `tail` of arguments left, recurse
           case Seq( (arg, inT), tail@_* ) =>
-            con(arg)(λ(expT(inT, read))(e => rec(tail, exps :+ e, inTs :+ inT) ))
+            con(arg)(fun(expT(inT, read))(e => rec(tail, exps :+ e, inTs :+ inT) ))
         }
       }
 
@@ -326,35 +326,35 @@ object AcceptorTranslation {
 
     // CUDA
     case cuda.AsFragment(rows, columns, layers, dataType, fragmentKind, layout, matrix) =>
-      con(matrix)(λ(ExpType(ArrayType(rows, ArrayType(columns, dataType)), read))(matrix =>
+      con(matrix)(fun(ExpType(ArrayType(rows, ArrayType(columns, dataType)), read))(matrix =>
         cudaImp.WmmaLoad(rows, columns, layers, dataType, fragmentKind, layout, matrix, A)))
 
     case cuda.AsMatrix(rows, columns, layers, dataType, fragment) =>
-      con(fragment)(λ(ExpType(fragment.t.dataType, read))(fragment =>
+      con(fragment)(fun(ExpType(fragment.t.dataType, read))(fragment =>
         cudaImp.WmmaStore(rows, columns, layers, dataType, fragment, A)))
 
     case cuda.GenerateFragment(rows, columns, layers, dataType, frag, layout, fill) =>
-      con(fill)(λ(ExpType(dataType, read))(fill =>
+      con(fill)(fun(ExpType(dataType, read))(fill =>
         cudaImp.WmmaFill(rows, columns, layers, dataType, frag, layout, fill, A)))
 
     case map@cuda.Map(level, dim) =>
       val (n, dt1, dt2, f, array) = map.unwrap
-      con(array)(λ(expT(n `.` dt1, read))(x =>
+      con(array)(fun(expT(n `.` dt1, read))(x =>
         cudaI.MapI(level, dim)(n, dt1, dt2,
-          λ(expT(dt1, read))(x => λ(accT(dt2))(o => acc(f(x))(o))),
+          fun(expT(dt1, read))(x => fun(accT(dt2))(o => acc(f(x))(o))),
           x, A)))
 
-    case cuda.MapFragment(rows, columns, layers, dt, frag, layout, fun, input) =>
-      con(input)(λ(expT(FragmentType(rows, columns, layers, dt, frag, layout), read))(input =>
+    case cuda.MapFragment(rows, columns, layers, dt, frag, layout, f, input) =>
+      con(input)(fun(expT(FragmentType(rows, columns, layers, dt, frag, layout), read))(input =>
         shine.cuda.primitives.imperative.ForFragment(rows, columns, layers, dt, frag, layout, input, A,
-          λ(expT(dt, read))(x =>
-            λ(accT(dt))(o =>
-              acc(fun(x))(o))))))
+          fun(expT(dt, read))(x =>
+            fun(accT(dt))(o =>
+              acc(f(x))(o))))))
 
     case cuda.TensorMatMultAdd(m, n, k, layoutA, layoutB, dataType, dataTypeAcc, aMatrix, bMatrix, cMatrix) =>
-      con(aMatrix)(λ(ExpType(FragmentType(m, n, k, dataType, Fragment.AMatrix, layoutA), read))(aMatrix =>
-        con(bMatrix)(λ(ExpType(FragmentType(m, n, k, dataType, Fragment.BMatrix, layoutB), read))(bMatrix =>
-          con(cMatrix)(λ(ExpType(FragmentType(m, n, k, dataTypeAcc, Fragment.Accumulator, MatrixLayout.None), read))(cMatrix =>
+      con(aMatrix)(fun(ExpType(FragmentType(m, n, k, dataType, Fragment.AMatrix, layoutA), read))(aMatrix =>
+        con(bMatrix)(fun(ExpType(FragmentType(m, n, k, dataType, Fragment.BMatrix, layoutB), read))(bMatrix =>
+          con(cMatrix)(fun(ExpType(FragmentType(m, n, k, dataTypeAcc, Fragment.Accumulator, MatrixLayout.None), read))(cMatrix =>
             cudaImp.WmmaMMA(m, n, k, layoutA, layoutB, dataType, dataTypeAcc, aMatrix, bMatrix, cMatrix, A)))))))
 
     //GAP8
@@ -368,7 +368,7 @@ object AcceptorTranslation {
         case Nil =>
           shine.GAP8.primitives.imperative.KernelCallCmd(name, cores, n)(kc.inTs, kc.outT, kc.args, A)
         case Seq(arg, tail@_*) =>
-          con(arg)(λ(expT(arg.t.dataType, read))(e => rec(tail, es :+ e)))
+          con(arg)(fun(expT(arg.t.dataType, read))(e => rec(tail, es :+ e)))
       }
 
       rec(kc.args, Seq())

--- a/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/ContinuationTranslation.scala
@@ -33,13 +33,13 @@ object ContinuationTranslation {
       case n: Natural => C(n)
 
       case u@UnaryOp(op, e) =>
-        con(e)(λ(u.t)(x =>
+        con(e)(fun(u.t)(x =>
           C(UnaryOp(op, x))
         ))
 
       case b@BinOp(op, e1, e2) =>
-        con(e1)(λ(b.t)(x =>
-          con(e2)(λ(b.t)(y =>
+        con(e1)(fun(b.t)(x =>
+          con(e2)(fun(b.t)(y =>
             C(BinOp(op, x, y))
           ))
         ))
@@ -58,7 +58,7 @@ object ContinuationTranslation {
       }
 
       case IfThenElse(cond, thenP, elseP) =>
-        con(cond)(λ(cond.t) { x =>
+        con(cond)(fun(cond.t) { x =>
           `if`(x) `then` con(thenP)(C) `else` con(elseP)(C)
         })
 
@@ -73,15 +73,15 @@ object ContinuationTranslation {
                (C: Phrase[ExpType ->: CommType])
                (implicit context: TranslationContext): Phrase[CommType] = E match {
     case AsScalar(n, m, dt, access, array) =>
-      con(array)(λ(array.t)(x =>
+      con(array)(fun(array.t)(x =>
         C(AsScalar(n, m, dt, access, x))))
 
     case AsVector(n, m, dt, access, array) =>
-      con(array)(λ(array.t)(x =>
+      con(array)(fun(array.t)(x =>
         C(AsVector(n, m, dt, access, x))))
 
     case AsVectorAligned(n, m, w, dt, array) =>
-      con(array)(λ(array.t)(x =>
+      con(array)(fun(array.t)(x =>
         C(AsVectorAligned(n, m, w, dt, x)) ))
 
     case Cast(dt1, dt2, e) =>
@@ -93,34 +93,34 @@ object ContinuationTranslation {
         C(Cycle(n, m, dt, x))))
 
     case DepIdx(n, ft, index, array) =>
-      con(array)(λ(expT(n`.d`ft, read))(e =>
+      con(array)(fun(expT(n`.d`ft, read))(e =>
         C(DepIdx(n, ft, index, e))))
 
     case DepJoin(n, lenF, dt, array) =>
-      con(array)(λ(expT(n `.d` { i => lenF(i)`.`dt }, read))(x =>
+      con(array)(fun(expT(n `.d` { i => lenF(i)`.`dt }, read))(x =>
         C(DepJoin(n, lenF, dt, x))))
 
     case depMapSeq: DepMapSeq =>
       val (n, _, ft2, _, _) = depMapSeq.unwrap
-      `new`(n`.d`ft2, λ(varT(n`.d`ft2))(tmp =>
+      `new`(n`.d`ft2, fun(varT(n`.d`ft2))(tmp =>
         acc(depMapSeq)(tmp.wr) `;` C(tmp.rd) ))
 
     case DepZip(n, ft1, ft2, e1, e2) =>
-      con(e1)(λ(ExpType(DepArrayType(n, ft1), read))(x =>
-        con(e2)(λ(ExpType(DepArrayType(n, ft2), read))(y =>
+      con(e1)(fun(ExpType(DepArrayType(n, ft1), read))(x =>
+        con(e2)(fun(ExpType(DepArrayType(n, ft2), read))(y =>
           C(DepZip(n, ft1, ft2, x, y)) )) ))
 
     case DMatch(x, elemT, outT, a, f, input) =>
       // Turn the f imperative by means of forwarding the continuation translation
-      con(input)(λ(expT(DepPairType(NatKind, x, elemT), read))(pair =>
+      con(input)(fun(expT(DepPairType(NatKind, x, elemT), read))(pair =>
         DMatchI(x, elemT, outT,
-          _Λ_(NatKind)((fst: NatIdentifier) =>
-            λ(expT(substituteNatInType(fst, x, elemT), read))(snd =>
+          depFun(NatKind)((fst: NatIdentifier) =>
+            fun(expT(substituteNatInType(fst, x, elemT), read))(snd =>
               con(f(fst)(snd))(C)
             )), pair)))
 
     case Drop(n, m, dt, array) =>
-      con(array)(λ(expT((n + m)`.` dt, read))(x =>
+      con(array)(fun(expT((n + m)`.` dt, read))(x =>
         C(Drop(n, m, dt, x))))
 
     case ffc@ForeignFunctionCall(funDecl, n) =>
@@ -130,7 +130,7 @@ object ContinuationTranslation {
         ts match {
           // with only one argument left to process return the assignment of the function call
           case Seq( (arg, inT) ) =>
-            con(arg)(λ(expT(inT, read))(e =>
+            con(arg)(fun(expT(inT, read))(e =>
               ffc.outT match {
                 // TODO: this is an ugly fix to avoid calling the function multiple times
                 //  for pair assignment, see:
@@ -151,7 +151,7 @@ object ContinuationTranslation {
               }))
           // with a `tail` of arguments left, rec
           case Seq( (arg, inT), tail@_* ) =>
-            con(arg)(λ(expT(inT, read))(e =>
+            con(arg)(fun(expT(inT, read))(e =>
               rec(tail, exps :+ e, inTs :+ inT) ))
         }
       }
@@ -159,7 +159,7 @@ object ContinuationTranslation {
       rec(ffc.args zip ffc.inTs, Seq(), Seq())
 
     case Fst(dt1, dt2, pair) =>
-      con(pair)(λ(expT(dt1 x dt2, read))(x =>
+      con(pair)(fun(expT(dt1 x dt2, read))(x =>
         C(Fst(dt1, dt2, x))))
 
     case Gather(n, m, dt, indices, input) =>
@@ -175,20 +175,20 @@ object ContinuationTranslation {
             con(f(i))(fun(expT(dt, read))(g => Apply(cont, g)))))))
 
     case Idx(n, dt, index, array) =>
-      con(array)(λ(expT(n`.`dt, read))(e =>
+      con(array)(fun(expT(n`.`dt, read))(e =>
         con(index)(fun(index.t)(i =>
           C(Idx(n, dt, i, e))))))
 
     case IdxVec(n, st, index, vector) =>
-      con(vector)(λ(expT(vec(n, st), read))(e =>
+      con(vector)(fun(expT(vec(n, st), read))(e =>
         C(IdxVec(n, st, index, e))))
 
     case IndexAsNat(n, e) =>
-      con(e)(λ(expT(idx(n), read))(x =>
+      con(e)(fun(expT(idx(n), read))(x =>
         C(IndexAsNat(n, x))))
 
     case Join(n, m, w, dt, array) =>
-      con(array)(λ(expT(n`.`(m`.`dt), read))(x =>
+      con(array)(fun(expT(n`.`(m`.`dt), read))(x =>
         C(Join(n, m, w, dt, x))))
 
     case Let(dt1, dt2, access, value, f) =>
@@ -222,12 +222,12 @@ object ContinuationTranslation {
       })
 
     case MakePair(dt1, dt2, access, fst, snd) =>
-      con(fst)(λ(expT(dt1, read))(x =>
-        con(snd)(λ(expT(dt2, read))(y =>
+      con(fst)(fun(expT(dt1, read))(x =>
+        con(snd)(fun(expT(dt2, read))(y =>
           C(MakePair(dt1, dt2, access, x, y))))))
 
     case Map(n, dt1, dt2, access, f, array) =>
-      con(array)(λ(expT(n`.`dt1, read))(x =>
+      con(array)(fun(expT(n`.`dt1, read))(x =>
         C(MapRead(n, dt1, dt2,
           fun(expT(dt1, read))(a =>
             fun(expT(dt2, read) ->: (comm: CommType))(cont =>
@@ -242,7 +242,7 @@ object ContinuationTranslation {
       val (n, _, dt2, _, _) = mapSeq.unwrap
       println("WARNING: map loop continuation translation allocates memory")
       // TODO should be removed
-      `new`(n`.`dt2, λ(varT(n`.`dt2))(tmp =>
+      `new`(n`.`dt2, fun(varT(n`.`dt2))(tmp =>
         acc(mapSeq)(tmp.wr) `;` C(tmp.rd) ))
 
     case MapSnd(w, dt1, dt2, dt3, f, record) =>
@@ -253,25 +253,25 @@ object ContinuationTranslation {
       println("WARNING: map loop continuation translation allocates memory")
       // TODO should be removed
       `new`(vec(n, dt2),
-        λ(varT(vec(n, dt2)))(tmp =>
+        fun(varT(vec(n, dt2)))(tmp =>
           acc(mapVec)(tmp.wr) `;`
             C(tmp.rd)))
 
     case NatAsIndex(n, e) =>
-      con(e)(λ(e.t)(x =>
+      con(e)(fun(e.t)(x =>
         C(NatAsIndex(n, x))))
 
     case PadCst(n, l, r, dt, padExp, array) =>
-      con(array)(λ(expT(n`.`dt, read))(x =>
-        con(padExp)(λ(expT(dt, read))(p =>
+      con(array)(fun(expT(n`.`dt, read))(x =>
+        con(padExp)(fun(expT(dt, read))(p =>
           C(PadCst(n, l, r, dt, p, x))))))
 
     case PadClamp(n, l, r, dt, array) =>
-      con(array)(λ(expT(n`.`dt, read))(x =>
+      con(array)(fun(expT(n`.`dt, read))(x =>
         C(PadClamp(n, l, r, dt, x))))
 
     case Partition(n, m, lenF, dt, array) =>
-      con(array)(λ(expT(n`.`dt, read))(x =>
+      con(array)(fun(expT(n`.`dt, read))(x =>
         C(Partition(n, m, lenF, dt, x))))
 
     case PrintType(msg, dt, access, input) =>
@@ -279,36 +279,36 @@ object ContinuationTranslation {
 
     case reduceSeq@ReduceSeq(unroll) =>
       val (n, dt1, dt2, f, init, array) = reduceSeq.unwrap
-      con(array)(λ(expT(n`.`dt1, read))(X =>
+      con(array)(fun(expT(n`.`dt1, read))(X =>
         ReduceSeqI(n, dt1, dt2,
-          λ(expT(dt2, read))(x =>
-            λ(expT(dt1, read))(y =>
-              λ(accT(dt2))(o => acc(f(x)(y))(o)))),
+          fun(expT(dt2, read))(x =>
+            fun(expT(dt1, read))(y =>
+              fun(accT(dt2))(o => acc(f(x)(y))(o)))),
           init, X, C, unroll)(context)))
 
     case Reorder(n, dt, access, idxF, idxFinv, input) =>
-      con(input)(λ(expT(n`.`dt, read))(x =>
+      con(input)(fun(expT(n`.`dt, read))(x =>
         C(Reorder(n, dt, access, idxF, idxFinv, x))))
 
     case scanSeq@ScanSeq(n, dt1, dt2, f, init, array) =>
-      `new`(n`.`dt2, λ(varT(n`.`dt2))(tmp =>
+      `new`(n`.`dt2, fun(varT(n`.`dt2))(tmp =>
         acc(scanSeq)(tmp.wr) `;` C(tmp.rd) ))
 
     case slide@Slide(n, sz, sp, dt, input) =>
       val inputSize = sp*n+sz
-      con(input)(λ(expT(inputSize`.`dt, read))(x =>
+      con(input)(fun(expT(inputSize`.`dt, read))(x =>
         C(Slide(n, sz, sp, dt, x)) ))
 
     case Snd(dt1, dt2, pair) =>
-      con(pair)(λ(expT(dt1 x dt2, read))(x =>
+      con(pair)(fun(expT(dt1 x dt2, read))(x =>
         C(Snd(dt1, dt2, x))))
 
     case Split(n, m, w, dt, array) =>
-      con(array)(λ(expT((m * n)`.`dt, read))(x =>
+      con(array)(fun(expT((m * n)`.`dt, read))(x =>
         C(Split(n, m, w, dt, x))))
 
     case Take(n, m, dt, array) =>
-      con(array)(λ(expT((n + m)`.`dt, read))(x =>
+      con(array)(fun(expT((n + m)`.`dt, read))(x =>
         C(Take(n, m, dt, x))))
 
     case ToMem(dt, input) =>
@@ -319,51 +319,51 @@ object ContinuationTranslation {
         C(Transpose(n, m, dt, access, x))))
 
     case TransposeDepArray(n, m, f, array) =>
-      con(array)(λ(expT(n`.`(m`.d`f), read))(x =>
+      con(array)(fun(expT(n`.`(m`.d`f), read))(x =>
         C(TransposeDepArray(n, m, f, x))))
 
     case Unzip(n, dt1, dt2, access, e) =>
-      con(e)(λ(expT(n`.`(dt1 x dt2), read))(x =>
+      con(e)(fun(expT(n`.`(dt1 x dt2), read))(x =>
         C(Unzip(n, dt1, dt2, access, x))))
 
     case VectorFromScalar(n, dt, arg) =>
-      con(arg)(λ(expT(dt, read))(e =>
+      con(arg)(fun(expT(dt, read))(e =>
         C(VectorFromScalar(n, dt, e)) ))
 
     case Zip(n, dt1, dt2, access, e1, e2) =>
-      con(e1)(λ(expT(n`.`dt1, read))(x =>
-        con(e2)(λ(expT(n`.`dt2, read))(y =>
+      con(e1)(fun(expT(n`.`dt1, read))(x =>
+        con(e2)(fun(expT(n`.`dt2, read))(y =>
           C(Zip(n, dt1, dt2, access, x, y)) )) ))
 
     // OpenMP
     case depMapPar@omp.DepMapPar(n, ft1, ft2, f, array) =>
-      `new`(n`.d`ft2, λ(varT(n`.d`ft2))(tmp =>
+      `new`(n`.d`ft2, fun(varT(n`.d`ft2))(tmp =>
         acc(depMapPar)(tmp.wr) `;` C(tmp.rd) ))
 
     case mapPar@omp.MapPar(n, dt1, dt2, f, array) =>
       println("WARNING: map loop continuation translation allocates memory")
       // TODO should be removed
-      `new`(n`.`dt2, λ(varT(n`.`dt2))(tmp =>
+      `new`(n`.`dt2, fun(varT(n`.`dt2))(tmp =>
         acc(mapPar)(tmp.wr) `;` C(tmp.rd) ))
 
     case omp.ReducePar(n, dt1, dt2, f, init, array) =>
-      con(array)(λ(expT(n`.`dt1, read))(X =>
-        con(init)(λ(expT(dt2, read))(Y =>
+      con(array)(fun(expT(n`.`dt1, read))(X =>
+        con(init)(fun(expT(dt2, read))(Y =>
           ompI.ReduceParI(n, dt1, dt2,
-            λ(expT(dt2, read))(x => λ(expT(dt1, read))(y => λ(accT(dt2))(o =>
+            fun(expT(dt2, read))(x => fun(expT(dt1, read))(y => fun(accT(dt2))(o =>
               acc( f(x)(y) )( o ) ))),
             Y, X, C)))))
 
     // OpenCL
     case depMap: ocl.DepMap =>
       val (n, _, ft2, _, _) = depMap.unwrap
-      `new`(n`.d`ft2, λ(varT(n`.d`ft2))(tmp =>
+      `new`(n`.d`ft2, fun(varT(n`.d`ft2))(tmp =>
         acc(depMap)(tmp.wr) `;` C(tmp.rd) ))
 
     case map@ocl.Map(level, dim) =>
       println("WARNING: map loop continuation translation allocates memory")
       // TODO should be removed
-      `new`(map.n `.` map.dt2, λ(varT(map.n `.` map.dt2))(tmp =>
+      `new`(map.n `.` map.dt2, fun(varT(map.n `.` map.dt2))(tmp =>
         acc(map)(tmp.wr) `;` C(tmp.rd)))
 
     case fc@ocl.OpenCLFunctionCall(name, n) =>
@@ -373,11 +373,11 @@ object ContinuationTranslation {
         ts match {
           // with only one argument left to process continue with the OpenCLFunction call
           case Seq( (arg, inT) ) =>
-            con(arg)(λ(expT(inT, read))(e =>
+            con(arg)(fun(expT(inT, read))(e =>
               C(ocl.OpenCLFunctionCall(name, n)(inTs :+ inT, fc.outT, es :+ e)) ))
           // with a `tail` of arguments left, rec
           case Seq( (arg, inT), tail@_* ) =>
-            con(arg)(λ(expT(inT, read))(e => rec(tail, es :+ e, inTs :+ inT) ))
+            con(arg)(fun(expT(inT, read))(e => rec(tail, es :+ e, inTs :+ inT) ))
         }
       }
 
@@ -386,11 +386,11 @@ object ContinuationTranslation {
     case reduceSeq@ocl.ReduceSeq(unroll) =>
       val (n, a, dt1, dt2, f, init, array) = reduceSeq.unwrap
 
-      con(array)(λ(expT(n`.`dt1, read))(X =>
+      con(array)(fun(expT(n`.`dt1, read))(X =>
         oclI.ReduceSeqI(n, a, dt1, dt2,
-          λ(expT(dt2, read))(x =>
-            λ(expT(dt1, read))(y =>
-              λ(accT(dt2))(o => acc( f(x)(y) )( o )))),
+          fun(expT(dt2, read))(x =>
+            fun(expT(dt1, read))(y =>
+              fun(accT(dt2))(o => acc( f(x)(y) )( o )))),
           init, X, C, unroll)(context)))
 
     case ocl.ToMem(addrSpace, dt, input) =>
@@ -414,19 +414,19 @@ object ContinuationTranslation {
 
       println("WARNING: map loop continuation translation allocates memory")
       // TODO should be removed
-      `new`(n `.` dt2, λ(varT(n `.` dt2))(tmp =>
+      `new`(n `.` dt2, fun(varT(n `.` dt2))(tmp =>
         acc(map)(tmp.wr) `;` C(tmp.rd)))
 
-    case m@cuda.MapFragment(rows, columns, layers, dt, frag, layout, fun, input) =>
+    case m@cuda.MapFragment(rows, columns, layers, dt, frag, layout, f, input) =>
       val fragType = FragmentType(rows, columns, layers, dt, frag, layout)
       shine.OpenCL.primitives.imperative.New(AddressSpace.Private, fragType,
-        λ(VarType(fragType))(fragmentAcc =>
+        fun(VarType(fragType))(fragmentAcc =>
           (if (input.t.accessType.toString == write.toString)
             acc(input)(fragmentAcc.wr) `;`
               cudaIm.ForFragment(rows, columns, layers, dt, frag, layout, fragmentAcc.rd, fragmentAcc.wr,
-                λ(expT(dt, read))(x =>
-                  λ(accT(dt))(o =>
-                    acc(fun(x))(o))))
+                fun(expT(dt, read))(x =>
+                  fun(accT(dt))(o =>
+                    acc(f(x))(o))))
           else
             acc(m)(fragmentAcc.wr)) `;`
             C(fragmentAcc.rd)))

--- a/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
+++ b/src/main/scala/shine/DPIA/Compilation/FedeTranslation.scala
@@ -54,7 +54,7 @@ object FedeTranslation {
         AsScalarAcc(n, m, dt, C(o))))
 
     case Join(n, m, _, dt, array) =>
-      fedAcc(env)(array)(λ(accT(C.t.inT.dataType))(o =>
+      fedAcc(env)(array)(fun(accT(C.t.inT.dataType))(o =>
         JoinAcc(n, m, dt, C(o))))
 
     case Map(n, dt1, dt2, access, f, array) =>
@@ -63,10 +63,10 @@ object FedeTranslation {
       val otype = AccType(dt2)
       val o = Identifier(freshName("fede_o"), otype)
 
-      fedAcc(env)(array)(λ(env.toList.head._2.t)(y =>
+      fedAcc(env)(array)(fun(env.toList.head._2.t)(y =>
         MapAcc(n, dt2, dt1,
           Lambda(o,
-            fedAcc(Predef.Map((x, o)))(f(x))(λ(otype)(x => x))), C(y))))
+            fedAcc(Predef.Map((x, o)))(f(x))(fun(otype)(x => x))), C(y))))
 
     case MapFst(w, dt1, dt2, dt3, f, record) =>
       val x = Identifier(freshName("fede_x"), ExpType(dt1, write))
@@ -95,11 +95,11 @@ object FedeTranslation {
         TakeAcc(n, r, dt, C(o))))
 
     case Reorder(n, dt, _, _, idxFinv, input) =>
-      fedAcc(env)(input)(λ(accT(C.t.inT.dataType))(o =>
+      fedAcc(env)(input)(fun(accT(C.t.inT.dataType))(o =>
         ReorderAcc(n, dt, idxFinv, C(o))))
 
     case Split(n, m, _, dt, array) =>
-      fedAcc(env)(array)(λ(accT(C.t.inT.dataType))(o =>
+      fedAcc(env)(array)(fun(accT(C.t.inT.dataType))(o =>
         SplitAcc(n, m, dt, C(o))))
 
     case Transpose(n, m, dt, _, array) =>

--- a/src/main/scala/shine/DPIA/DSL/Core.scala
+++ b/src/main/scala/shine/DPIA/DSL/Core.scala
@@ -6,24 +6,22 @@ import shine.DPIA.Types._
 import shine.DPIA._
 
 object identifier {
-  def apply[T <: PhraseType](name: String, t: T) = Identifier(name, t)
+  def apply[T <: PhraseType](name: String, t: T): Identifier[T] = Identifier(name, t)
 }
 
-trait funDef {
-
-  def apply[T1 <: PhraseType, T2 <: PhraseType](t: T1)
-                                               (f: Identifier[T1] => Phrase[T2]): Lambda[T1, T2] = {
+case class fun[T <: PhraseType](t: T) {
+  def apply[U <: PhraseType](f: Identifier[T] => Phrase[U]): Lambda[T, U] = {
     val param = identifier(freshName("x"), t)
     Lambda(param, f(param))
   }
-
 }
 
-object fun extends funDef
-
-object \ extends funDef
-
-object λ extends funDef
+case class depFun[T, I](kind: Kind[T, I]) {
+  def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U] = {
+    val x = Kind.makeIdentifier(kind)
+    DepLambda(kind, x, f(x))
+  }
+}
 
 object nFun {
   def apply[T <: PhraseType](f: NatIdentifier => Phrase[T],
@@ -31,28 +29,4 @@ object nFun {
     val x = NatIdentifier(freshName("n"), range)
     DepLambda(NatKind, x, f(x))
   }
-}
-
-trait depFunDef {
-  def apply[T, I](kind: Kind[T, I]): Object {
-    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U]
-  } = new {
-    def apply[U <: PhraseType](f: I => Phrase[U]): DepLambda[T, I, U] = {
-      val x = Kind.makeIdentifier(kind)
-      DepLambda(kind, x, f(x))
-    }
-  }
-}
-
-object depFun extends depFunDef
-object _Λ_ extends depFunDef
-
-object π1 {
-  def apply[T1 <: PhraseType, T2 <: PhraseType](pair: Phrase[T1 x T2]) =
-    Proj1(pair)
-}
-
-object π2 {
-  def apply[T1 <: PhraseType, T2 <: PhraseType](pair: Phrase[T1 x T2]) =
-    Proj2(pair)
 }

--- a/src/main/scala/shine/DPIA/DSL/ImperativePrimitives.scala
+++ b/src/main/scala/shine/DPIA/DSL/ImperativePrimitives.scala
@@ -20,7 +20,7 @@ object `new` {
 
   def apply(dt: DataType,
             f: Phrase[VarType] => Phrase[CommType]): New =
-    New(dt, λ(varT(dt))( v => f(v) ))
+    New(dt, fun(varT(dt))( v => f(v) ))
 }
 
 object newDoubleBuffer {
@@ -30,10 +30,10 @@ object newDoubleBuffer {
             in: Phrase[ExpType],
             out: Phrase[AccType],
             f: (Phrase[VarType], Phrase[CommType], Phrase[CommType]) => Phrase[CommType]): NewDoubleBuffer =
-    NewDoubleBuffer(dt1, dt2, dt3.elemType, dt3.size, in, out, λ(varT(dt1) x CommType() x CommType())(ps => {
-      val    v: Phrase[VarType]  = ps._1._1
-      val swap: Phrase[CommType] = ps._1._2
-      val done: Phrase[CommType] = ps._2
+    NewDoubleBuffer(dt1, dt2, dt3.elemType, dt3.size, in, out, fun(varT(dt1) x CommType() x CommType())(ps => {
+      val    v: Phrase[VarType]  = ps.`1`.`1`
+      val swap: Phrase[CommType] = ps.`1`.`2`
+      val done: Phrase[CommType] = ps.`2`
       f(v, swap, done)
     }))
 }
@@ -45,8 +45,13 @@ object `if` {
     IfThenElse(cond, thenP, elseP)
 
   //noinspection TypeAnnotation
-  def apply(cond: Phrase[ExpType]) = new {
-    def `then`[T <: PhraseType](thenP: Phrase[T]) = new {
+  def apply(cond: Phrase[ExpType]): IfHelper = IfHelper(cond)
+
+  case class IfHelper(cond: Phrase[ExpType]) {
+    def `then`[T <: PhraseType](thenP: Phrase[T]): IfHelper.ThenHelper[T] = IfHelper.ThenHelper(cond, thenP)
+  }
+  object IfHelper {
+    case class ThenHelper[T <: PhraseType](cond: Phrase[ExpType], thenP: Phrase[T]) {
       def `else`(elseP: Phrase[T]): IfThenElse[T] = {
         IfThenElse(cond, thenP, elseP)
       }
@@ -57,7 +62,7 @@ object `if` {
 object `for` {
   def apply(n: Nat,
             f: Identifier[ExpType] => Phrase[CommType], unroll:Boolean = false): For =
-    For(unroll)(n, λ(expT(idx(n), read))( i => f(i) ))
+    For(unroll)(n, fun(expT(idx(n), read))( i => f(i) ))
 }
 
 object forNat {

--- a/src/main/scala/shine/DPIA/DSL/package.scala
+++ b/src/main/scala/shine/DPIA/DSL/package.scala
@@ -77,11 +77,14 @@ package object DSL {
 
   //noinspection TypeAnnotation
   implicit class AssignmentHelper(lhs: Phrase[AccType]) {
-    def :=|(dt: DataType) = new {
+    def :=|(dt: DataType): AssignmentHelper.SyntaxHelper =
+      AssignmentHelper.SyntaxHelper(lhs, dt)
+  }
+  object AssignmentHelper {
+    case class SyntaxHelper(lhs: Phrase[AccType], dt: DataType) {
       def |(rhs: Phrase[ExpType])
-           (implicit context: TranslationContext): Phrase[CommType] = {
+           (implicit context: TranslationContext): Phrase[CommType] =
         context.assign(dt, lhs, rhs)
-      }
     }
   }
 
@@ -113,7 +116,7 @@ package object DSL {
 
   implicit class FunComp[T1 <: PhraseType, T2 <: PhraseType](f: Phrase[T1 ->: T2]) {
     def o[T3 <: PhraseType](g: Phrase[T3 ->: T1]): Phrase[T3 ->: T2] = {
-      λ(g.t.inT)(arg => f(g(arg)))
+      fun(g.t.inT)(arg => f(g(arg)))
     }
   }
 
@@ -122,13 +125,13 @@ package object DSL {
   }
 
   implicit class VarExtensions(v: Phrase[VarType]) {
-    def rd: Proj1[ExpType, AccType] = π1(v)
-    def wr: Proj2[ExpType, AccType] = π2(v)
+    def rd: Proj1[ExpType, AccType] = Proj1(v)
+    def wr: Proj2[ExpType, AccType] = Proj2(v)
   }
 
   implicit class PairExtensions[T1 <: PhraseType, T2 <: PhraseType](v: Phrase[T1 x T2]) {
-    def _1: Proj1[T1, T2] = π1(v)
-    def _2: Proj2[T1, T2] = π2(v)
+    def `1`: Proj1[T1, T2] = Proj1(v)
+    def `2`: Proj2[T1, T2] = Proj2(v)
   }
 
   def mapTransientNat(natExpr: Phrase[ExpType], f: Nat => Nat): Phrase[ExpType] = {

--- a/src/main/scala/shine/DPIA/Lifting.scala
+++ b/src/main/scala/shine/DPIA/Lifting.scala
@@ -36,7 +36,7 @@ object Lifting {
 
     p match {
       case l: Lambda[T1, T2] =>
-        Reducing((arg: Phrase[T1]) => l.body `[` arg  `/` l.param `]`)
+        Reducing((arg: Phrase[T1]) => Phrase.substitute(arg, `for`=l.param, in=l.body))
       case app: Apply[_, T1 ->: T2] =>
         chain(liftFunction(app.fun).map(lf => lf(app.arg)))
       case DepApply(_, f, arg) =>
@@ -56,7 +56,7 @@ object Lifting {
   def liftFunctionToNatLambda[T <: PhraseType](p: Phrase[ExpType ->: T]): Nat => Phrase[T] = {
     p match {
       case l: Lambda[ExpType, T] =>
-        (arg: Nat) => l.body `[` arg  `/` NatIdentifier(l.param.name) `]`
+        (arg: Nat) => Types.substitute(arg, `for`=NatIdentifier(l.param.name), in=l.body)
       case app: Apply[_, ExpType ->: T] =>
         val fun = liftFunction(app.fun).reducing
         liftFunctionToNatLambda(fun(app.arg))

--- a/src/main/scala/shine/DPIA/Phrases/Phrase.scala
+++ b/src/main/scala/shine/DPIA/Phrases/Phrase.scala
@@ -47,9 +47,9 @@ final case class DepLambda[T, I, U <: PhraseType](kind: Kind[T, I],
 }
 
 object DepLambda {
-  def apply[T, I](kind: Kind[T, I], x: I): Object {
-    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U]
-  } = new {
+  def apply[T, I](kind: Kind[T, I], x: I): SyntaxHelper[T, I] = SyntaxHelper(kind, x)
+
+  case class SyntaxHelper[T, I](kind: Kind[T, I], x: I) {
     def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
   }
 }

--- a/src/main/scala/shine/DPIA/Types/MatchingDSL.scala
+++ b/src/main/scala/shine/DPIA/Types/MatchingDSL.scala
@@ -3,9 +3,8 @@ package shine.DPIA.Types
 object MatchingDSL {
 
   object ->: {
-    def unapply[T <: PhraseType, R <: PhraseType](funType: FunType[T, R]
-                                                 ): Option[(T, R)] = {
-      FunType.unapply(funType)
+    def unapply[T <: PhraseType, R <: PhraseType](funType: FunType[T, R]): Option[(T, R)] = {
+      Some((funType.inT, funType.outT))
     }
   }
 

--- a/src/main/scala/shine/DPIA/fromRise.scala
+++ b/src/main/scala/shine/DPIA/fromRise.scala
@@ -88,12 +88,8 @@ object fromRise {
     Lambda(x, f(x))
   }
 
-  object depFun {
-    def apply[T, I](kind: rt.Kind[T, I], x: I): Object {
-      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U]
-    } = new {
-      def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
-    }
+  case class depFun[T, I](kind: rt.Kind[T, I], x: I) {
+    def apply[U <: PhraseType](body: Phrase[U]): DepLambda[T, I, U] = DepLambda(kind, x, body)
   }
 
   private def primitive(p: r.Primitive,

--- a/src/main/scala/shine/DPIA/package.scala
+++ b/src/main/scala/shine/DPIA/package.scala
@@ -10,7 +10,7 @@ import rise.core.{types => rt}
 package object DPIA {
 
   def error(found: String, expected: String): Nothing = {
-    throw new TypeException(s"Found $found but expected $expected")
+    throw TypeException(s"Found $found but expected $expected")
   }
 
   def error(msg: String = "This should not happen"): Nothing = {
@@ -48,42 +48,6 @@ package object DPIA {
     def apply(dt: DataType): PhrasePairType[ExpType, AccType] = ExpType(dt, read) x AccType(dt)
   }
 
-  //noinspection TypeAnnotation
-  implicit class PhraseTypeSubstitutionHelper[T <: PhraseType](t: PhraseType) {
-    def `[`(e: Nat) = new {
-      def `/`(a: NatIdentifier) = new {
-        def `]`: PhraseType = shine.DPIA.Types.substitute(e, `for`=a, in=t)
-      }
-    }
-
-    def `[`(e: DataType) = new {
-      def `/`(a: DataType) = new {
-        def `]`: PhraseType = shine.DPIA.Types.substitute(e, `for`=a, in=t)
-      }
-    }
-  }
-
-  //noinspection TypeAnnotation
-  implicit class PhraseSubstitutionHelper[T1 <: PhraseType](in: Phrase[T1]) {
-    def `[`[T2 <: PhraseType](p: Phrase[T2]) = new {
-      def `/`(`for`: Phrase[T2]) = new {
-        def `]`: Phrase[T1] = Phrase.substitute(p, `for`, in)
-      }
-    }
-
-    def `[`(e: Nat) = new {
-      def `/`(`for`: NatIdentifier) = new {
-        def `]`: Phrase[T1] = shine.DPIA.Types.substitute(e, `for`, in)
-      }
-    }
-
-    def `[`(dt: DataType) = new {
-      def `/`(`for`: DataTypeIdentifier) = new {
-        def `]`: Phrase[T1] = shine.DPIA.Types.substitute(dt, `for`, in)
-      }
-    }
-  }
-
   implicit class PairTypeConstructor[T1 <: PhraseType](t1: T1) {
     @inline
     def x[T2 <: PhraseType](t2: T2): T1 x T2 = PhrasePairType(t1, t2)
@@ -109,7 +73,7 @@ package object DPIA {
     def apply(dt: DataType, a: Access): ExpType = ExpType(dt, a)
 
     def unapply(et: ExpType): Option[(DataType, Access)] = {
-      ExpType.unapply(et)
+      Some((et.dataType, et.accessType))
     }
   }
 
@@ -117,7 +81,7 @@ package object DPIA {
     def apply(dt: DataType): AccType = AccType(dt)
 
     def unapply(at: AccType): Option[DataType] = {
-      AccType.unapply(at)
+      Some(at.dataType)
     }
   }
 

--- a/src/main/scala/shine/OpenCL/Compilation/HostManagedBuffers.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/HostManagedBuffers.scala
@@ -66,7 +66,7 @@ object HostManagedBuffers {
     } else {
       assert(current.device_reads.isEmpty)
       assert(current.device_writes.isEmpty)
-      val env = (current.host_reads ++ current.host_writes)
+      val env: Map[Identifier[_ <: PhraseType], AccessFlags] = (current.host_reads ++ current.host_writes)
         .filter(optionallyManaged(_).isDefined).map(i => {
         var access = 0
         if (current.host_reads.contains(i)) { access |= HOST_READ }
@@ -151,9 +151,10 @@ object HostManagedBuffers {
   private def insertManagedBuffers(
     managed: mutable.Map[Identifier[_ <: PhraseType], AccessFlags]
   ): Phrase[CommType] => Phrase[CommType] = p => {
-    val managed2 = managed.iterator.flatMap { case (i, a) =>
-      optionallyManaged(i).map(om => i -> (a, om._1))
-    }.toMap
+    val managed2: Map[Identifier[_ <: PhraseType], (AccessFlags, Identifier[_ <: PhraseType])] =
+      managed.iterator.flatMap { case (i, a) =>
+        optionallyManaged(i).map(om => i -> (a, om._1))
+      }.toMap
     VisitAndRebuild(p, InsertManagedBuffersVisitor(managed2))
   }
 

--- a/src/main/scala/shine/OpenCL/Compilation/Passes/HoistMemoryAllocations.scala
+++ b/src/main/scala/shine/OpenCL/Compilation/Passes/HoistMemoryAllocations.scala
@@ -109,16 +109,16 @@ object HoistMemoryAllocations {
           case Left(identExpr) =>
             Phrase.substitute(
               substitutionMap = Map(
-                π1(oldVariable) -> (π1(newVariable) `@` identExpr),
-                π2(oldVariable) -> (π2(newVariable) `@` identExpr)
+                oldVariable.rd -> (newVariable.rd `@` identExpr),
+                oldVariable.wr -> (newVariable.wr `@` identExpr)
               ),
               in = oldBody
             )
           case Right(identNat) =>
             Phrase.substitute(
               substitutionMap = Map(
-                π1(oldVariable) -> (π1(newVariable) `@` identNat),
-                π2(oldVariable) -> (π2(newVariable) `@` identNat)
+                oldVariable.rd -> (newVariable.rd `@` identNat),
+                oldVariable.wr -> (newVariable.wr `@` identNat)
               ),
               in = oldBody
             )

--- a/src/main/scala/shine/OpenCL/DSL/package.scala
+++ b/src/main/scala/shine/OpenCL/DSL/package.scala
@@ -42,7 +42,7 @@ package object DSL {
   private def parForBodyFunction(n:Nat, ft:NatToData,
                                  f:NatIdentifier => Phrase[AccType] => Phrase[CommType]
                                 ): DepLambda[Nat, NatIdentifier, AccType ->: CommType] = {
-    nFun(idx => λ(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1))
+    nFun(idx => fun(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1))
   }
 
   def parForNatGlobal(dim:Int)(n:Nat, ft:NatToData, out:Phrase[AccType],
@@ -60,7 +60,7 @@ package object DSL {
   object `new` {
     def apply(addrSpace: AddressSpace)
              (dt: DataType, f: Phrase[VarType] => Phrase[CommType]): New =
-      New(addrSpace, dt, λ(varT(dt))(v => f(v) ))
+      New(addrSpace, dt, fun(varT(dt))(v => f(v) ))
   }
 
   object newDoubleBuffer {
@@ -72,10 +72,10 @@ package object DSL {
               out: Phrase[AccType],
               f: (Phrase[VarType], Phrase[CommType], Phrase[CommType]) => Phrase[CommType]): NewDoubleBuffer =
       NewDoubleBuffer(a, dt1, dt2, dt3.elemType, dt3.size, in, out,
-        λ(varT(dt1) x CommType() x CommType())(ps => {
-          val    v: Phrase[VarType]  = ps._1._1
-          val swap: Phrase[CommType] = ps._1._2
-          val done: Phrase[CommType] = ps._2
+        fun(varT(dt1) x CommType() x CommType())(ps => {
+          val    v: Phrase[VarType]  = ps.`1`.`1`
+          val swap: Phrase[CommType] = ps.`1`.`2`
+          val done: Phrase[CommType] = ps.`2`
           f(v, swap, done)
         }))
   }

--- a/src/main/scala/shine/OpenCL/KernelExecutor.scala
+++ b/src/main/scala/shine/OpenCL/KernelExecutor.scala
@@ -21,8 +21,8 @@ object KernelExecutor {
   sealed case class KernelWithSizes(ktu: KernelModule,
                                     localSize: LocalSize,
                                     globalSize: GlobalSize) {
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      FromKernelModule(ktu).as[F](localSize, globalSize)
+    def as[T, R](implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      FromKernelModule(ktu).as[T, R](localSize, globalSize)
     }
 
     def code: String = util.gen.opencl.kernel.asString(ktu)
@@ -31,18 +31,15 @@ object KernelExecutor {
   }
 
   sealed case class KernelNoSizes(ktu: KernelModule) {
-    //noinspection TypeAnnotation
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): Object {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
+    def as[T, R](implicit ev: T <:< HList): AS[T, R] = AS()
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
-    } = new {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu).as[F](localSize, globalSize)
+    case class AS[T, R]()(implicit ev: T <:< HList) {
+      def apply(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu).as[T, R](localSize, globalSize)
       }
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu).as[F](localSize, globalSize)
+      def withSizes(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu).as[T, R](localSize, globalSize)
       }
     }
 
@@ -83,9 +80,9 @@ object KernelExecutor {
       val kernelF = kernel.as[ScalaFunction`(`Array[Float]`)=>`Array[Float]]
       val (result, time) = kernelF(xs `;`)
       */
-    def as[F <: FunctionHelper](localSize: LocalSize, globalSize: GlobalSize)
-                               (implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      hArgs: F#T => {
+    def as[T, R](localSize: LocalSize, globalSize: GlobalSize)
+                (implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      (hArgs: T) => {
         val args: List[Any] = hArgs.toList
         assert(kernel.inputParams.length == args.length)
 
@@ -141,7 +138,7 @@ object KernelExecutor {
           kernelArgs.toArray
         )
 
-        val output = castToOutputType[F#R](outputParam._2.typ, outputArg)
+        val output = castToOutputType[R](outputParam._2.typ, outputArg)
 
         kernelArgs.foreach(_.dispose)
         kernelJNI.dispose()

--- a/src/main/scala/shine/OpenCL/package.scala
+++ b/src/main/scala/shine/OpenCL/package.scala
@@ -55,15 +55,6 @@ package object OpenCL {
       BuiltInFunctionCall("get_group_id", param, ContinuousRange(0, get_num_groups(param)))
   }
 
-  trait FunctionHelper {
-    type T
-    type R
-    type F = T => R
-  }
-
-
-  type `)=>`[TT, RR] = FunctionHelper { type T = TT; type R = RR }
-
   sealed trait HList {
     def length: Int
     def toList: List[Any]
@@ -85,7 +76,7 @@ package object OpenCL {
 
   type `,`[L <: HList, N] = HCons[L, N]
 
-  type `(`[L <: ScalaFunction, N] = HCons[L, N]
+  type `(`[L <: Args, N] = HCons[HNil.type, N]
 
   implicit class HNilHelper[V](v1: V) {
     def `,`[V2](v2: V2): HCons[HCons[HNil.type, V], V2] = HCons(HCons(HNil, v1), v2)
@@ -93,5 +84,5 @@ package object OpenCL {
     def `;`: HCons[HNil.type, V] = HCons(HNil, v1)
   }
 
-  type ScalaFunction = HNil.type
+  type Args = HNil.type
 }

--- a/src/main/scala/shine/OpenCL/primitives/intermediate/MapI.scala
+++ b/src/main/scala/shine/OpenCL/primitives/intermediate/MapI.scala
@@ -15,6 +15,6 @@ final case class MapI(level: ParallelismLevel, dim: Int) {
             out: Phrase[AccType]): Phrase[CommType] = {
     comment(s"map${level.toString}") `;`
       shine.OpenCL.DSL.parFor(level, dim, unroll = false)(n, dt2, out,
-        λ(expT(idx(n), read))(i => λ(accT(dt2))(a => f(in `@` i)(a))))
+        fun(expT(idx(n), read))(i => fun(accT(dt2))(a => f(in `@` i)(a))))
   }
 }

--- a/src/main/scala/shine/OpenMP/DSL/ImperativePrimitives.scala
+++ b/src/main/scala/shine/OpenMP/DSL/ImperativePrimitives.scala
@@ -15,7 +15,7 @@ object parFor {
             dt: DataType,
             out: Phrase[AccType],
             f: Phrase[ExpType] => Phrase[AccType] => Phrase[CommType]): ParFor =
-    ParFor(n, dt, out, λ(expT(idx(n), read))(i => λ(accT(dt))(o => f(i)(o) )))
+    ParFor(n, dt, out, fun(expT(idx(n), read))(i => fun(accT(dt))(o => f(i)(o) )))
 }
 
 object `parForVec` {
@@ -23,12 +23,12 @@ object `parForVec` {
             st: DataType,
             out: Phrase[AccType],
             f: Phrase[ExpType] => Phrase[AccType] => Phrase[CommType]): ForVec =
-    ForVec(n, st, out, λ(expT(idx(n), read))(i => λ(accT(st))(o => f(i)(o) )))
+    ForVec(n, st, out, fun(expT(idx(n), read))(i => fun(accT(st))(o => f(i)(o) )))
 }
 
 object parForNat {
   def apply(n: Nat, ft: NatToData, out: Phrase[AccType],
             f: NatIdentifier => Phrase[AccType] => Phrase[CommType]): ParForNat = {
-    ParForNat(n, ft, out, nFun(idx => λ(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1)))
+    ParForNat(n, ft, out, nFun(idx => fun(accT(ft(idx)))(o => f(idx)(o)), RangeAdd(0, n, 1)))
   }
 }

--- a/src/main/scala/shine/OpenMP/TranslationContext.scala
+++ b/src/main/scala/shine/OpenMP/TranslationContext.scala
@@ -1,7 +1,7 @@
 package shine.OpenMP
 
 import shine.C
-import shine.DPIA.DSL.λ
+import shine.DPIA.DSL.fun
 import shine.DPIA.primitives.intermediate.MapVecI
 import shine.DPIA.Phrases.Phrase
 import shine.DPIA.Types.{AccType, CommType, ExpType}
@@ -14,7 +14,7 @@ class TranslationContext() extends C.Compilation.TranslationContext {
                       E: Phrase[ExpType]): Phrase[CommType] = {
     dt match {
       case VectorType(n, st) =>
-        MapVecI(n, st, st, λ(ExpType(st, read))(x => λ(AccType(st))(a => assign(st, a, x) )), E, A)
+        MapVecI(n, st, st, fun(ExpType(st, read))(x => fun(AccType(st))(a => assign(st, a, x) )), E, A)
 
       case _ => super.assign(dt, A, E)
     }

--- a/src/main/scala/shine/cuda/Compilation/Passes/HoistMemoryAllocations.scala
+++ b/src/main/scala/shine/cuda/Compilation/Passes/HoistMemoryAllocations.scala
@@ -1,7 +1,7 @@
 package shine.cuda.Compilation.Passes
 
 import arithexpr.arithmetic.ArithExpr.Math.Min
-import shine.DPIA.DSL.{π1, π2, _}
+import shine.DPIA.DSL._
 import shine.DPIA.Phrases.{Identifier, Lambda, Phrase, VisitAndRebuild}
 import rise.core.types._
 import rise.core.DSL.Type._
@@ -105,16 +105,16 @@ object HoistMemoryAllocations {
           case Left(identExpr) =>
             Phrase.substitute(
               substitutionMap = Map(
-                π1(oldVariable) -> (π1(newVariable) `@` identExpr),
-                π2(oldVariable) -> (π2(newVariable) `@` identExpr)
+                oldVariable.rd -> (newVariable.rd `@` identExpr),
+                oldVariable.wr -> (newVariable.wr `@` identExpr)
               ),
               in = oldBody
             )
           case Right(identNat) =>
             Phrase.substitute(
               substitutionMap = Map(
-                π1(oldVariable) -> (π1(newVariable) `@` identNat),
-                π2(oldVariable) -> (π2(newVariable) `@` identNat)
+                oldVariable.rd -> (newVariable.rd `@` identNat),
+                oldVariable.wr -> (newVariable.wr `@` identNat)
               ),
               in = oldBody
             )

--- a/src/main/scala/shine/cuda/Compilation/TranslationContext.scala
+++ b/src/main/scala/shine/cuda/Compilation/TranslationContext.scala
@@ -16,8 +16,8 @@ class TranslationContext() extends shine.OpenCL.Compilation.TranslationContext {
     dt match {
       case FragmentType(rows, columns, layers, dt, frag, layout) =>
         ForFragment(rows, columns, layers, dt, frag, layout, rhs, lhs,
-          λ(expT(dt, read))(x =>
-            λ(accT(dt))(o =>
+          fun(expT(dt, read))(x =>
+            fun(accT(dt))(o =>
               Assign(dt, o, x))))
 
       case _ =>

--- a/src/main/scala/shine/cuda/KernelExecutor.scala
+++ b/src/main/scala/shine/cuda/KernelExecutor.scala
@@ -8,7 +8,7 @@ import shine.C.AST.ParamKind
 import shine.DPIA.Types._
 import shine.DPIA._
 import shine.OpenCL
-import shine.OpenCL.{FunctionHelper, GlobalSize, HList, LocalSize, NDRange, get_global_size, get_local_size, get_num_groups}
+import shine.OpenCL.{GlobalSize, HList, LocalSize, NDRange, get_global_size, get_local_size, get_num_groups}
 import shine.cuda.AST.Kernel
 import util.Time.ms
 import util.{Time, TimeSpan}
@@ -29,8 +29,8 @@ object KernelExecutor {
                                     localSize: LocalSize,
                                     globalSize: GlobalSize,
                                     compilerOptions: List[String] = List.empty) {
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+    def as[T, R](implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
     }
 
     def benchmark(creator: KernelArgCreator, numberOfIterations: Integer, dataSizesBytes: Array[Long]) : BenchmarkResult =
@@ -43,18 +43,15 @@ object KernelExecutor {
 
   sealed case class KernelNoSizes(ktu: KernelModule,
                                   compilerOptions: List[String] = List.empty) {
-    //noinspection TypeAnnotation
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): Object {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
+    def as[T, R](implicit ev: T <:< HList): AS[T, R] = AS()
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
-    } = new {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+    case class AS[T, R]()(implicit ev: T <:< HList) {
+      def apply(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
       }
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+      def withSizes(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
       }
     }
 
@@ -79,9 +76,7 @@ object KernelExecutor {
     def getBlockDim(dataLength: Int) : LocalSize
   }
 
-  case class FromKernelModule(ktu: KernelModule,
-                              compilerOptions: List[String]) {
-
+  case class FromKernelModule(ktu: KernelModule, compilerOptions: List[String]) {
     assert(ktu.kernels.size == 1)
 
     val kernel: Kernel = ktu.kernels.head
@@ -110,9 +105,9 @@ object KernelExecutor {
       * val kernelF = kernel.as[ScalaFunction`(`Array[Float]`)=>`Array[Float]]
       * val (result, time) = kernelF(xs `;`)
       */
-    def as[F <: FunctionHelper](localSize: LocalSize, globalSize: GlobalSize)
-                               (implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      hArgs: F#T => {
+    def as[T, R](localSize: LocalSize, globalSize: GlobalSize)
+                (implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      (hArgs: T) => {
         val args: List[Any] = hArgs.toList
         assert(kernel.inputParams.length == args.length)
 
@@ -146,7 +141,7 @@ object KernelExecutor {
 
         val dt = outputParam._2.typ
         assert(dt.isInstanceOf[ArrayType] || dt.isInstanceOf[DepArrayType])
-        val output = asArray[F#R](getOutputType(dt), outputArg)
+        val output = asArray[R](getOutputType(dt), outputArg)
 
         dispose(kernelArgs)
 

--- a/src/main/scala/shine/cuda/primitives/intermediate/MapI.scala
+++ b/src/main/scala/shine/cuda/primitives/intermediate/MapI.scala
@@ -16,7 +16,7 @@ final case class MapI(level: ParallelismLevel, dim: Int) {
             out: Phrase[AccType]): Phrase[CommType] = {
     val imperativ = comment(s"map${level.toString}") `;`
                       shine.cuda.DSL.parFor(level, dim, unroll = false)(n, dt2, out,
-                        λ(expT(idx(n), read))(i => λ(accT(dt2))(a => f(in `@` i)(a))))
+                        fun(expT(idx(n), read))(i => fun(accT(dt2))(a => f(in `@` i)(a))))
     //TODO use other InsertMemoryBarrieres-mechanism
     level match {
       case Local => imperativ `;` SyncThreads()

--- a/src/main/scala/util/compiler/DSL.scala
+++ b/src/main/scala/util/compiler/DSL.scala
@@ -40,7 +40,7 @@ object DSL {
     def asCompiler: S => T = composeC(pc, identity[T])(_)
   }
 
-  def run[S](f: S => ()): S => S = s => {
+  def run[S](f: S => Unit): S => S = s => {
     f(s)
     s
   }

--- a/src/main/scala/util/monads.scala
+++ b/src/main/scala/util/monads.scala
@@ -12,7 +12,10 @@ object monads {
         bind(mx)(x => bind(mxs)(xs => return_(x +: xs)))})
   }
 
-  implicit def monadicSyntax[M[_], A](m: M[A])(implicit tc: Monad[M]) = new {
+  implicit def monadicSyntax[M[_], A](m: M[A])(implicit tc: Monad[M]): MonadicSyntax[M, A] =
+    new MonadicSyntax[M, A](m, tc)
+
+  class MonadicSyntax[M[_], A](m: M[A], tc: Monad[M]) {
     def map[B](f: A => B): M[B] = tc.bind(m)(a => tc.return_(f(a)) )
     def flatMap[B](f: A => M[B]): M[B] = tc.bind(m)(f)
   }

--- a/src/test/scala/apps/Acoustic3D.scala
+++ b/src/test/scala/apps/Acoustic3D.scala
@@ -47,11 +47,11 @@ class Acoustic3D extends test_util.TestsWithExecutor {
   def runKernel(k: KernelExecutor.KernelNoSizes,
                 mat1: Array[Array[Array[Float]]],
                 mat2: Array[Array[Array[Float]]]): (Array[Float], TimeSpan[Time.ms]) = {
-    val f = k.as[ScalaFunction `(`
+    val f = k.as[Args `(`
       Int `,` Int `,` Int `,`
       Array[Array[Array[Float]]] `,`
-      Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+      Array[Array[Array[Float]]],
+      Array[Float]]
     f(localSize, globalSize)(O `,` N `,` M `,` mat1 `,` mat2)
   }
 

--- a/src/test/scala/apps/asum.scala
+++ b/src/test/scala/apps/asum.scala
@@ -128,7 +128,7 @@ class asum extends test_util.TestsWithExecutor {
     )(n: Int, input: Array[Float]): Array[Float] = {
       import shine.OpenCL._
       val k = gen.opencl.kernel.fromExpr(kernel)
-      val runKernel = k.as[ScalaFunction `(` Int `,` Array[Float] `)=>` Array[Float]]
+      val runKernel = k.as[Args `(` Int `,` Array[Float], Array[Float]]
       val (output, _) = runKernel(localSize, globalSize)(n `,` input)
       output
     }

--- a/src/test/scala/apps/convolution1D.scala
+++ b/src/test/scala/apps/convolution1D.scala
@@ -89,14 +89,10 @@ class convolution1D extends test_util.Tests {
     val goldKernel = gen.opencl.kernel.fromExpr(wrapExpr(binomialSeq))
     val kernel = gen.opencl.kernel.fromExpr(wrapExpr(e))
 
-    val goldRun = goldKernel.as[ScalaFunction `(`
-      Int `,` Array[Float]
-      `)=>` Array[Float]]
+    val goldRun = goldKernel.as[Args `(` Int `,` Array[Float], Array[Float]]
     val (gold, _) = goldRun(LocalSize(1), GlobalSize(1))(N `,` input)
 
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Array[Float]
-      `)=>` Array[Float]]
+    val run = kernel.as[Args `(` Int `,` Array[Float], Array[Float]]
     val (output, time) = run(localSize, globalSize)(N `,` input)
     util.assertSame(output, gold, "output is different from gold")
     logger.debug(s"time: $time")

--- a/src/test/scala/apps/fft.scala
+++ b/src/test/scala/apps/fft.scala
@@ -16,8 +16,8 @@ class fft extends test_util.Tests {
     val sinpi = foreignFun("sinpi", f64 ->: f64)
 
     val cmultandsum = fun(acc => fun(vt => {
-      val lres = acc._1 + (vt._1._1 * vt._2._1 - vt._1._2 * vt._2._2)
-      val rres = acc._2 + (vt._1._2 * vt._2._1 + vt._1._1 * vt._2._2)
+      val lres = acc.`1` + (vt.`1`.`1` * vt.`2`.`1` - vt.`1`.`2` * vt.`2`.`2`)
+      val rres = acc.`2` + (vt.`1`.`2` * vt.`2`.`1` + vt.`1`.`1` * vt.`2`.`2`)
       makePair(lres)(rres)
     }))
 
@@ -43,8 +43,8 @@ class fft extends test_util.Tests {
       ) |> map(fun(yChunkRow =>
         zip(yChunkRow)(reorderedB))
       ) |> mapGlobal(mapSeq(fun(yChunkWithBrow => {
-        val yChunk = yChunkWithBrow._1
-        val Brow = yChunkWithBrow._2
+        val yChunk = yChunkWithBrow.`1`
+        val Brow = yChunkWithBrow.`2`
         Brow |> mapSeq(
           fun(Bchunk =>
             zip(yChunk)(Bchunk) |> reduceSeq(cmultandsum)(

--- a/src/test/scala/apps/gemmTensorCheck.scala
+++ b/src/test/scala/apps/gemmTensorCheck.scala
@@ -58,10 +58,10 @@ class gemmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+      val run = KernelNoSizes(kernel, compilerOptions).as[Args `(`
         Int `,` Int `,` Int `,` Float `,` Float `,`
-        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]],
+        Array[Float]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b
@@ -86,10 +86,10 @@ class gemmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[ScalaFunction `(`
+      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[Args `(`
         Int `,` Int `,` Int `,` Float `,` Float `,`
-        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]],
+        Array[Float]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b

--- a/src/test/scala/apps/harrisCornerDetectionHalideCheck.scala
+++ b/src/test/scala/apps/harrisCornerDetectionHalideCheck.scala
@@ -100,14 +100,14 @@ class harrisCornerDetectionHalideCheck
     val random = new scala.util.Random()
     val input = Array.fill(3, Hi, Wi)(random.nextFloat() * 10.0f)
 
-    val fg = goldProg.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+    val fg = goldProg.as[Args `(`
+      Int `,` Int `,` Array[Array[Array[Float]]],
+      Array[Float]]
     val (gold, goldTime) = fg(LocalSize(1), GlobalSize(1))(Ho `,` Wo `,` input)
 
-    val f = prog.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+    val f = prog.as[Args `(`
+      Int `,` Int `,` Array[Array[Array[Float]]],
+      Array[Float]]
     val (output, time) = f(ls, gs)(Ho `,` Wo `,` input)
 
     logger.debug(s"gold time: $goldTime")

--- a/src/test/scala/apps/mmTensorCheck.scala
+++ b/src/test/scala/apps/mmTensorCheck.scala
@@ -21,9 +21,9 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     println(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
-        Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val run = KernelNoSizes(kernel, compilerOptions).as[Args `(`
+        Array[Array[Float]] `,` Array[Array[Float]],
+        Array[Float]]
 
       val (output, _) =  run(LocalSize(1), GlobalSize(32))(a `,` b)
 
@@ -154,10 +154,10 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-        val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+        val run = KernelNoSizes(kernel, compilerOptions).as[Args `(`
           Int `,` Int `,` Int `,`
-          Array[Array[Float]] `,` Array[Array[Float]]
-          `)=>` Array[Float]]
+          Array[Array[Float]] `,` Array[Array[Float]],
+          Array[Float]]
 
         val aMatrix = if (matrixATranspose) a.transpose else a
         val bMatrix = if (matrixBTranspose) b.transpose else b
@@ -185,10 +185,10 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[ScalaFunction `(`
+      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[Args `(`
         Int `,` Int `,` Int `,`
-        Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]],
+        Array[Float]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b

--- a/src/test/scala/apps/separableConvolution2DCheck.scala
+++ b/src/test/scala/apps/separableConvolution2DCheck.scala
@@ -93,9 +93,9 @@ int main(int argc, char** argv) {
     val gold = computeGold(H, W, input, binomialWeights2d).flatten
 
     val kernel = gen.opencl.kernel.fromExpr(wrapExpr(e))
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Float]]
-      `)=>` Array[Float]]
+    val run = kernel.as[Args `(`
+      Int `,` Int `,` Array[Array[Float]],
+      Array[Float]]
     val (output, time) = run(localSize, globalSize)(H `,` W `,` input)
     util.assertSame(output, gold, "output is different from gold")
     logger.debug(s"time: $time")

--- a/src/test/scala/apps/stencil.scala
+++ b/src/test/scala/apps/stencil.scala
@@ -73,7 +73,7 @@ class stencil extends test_util.Tests {
     ): (Array[Float], TimeSpan[ms]) = {
       import shine.OpenCL._
 
-      val kernelFun = k.as[ScalaFunction `(` Int `,` Input `)=>` Array[Float]]
+      val kernelFun = k.as[Args `(` Int `,` Input, Array[Float]]
       kernelFun(inputSize `,` input)
     }
   }

--- a/src/test/scala/rise/OpenCL/ExecuteOpenCL.scala
+++ b/src/test/scala/rise/OpenCL/ExecuteOpenCL.scala
@@ -19,7 +19,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[Args`(`Int`,`Array[Int], Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(8)(0)
 
     val (result, time) = kernelF(8`,`xs)
@@ -36,7 +36,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[Args`(`Array[Int], Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(n)(0)
 
     val (result, time) = kernelF(xs`;`)
@@ -53,7 +53,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`,`Int`)=>`Array[Int]]
+    val kernelF = kernel.as[Args `(` Array[Int]`,`Int, Array[Int]]
     val xs = Array.fill(n)(0)
 
     val (result, _) = kernelF(LocalSize(1), GlobalSize(1))(xs`,`n)
@@ -71,7 +71,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Int`,`Array[Array[Int]]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[Args`(`Int`,`Int`,`Array[Array[Int]], Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(m)(Array.fill(n)(0))
 
     val (result, time) =  kernelF(m`,`n`,`xs)
@@ -89,7 +89,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Array[Int]`,`Int`)=>`Array[Int]]
+    val kernelF = kernel.as[Args`(`Int`,`Array[Int]`,`Int, Array[Int]]
 
     val xs = Array.fill(n)(2)
     val (result, _) =  kernelF(LocalSize(1), GlobalSize(1))(n`,`xs`,`s)
@@ -105,7 +105,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[Args`(`Array[Int], Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(n)(0)
 
     val (result, time) =  kernelF(xs`;`)

--- a/src/test/scala/rise/core/dependentTypes.scala
+++ b/src/test/scala/rise/core/dependentTypes.scala
@@ -195,8 +195,8 @@ class dependentTypes extends test_util.Tests {
             reduceSeq(
               fun(x => fun(y => x + y))
             )(lf32(0.0f))(mapSeq(fun(entry => {
-              val number = entry._1
-              val index = entry._2
+              val number = entry.`1`
+              val index = entry.`2`
               number * (vector `@` index)
             }))(row))
         )

--- a/src/test/scala/rise/core/dotPrinterTests.scala
+++ b/src/test/scala/rise/core/dotPrinterTests.scala
@@ -45,10 +45,10 @@ class dotPrinterTests extends test_util.Tests {
         ((a, b, c, alpha, beta) =>
 
           zip(a)(c) |> map(fun(ac =>
-            zip(transpose(b))(ac._2) |> map(fun(bc =>
-              zip(ac._1)(bc._1) |>
-                reduceSeq(fun( (acc, y) => acc + (y._1 * y._2)))(lf32(0.0f)) |>
-                fun(x => (x * alpha) + (beta * bc._2))
+            zip(transpose(b))(ac.`2`) |> map(fun(bc =>
+              zip(ac.`1`)(bc.`1`) |>
+                reduceSeq(fun( (acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f)) |>
+                fun(x => (x * alpha) + (beta * bc.`2`))
             ))
           ))
         )

--- a/src/test/scala/rise/core/showRise.scala
+++ b/src/test/scala/rise/core/showRise.scala
@@ -17,8 +17,8 @@ class showRise extends test_util.Tests {
 
   private val dotElemWeights = fun((weights, elem) =>
     oclReduceSeqUnroll(AddressSpace.Private)(fun((acc, pair) => {
-      val pixel = pair._1
-      val weight = pair._2
+      val pixel = pair.`1`
+      val weight = pair.`2`
       acc + (pixel * weight)
     }))(lf32(0.0f))(zip(join(elem))(weights))
   )

--- a/src/test/scala/rise/core/showScalaTest.scala
+++ b/src/test/scala/rise/core/showScalaTest.scala
@@ -23,8 +23,8 @@ class showScalaTest extends test_util.Tests {
 
   private val dotElemWeights = fun((weights, elem) =>
     oclReduceSeqUnroll(AddressSpace.Private)(fun((acc, pair) => {
-      val pixel = pair._1
-      val weight = pair._2
+      val pixel = pair.`1`
+      val weight = pair.`2`
       acc + (pixel * weight)
     }))(lf32(0.0f))(zip(join(elem))(weights))
   )

--- a/src/test/scala/rise/elevate/algorithmic.scala
+++ b/src/test/scala/rise/elevate/algorithmic.scala
@@ -100,7 +100,7 @@ class algorithmic extends test_util.Tests {
           a |> map(fun(ak =>
             transpose(b) |> map(fun(bk =>
               zip(ak)(bk) |>
-                reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(
+                reduceSeq(fun((acc, y) => acc + (y.`1` * y.`2`)))(
                   lf32(0.0f)))))))))))
 
     def goldMKN(reduceFun: ToBeTyped[Rise]): ToBeTyped[Rise] = {
@@ -278,7 +278,7 @@ class algorithmic extends test_util.Tests {
         fun(ArrayType(K, ArrayType(N, f32)))(b =>
           map(fun(ak =>
             map(fun(bk =>
-              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(lf32(0.0f))) $
+              (reduceSeq(fun((acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f))) $
                 zip(ak)(bk))) $ transpose(b) )) $ a)))))).get
 
     val tile = body(body(body(body(body(tileND(2)(32)))))) `;` DFNF
@@ -308,7 +308,7 @@ class algorithmic extends test_util.Tests {
         ((a, b) =>
           map(fun(ak =>
             map(fun(bk =>
-              (reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(lf32(0.0f))) $
+              (reduceSeq(fun((acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f))) $
                 zip(ak)(bk))) $ transpose(b) )) $ a
         )
       )

--- a/src/test/scala/rise/elevate/movement.scala
+++ b/src/test/scala/rise/elevate/movement.scala
@@ -49,10 +49,10 @@ class movement extends test_util.Tests {
         ((a, b, c, alpha, beta) =>
           (transpose o map(fun(ac =>
             map(fun(bc =>
-              (fun(x => (x * alpha) + beta * bc._2) o
-                reduceSeq(fun((acc, y) => acc + (y._1 * y._2)))(lf32(0.0f))) $
-                zip(ac._1)(bc._1))) $
-              zip(transpose(b))(ac._2)))) $
+              (fun(x => (x * alpha) + beta * bc.`2`) o
+                reduceSeq(fun((acc, y) => acc + (y.`1` * y.`2`)))(lf32(0.0f))) $
+                zip(ac.`1`)(bc.`1`))) $
+              zip(transpose(b))(ac.`2`)))) $
             zip(a)(c)
         )
       )

--- a/src/test/scala/rise/eqsat/Basic.scala
+++ b/src/test/scala/rise/eqsat/Basic.scala
@@ -90,13 +90,13 @@ class Basic extends test_util.Tests {
   }
 
   test("slideBeforeMapMapF") {
-    val `_` = rct.TypePlaceholder
+    val `__` = rct.TypePlaceholder
     def wrap(inner: ToBeTyped[rc.Expr] => ToBeTyped[rc.Expr])
     : ToBeTyped[rc.Expr] =
       depFun((n: rct.Nat) =>
       depFun((dt1: rct.DataType) => depFun((dt2: rct.DataType) =>
       fun(f =>
-        inner(f :: dt1 ->: dt2) :: ((n`.`dt1) ->: `_`)
+        inner(f :: dt1 ->: dt2) :: ((n`.`dt1) ->: `__`)
       ))))
 
     proveEquiv(

--- a/src/test/scala/shine/DPIA/Primitives/Pad.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Pad.scala
@@ -100,8 +100,8 @@ class Pad extends test_util.Tests {
     val localSize = LocalSize(1)
     val globalSize = GlobalSize(1)
 
-    val f1 = k1.as[ScalaFunction `(` Int `,` Array[Array[Int]] `)=>`Array[Int]]
-    val f2 = k2.as[ScalaFunction `(` Int `,` Array[Array[Int]] `)=>`Array[Int]]
+    val f1 = k1.as[Args `(` Int `,` Array[Array[Int]], Array[Int]]
+    val f2 = k2.as[Args `(` Int `,` Array[Array[Int]], Array[Int]]
 
     val ((r1, _), (r2, _)) = util.withExecutor {
       (f1(localSize, globalSize)(N `,` input),

--- a/src/test/scala/shine/DPIA/Primitives/Partition.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Partition.scala
@@ -62,7 +62,7 @@ class Partition extends test_util.Tests {
                                        input: Array[Float]): (Array[Float], TimeSpan[Time.ms]) = {
         import shine.OpenCL._
 
-        val kernelFun = k.as[ScalaFunction `(` Int `,` Input `)=>` Array[Float]]
+        val kernelFun = k.as[Args `(` Int `,` Input, Array[Float]]
         kernelFun(inputSize `,` input)
       }
     }

--- a/src/test/scala/shine/DPIA/Primitives/Reduce.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Reduce.scala
@@ -67,7 +67,7 @@ class Reduce extends test_util.TestsWithExecutor {
     val e = depFun((m: Nat, n: Nat) =>
       fun(m`.`n`.`f32)(arr => arr
         |> oclReduceSeq (AddressSpace.Private)
-          (fun((in1, in2) => zip (in1) (in2) |> mapSeq (fun(t => t._1 + t._2))))
+          (fun((in1, in2) => zip (in1) (in2) |> mapSeq (fun(t => t.`1` + t.`2`))))
           (initExp (n))
         |> mapSeq (fun(x => x))))
 
@@ -77,8 +77,7 @@ class Reduce extends test_util.TestsWithExecutor {
 
     val gold = A.reduce((row1, row2) => row1.zip(row2).map(in => in._1 + in._2))
 
-    val runKernel = gen.opencl.kernel.fromExpr(e(m)(n)).as[ScalaFunction `(`
-      Array[Array[Float]] `)=>` Array[Float]]
+    val runKernel = gen.opencl.kernel.fromExpr(e(m)(n)).as[Args `(` Array[Array[Float]], Array[Float]]
     val (out, _)  = runKernel(LocalSize(1), GlobalSize(1))(A`;`)
 
     assertResult(gold)(out)
@@ -97,9 +96,9 @@ class Reduce extends test_util.TestsWithExecutor {
         arr |> reduceSeq (fun(_ + _))  (init)))
 
     logger.debug("Fst:")
-    function.asStringFromExpr(e(initRecordExp._1))
+    function.asStringFromExpr(e(initRecordExp.`1`))
     logger.debug("Snd:")
-    function.asStringFromExpr(e(initRecordExp._2))
+    function.asStringFromExpr(e(initRecordExp.`2`))
   }
 
   test("Record access to specify initial accumulator value" +
@@ -120,13 +119,12 @@ class Reduce extends test_util.TestsWithExecutor {
     val gold = A.sum
 
     def runKernel(initWithRecordAccess: ToBeTyped[Expr]) =
-      gen.opencl.kernel.fromExpr(e(initWithRecordAccess))
-        .as[ScalaFunction `(`Int`,`Array[Float]`)=>`Array[Float]]
+      gen.opencl.kernel.fromExpr(e(initWithRecordAccess)).as[Args `(`Int`,`Array[Float], Array[Float]]
 
     val (out1, _) =
-      runKernel(initRecordExp._1)(LocalSize(1), GlobalSize(1))(n `,` A)
+      runKernel(initRecordExp.`1`)(LocalSize(1), GlobalSize(1))(n `,` A)
     val (out2, _) =
-      runKernel(initRecordExp._2)(LocalSize(1), GlobalSize(1))(n `,` A)
+      runKernel(initRecordExp.`2`)(LocalSize(1), GlobalSize(1))(n `,` A)
 
     assertResult(gold)(out1(0))
     assertResult(gold)(out2(0))

--- a/src/test/scala/shine/DPIA/Primitives/Scatter.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Scatter.scala
@@ -26,7 +26,7 @@ class Scatter extends test_util.Tests {
     val k = gen.opencl.kernel.fromExpr(e)
     val lS = LocalSize(1)
     val gS = GlobalSize(2)
-    val f = k.as[ScalaFunction `(` Array[Int] `)=>` Array[Int]]
+    val f = k.as[Args `(` Array[Int], Array[Int]]
     val input = (1 to N).toArray
     val expected = input.reverse
     val (r, _) = util.withExecutor {
@@ -53,7 +53,7 @@ class Scatter extends test_util.Tests {
     val k = gen.opencl.kernel.fromExpr(e)
     val lS = LocalSize(1)
     val gS = GlobalSize(2)
-    val f = k.as[ScalaFunction `(` Array[Int] `)=>` Array[Int]]
+    val f = k.as[Args `(` Array[Int], Array[Int]]
     val input = Array.fill(2)((1 to N).toArray)
     val expected = input(0).reverse
     val (r, _) = util.withExecutor {

--- a/src/test/scala/shine/DPIA/StructDecl.scala
+++ b/src/test/scala/shine/DPIA/StructDecl.scala
@@ -10,7 +10,7 @@ import util.gen.c.function
 
 class StructDecl extends test_util.Tests {
   val id = fun(x => x)
-  val addT = fun(t => t._1 + t._2)
+  val addT = fun(t => t.`1` + t.`2`)
 
   test("Program with tuples in output and tuple input, can be generated in C.") {
     val tupleOut = fun(ArrayType(8, PairType(f32, f32)))(xs => xs |> mapSeq(id))

--- a/src/test/scala/shine/OpenCL/OclToMem.scala
+++ b/src/test/scala/shine/OpenCL/OclToMem.scala
@@ -49,7 +49,7 @@ class OclToMem extends test_util.Tests {
       fun(m`.`n`.`f32)(xs =>
         xs
           |> toPrivateFun(mapLocal(1) (fun(x => makePair(x |> mapLocal(0) (fun(x => x)))(x |> mapLocal(0) (fun(x => x))))))
-          |> mapLocal(1) (fun(t => makePair(t._1 |> mapLocal(0) (fun(x => x)))(t._2 |> mapLocal(0) (fun(x => x)))))))
+          |> mapLocal(1) (fun(t => makePair(t.`1` |> mapLocal(0) (fun(x => x)))(t.`2` |> mapLocal(0) (fun(x => x)))))))
 
     val localSize = LocalSize((4, 4, 1))
     val globalSize = GlobalSize((4, 8, 1))
@@ -64,7 +64,7 @@ class OclToMem extends test_util.Tests {
       fun(m`.`n`.`f32)(xs =>
         xs
           |> toLocalFun(mapLocal(1) (fun(x => makePair(x |> mapLocal(0) (fun(x => x)))(x |> mapLocal(0) (fun(x => x))))))
-          |> mapLocal(1) (fun(t => makePair(t._1 |> mapLocal(0) (fun(x => x)))(t._2 |> mapLocal(0) (fun(x => x)))))))
+          |> mapLocal(1) (fun(t => makePair(t.`1` |> mapLocal(0) (fun(x => x)))(t.`2` |> mapLocal(0) (fun(x => x)))))))
 
     gen.opencl.kernel.fromExpr(e(4)(8))
 
@@ -85,10 +85,10 @@ class OclToMem extends test_util.Tests {
         xs
           |> oclReduceSeq(Private)(fun((x, y) =>
           zip(x)(y)
-            |> mapLocal(1)(fun(zippedDim4Row => zip(zippedDim4Row._1)(zippedDim4Row._2)
-            |> mapLocal(0)(fun(zippedDim3Row => zip(zippedDim3Row._1)(zippedDim3Row._2)
-            |> mapSeq(fun(zippedDim2Row => zip(zippedDim2Row._1)(zippedDim2Row._2)
-            |> mapSeq(fun(zippedDim1Row => zippedDim1Row._1 + zippedDim1Row._2))))))))))
+            |> mapLocal(1)(fun(zippedDim4Row => zip(zippedDim4Row.`1`)(zippedDim4Row.`2`)
+            |> mapLocal(0)(fun(zippedDim3Row => zip(zippedDim3Row.`1`)(zippedDim3Row.`2`)
+            |> mapSeq(fun(zippedDim2Row => zip(zippedDim2Row.`1`)(zippedDim2Row.`2`)
+            |> mapSeq(fun(zippedDim1Row => zippedDim1Row.`1` + zippedDim1Row.`2`))))))))))
         (zeros(m)(n)(o)(p) |> mapLocal(1)(mapLocal(0)(mapSeq(mapSeq(fun(x => x))))))
           |> mapLocal(1)(mapLocal(0)(mapSeq(mapSeq(fun(x => x)))))))
 

--- a/src/test/scala/shine/cuda/MMTest.scala
+++ b/src/test/scala/shine/cuda/MMTest.scala
@@ -67,8 +67,8 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[Args `(` scala.Array[scala.Array[Float]] `,`
+        scala.Array[scala.Array[Float]], scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(matrixATest `,` matrixBTest)
 
@@ -159,8 +159,8 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(` Int `,` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[Args `(` Int `,` scala.Array[scala.Array[Float]] `,`
+        scala.Array[scala.Array[Float]], scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(kTest `,` matrixATest `,` matrixBTest)
 
@@ -309,9 +309,9 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[Args `(`
         Int `,` Int `,` Int `,` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+        scala.Array[scala.Array[Float]], scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(mTest `,` nTest `,` kTest `,` matrixATest `,` matrixBTest)
 

--- a/src/test/scala/shine/cuda/basic.scala
+++ b/src/test/scala/shine/cuda/basic.scala
@@ -2,7 +2,7 @@ package shine.cuda
 
 import rise.core.types.DataType._
 import rise.core.types._
-import shine.DPIA.DSL.{depFun, λ}
+import shine.DPIA.DSL.{depFun, fun}
 import shine.DPIA.Types.ExpType
 import shine.OpenCL.{Global, Local}
 import util.gen
@@ -11,8 +11,8 @@ class basic extends test_util.Tests {
 
   test("id with mapThreads compiles to syntactically correct Cuda") {
     val mapId = depFun(NatKind)(n =>
-      λ(ExpType(ArrayType(n, f32), read))(array =>
-        shine.cuda.primitives.functional.Map(Local, 'x')(n, f32, f32, λ(ExpType(f32, read))(x => x), array))
+      fun(ExpType(ArrayType(n, f32), read))(array =>
+        shine.cuda.primitives.functional.Map(Local, 'x')(n, f32, f32, fun(ExpType(f32, read))(x => x), array))
     )
 
     val code = gen.cuda.kernel.asStringFromPhrase(mapId)
@@ -21,8 +21,8 @@ class basic extends test_util.Tests {
 
   test("id with mapGlobal compiles to syntactically correct CUDA") {
     val mapId = depFun(NatKind)(n =>
-      λ(ExpType(ArrayType(n, f32), read))(array =>
-        shine.cuda.primitives.functional.Map(Global, 'x')(n, f32, f32, λ(ExpType(f32, read))(x => x), array))
+      fun(ExpType(ArrayType(n, f32), read))(array =>
+        shine.cuda.primitives.functional.Map(Global, 'x')(n, f32, f32, fun(ExpType(f32, read))(x => x), array))
     )
 
     val code = gen.cuda.kernel.asStringFromPhrase(mapId)


### PR DESCRIPTION
This PR introduces changes that will help to ease the migration to Scala 3, but the code in this PR remains valid Scala 2 code.

In detail the changes are:
 - The type `()` is replaced with `Unit` (as Scala 3 seems to no longer accept `()` as a type)
 - The use of generic type projections (i.e. `T#U`) in the `FunctionHelper` class is avoided as these have been [dropped](https://docs.scala-lang.org/scala3/reference/dropped-features/type-projection.html) in Scala 3
 - The `._1` and `._2` notations on Rise and DPIA expressions do not work in Scala 3 (I don't know why) I have replaced them with `` `1` `` and `` `2` ``
 - The `` `_` `` notation is also not accepted by Scala 3, I have replaced it with `` `__` ``
 - Returning anonymous object types (i.e. `def foo() = new Object { ... } has changed somehow and I have avoided this now altogether by giving the returned type names. This was mainly used in the DSLs.
 - I accommodated a [change](https://docs.scala-lang.org/scala3/guides/migration/incompat-other-changes.html#explicit-call-to-unapply) in the signature of the `unapply` method generated for case classes.
 - I removed some syntax that used Unicode symbols. This is not related to Scala 3 but has repeatedly led to problems to compile on systems where the file system does not support Unicode (as Scala generates a file with the class name for each class).