### PR TITLE
Fix bug in HostManagedBuffers logic

### DIFF
--- a/runtime/ocl/buffer_one_copy.c
+++ b/runtime/ocl/buffer_one_copy.c
@@ -62,7 +62,7 @@ void* hostBufferSync(Context ctx, Buffer b, size_t byte_size, AccessFlags access
 
 DeviceBuffer deviceBufferSync(Context ctx, Buffer b, size_t byte_size, AccessFlags access) {
   if ((access & DEVICE_READ) && b->host_dirty) {
-    oclFatalError(clEnqueueWriteBuffer(ctx->queue, b->device_mem, CL_FALSE, 0, byte_size,
+    oclFatalError(clEnqueueWriteBuffer(ctx->queue, b->device_mem, CL_TRUE, 0, byte_size,
       b->host_mem, 0, NULL, NULL),
       "could not upload buffer data to host"
     );

--- a/src/main/scala/shine/DPIA/showDPIA.scala
+++ b/src/main/scala/shine/DPIA/showDPIA.scala
@@ -75,6 +75,8 @@ case class showDPIA(showTypes : ShowTypes = Off) {
     case Cast(_, dt2, e) => s"cast ${showKindedType(DataKind, dt2)} ${showPhrase(e)}"
     case RotateValues(_,_,_,wrt,in) => s"rotate ${showPhrase(in)}\n${tab(showPhrase(wrt))}"
     case f : ReduceSeq => s"reduce ${showPhrase(f.array)} ${showPhrase(f.init)}\n${tab(showPhrase(f.f))}"
+    case kc: shine.OpenCL.primitives.imperative.KernelCallCmd =>
+      s"${kc.name}<<<${kc.localSize}, ${kc.globalSize}>>>(${kc.args}, ${kc.output})"
     case p => p.toString
   }
 

--- a/src/main/scala/shine/DPIA/showDPIA.scala
+++ b/src/main/scala/shine/DPIA/showDPIA.scala
@@ -47,7 +47,7 @@ case class showDPIA(showTypes : ShowTypes = Off) {
   def showPrim : Primitive[_] => String = {
     case Comment(s) => s"/* ${s} */"
     case Seq(c1, c2) => s"${showPhrase(c1)};\n${showPhrase(c2)}"
-    case New(dt, f) => s"new (exp[${showDataType(dt)}] x acc[${showDataType(dt)}]) in \n${tab(showPhrase(f))}"
+    case New(dt, f) => s"new (${showType(f.t.inT)}) in \n${tab(showPhrase(f))}"
     case Assign(_, lhs, rhs) => s"${showTypedPhrase(lhs)} = ${showPhrase(rhs)}"
     case IdxAcc(_, _, idx, array) => s"${showTypedPhrase(array)}[${showPhrase(idx)}]"
     case Idx(_, _, idx, array) => s"${showTypedPhrase(array)}[${showPhrase(idx)}]"
@@ -76,8 +76,29 @@ case class showDPIA(showTypes : ShowTypes = Off) {
     case RotateValues(_,_,_,wrt,in) => s"rotate ${showPhrase(in)}\n${tab(showPhrase(wrt))}"
     case f : ReduceSeq => s"reduce ${showPhrase(f.array)} ${showPhrase(f.init)}\n${tab(showPhrase(f.f))}"
     case kc: shine.OpenCL.primitives.imperative.KernelCallCmd =>
-      s"${kc.name}<<<${kc.localSize}, ${kc.globalSize}>>>(${kc.args}, ${kc.output})"
+      val args = kc.args.map(showPhrase).mkString("(", ", ", ")")
+      s"${showPhrase(kc.output)} = oclLaunchKernel(${kc.name}, ${kc.localSize}, ${kc.globalSize})${args}"
+    case he: shine.OpenCL.primitives.imperative.HostExecution =>
+      val params = he.params.map(p => s"${showPhrase(p._1)} ${accessToString(p._2)}").mkString(", ")
+      s"oclHostExecution (${params}) in\n${tab(showPhrase(he.body))}"
+    case nmb: shine.OpenCL.primitives.imperative.NewManagedBuffer =>
+      s"newManagedBuffer (${showType(nmb.k.t.inT)} ${accessToString(nmb.access)}) in \n${tab(showPhrase(nmb.k))}"
     case p => p.toString
+  }
+
+  def accessToString(a: shine.OpenCL.AccessFlags): String = {
+    import shine.OpenCL.{HOST_WRITE, HOST_READ, DEVICE_WRITE, DEVICE_READ}
+
+    var res = ""
+    if ((a & HOST_WRITE) != 0) { res += "HOST_WRITE | " }
+    if ((a & HOST_READ) != 0) { res += "HOST_READ | " }
+    if ((a & DEVICE_WRITE) != 0) { res += "DEVICE_WRITE | " }
+    if ((a & DEVICE_READ) != 0) { res += "DEVICE_READ | " }
+    if (res == "") {
+      "0"
+    } else {
+      res.dropRight(3)
+    }
   }
 
   def showKindedType[T](kind : Kind[T, _], t : T) : String = showTypes match {

--- a/src/main/scala/shine/OpenCL/NDRange.scala
+++ b/src/main/scala/shine/OpenCL/NDRange.scala
@@ -16,14 +16,20 @@ case class NDRange(x: Nat, y: Nat, z: Nat) {
 
   def visitAndRebuild(f: VisitAndRebuild.Visitor): NDRange =
     NDRange(f.nat(x), f.nat(y), f.nat(z))
+
+  def toTuple(): (Nat, Nat, Nat) = (x, y, z)
 }
 
 case class LocalSize(size: NDRange) {
   def visitAndRebuild(f: VisitAndRebuild.Visitor): LocalSize =
     LocalSize(size.visitAndRebuild(f))
+
+  override def toString(): String = s"LocalSize${size.toTuple()}"
 }
 
 case class GlobalSize(size: NDRange) {
   def visitAndRebuild(f: VisitAndRebuild.Visitor): GlobalSize =
     GlobalSize(size.visitAndRebuild(f))
+
+  override def toString(): String = s"GlobalSize${size.toTuple()}"
 }


### PR DESCRIPTION
This didn't work, hitting an assertion:
```
depFun((n: Nat) => fun((n`.`i32) ->: (n`.`i32))(in =>
  mapSeq(add(li32(2)))(in) |> store(x =>
  oclRun(LocalSize(2), GlobalSize(n/2))(mapGlobal(add(li32(1)))(x)))
))
```
Now, it generates:
```c
#include "ocl/ocl.h"
struct foo_t {
  Kernel k0;
};

typedef struct foo_t foo_t;

void foo_init(Context ctx, foo_t* self){
  (*self).k0 = loadKernel(ctx, k0);
}

void foo_destroy(Context ctx, foo_t* self){
  destroyKernel(ctx, (*self).k0);
}

void foo_run(Context ctx, foo_t* self, Buffer moutput, int n1, Buffer me2){
  {
    Buffer mx101 = createBuffer(ctx, n1 * sizeof(int32_t), HOST_WRITE | DEVICE_READ);
    {
      int32_t* x101 = (int32_t*)hostBufferSync(ctx, mx101, n1 * sizeof(int32_t), HOST_WRITE);
      int32_t* e2 = (int32_t*)hostBufferSync(ctx, me2, n1 * sizeof(int32_t), HOST_READ);
      /* mapSeq */
      for (int i_110 = 0; i_110 < n1; i_110 = 1 + i_110) {
        x101[i_110] = ((int32_t)2) + e2[i_110];
      }
      
    }
    
    {
      DeviceBuffer b0 = deviceBufferSync(ctx, moutput, n1 * sizeof(int32_t), DEVICE_WRITE);
      DeviceBuffer b2 = deviceBufferSync(ctx, mx101, n1 * sizeof(int32_t), DEVICE_READ);
      const size_t global_size[3] = (const size_t[3]){n1 / 2, 1, 1};
      const size_t local_size[3] = (const size_t[3]){2, 1, 1};
      const KernelArg args[3] = (const KernelArg[3]){KARG(b0), KARG(n1), KARG(b2)};
      launchKernel(ctx, (*self).k0, global_size, local_size, 3, args);
    }
    
    destroyBuffer(ctx, mx101);
  }
  
}

void foo_init_run(Context ctx, Buffer moutput, int n1, Buffer me2){
  foo_t foo;
  foo_init(ctx, &foo);
  foo_run(ctx, &foo, moutput, n1, me2);
  foo_destroy(ctx, &foo);
}
```
However there seems to be another type of bug remaining. It looks like the "one_copy" buffer implementation is failing to produce the correct output.