### PR TITLE
added missing assert to mm execution test in auto tuning

### DIFF
--- a/src/test/scala/rise/autotune/TestExecution.scala
+++ b/src/test/scala/rise/autotune/TestExecution.scala
@@ -110,7 +110,7 @@ class TestExecution extends test_util.Tests {
 
       // check for execution error
       result.runtime match {
-        case Left(value) => value.errorLevel.equals(EXECUTION_ERROR)
+        case Left(value) => assert(value.errorLevel.equals(EXECUTION_ERROR))
         case Right(_) => // do nothing result is fine
       }
     })


### PR DESCRIPTION
The mm example execution as part of the auto tuning tests is a heavy workload if running on a non-gpu device. Therefore, the execution is allowed to fail with an `EXECUTION_ERROR`. This PR adds the missing `assert`.  