### PR TITLE
Removed generic type projection use

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.6.2

--- a/src/main/scala/apps/convolution.scala
+++ b/src/main/scala/apps/convolution.scala
@@ -143,9 +143,7 @@ object convolution {
     matrix: Array[Array[Float]],
     weights: Array[Float]
   ): (Array[Float], TimeSpan[Time.ms]) = {
-    val f = k.as[ScalaFunction `(`
-      Array[Array[Float]] `,` Array[Float]
-      `)=>` Array[Float]]
+    val f = k.as[In `=` Array[Array[Float]] `,` Array[Float], Out[Array[Float]]]
     f(localSize, globalSize)(matrix `,` weights)
   }
 }

--- a/src/main/scala/apps/gemv.scala
+++ b/src/main/scala/apps/gemv.scala
@@ -208,10 +208,9 @@ object gemv {
     val localSize = cgo17_localSize
     val globalSize = GlobalSize(M)
 
-    val run = kernel.as[ScalaFunction `(`
+    val run = kernel.as[In `=`
       Int `,` Int `,` Array[Array[Float]] `,`
-      Array[Float] `,` Array[Float] `,` Float `,` Float
-    `)=>` Array[Float]]
+      Array[Float] `,` Array[Float] `,` Float `,` Float, Out[Array[Float]]]
     run(localSize, globalSize)(N `,` M `,` mat `,` xs `,` ys `,` alpha `,` beta)
   }
 }

--- a/src/main/scala/apps/harrisCornerDetection.scala
+++ b/src/main/scala/apps/harrisCornerDetection.scala
@@ -252,19 +252,13 @@ object harrisCornerDetection {
       val localSize = LocalSize(1)
       val globalSize = GlobalSize(H)
 
-      val fSx = sobelX.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fSx = sobelX.as[In `=` Int `,` Int `,` Array[Array[Float]], Out[Array[Float]]]
       val (ix, ixt) = as2DW(fSx(localSize, globalSize)(H `,` W `,` input))
 
-      val fSy = sobelY.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fSy = sobelY.as[In `=` Int `,` Int `,` Array[Array[Float]], Out[Array[Float]]]
       val (iy, iyt) = as2DW(fSy(localSize, globalSize)(H `,` W `,` input))
 
-      val fMul = mul.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fMul = mul.as[In `=` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]], Out[Array[Float]]]
       val (ixx, ixxt) = as2DW(
         fMul(localSize, globalSize)(H `,` W `,` ix `,` ix))
       val (ixy, ixyt) = as2DW(
@@ -272,18 +266,14 @@ object harrisCornerDetection {
       val (iyy, iyyt) = as2DW(
         fMul(localSize, globalSize)(H `,` W `,` iy `,` iy))
 
-      val fG = gaussian.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fG = gaussian.as[In `=` Int `,` Int `,` Array[Array[Float]], Out[Array[Float]]]
       val (sxx, sxxt) = as2DW(fG(localSize, globalSize)(H `,` W `,` ixx))
       val (sxy, sxyt) = as2DW(fG(localSize, globalSize)(H `,` W `,` ixy))
       val (syy, syyt) = as2DW(fG(localSize, globalSize)(H `,` W `,` iyy))
 
-      val fC = coarsity.as[ScalaFunction `(`
-        Int `,` Int `,`
+      val fC = coarsity.as[In `=` Int `,` Int `,`
         Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]] `,`
-        Float
-        `)=>` Array[Float]]
+        Float, Out[Array[Float]]]
       val (k, kt) =
         fC(localSize, globalSize)(H `,` W `,` sxx `,` sxy `,` syy `,` kappa)
 
@@ -325,15 +315,11 @@ object harrisCornerDetection {
       val localSize = LocalSize(1)
       val globalSize = GlobalSize(H)
 
-      val fSxyM = sobelXYMuls.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fSxyM = sobelXYMuls.as[In `=` Int `,` Int `,` Array[Array[Float]], Out[Array[Float]]]
       def asIs[B] = as3D[Float, B](H, W)
       val (is, ist) = asIs(fSxyM(localSize, globalSize)(H `,` W `,` input))
 
-      val fGC = gaussianCoarsity.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Array[Float]]] `,` Float
-        `)=>` Array[Float]]
+      val fGC = gaussianCoarsity.as[In `=` Int `,` Int `,` Array[Array[Array[Float]]] `,` Float, Out[Array[Float]]]
       val (k, kt) = fGC(localSize, globalSize)(H `,` W `,` is `,` kappa)
 
       (k, Seq("Ixx, Ixy, Iyy" -> ist, "K" -> kt))
@@ -362,15 +348,11 @@ object harrisCornerDetection {
       val localSize = LocalSize(1)
       val globalSize = GlobalSize(H)
 
-      val fSxy = sobelXY.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val fSxy = sobelXY.as[In `=` Int `,` Int `,` Array[Array[Float]], Out[Array[Float]]]
       def asIs[B] = as3D[Float, B](H, W)
       val (is, ist) = asIs(fSxy(localSize, globalSize)(H `,` W `,` input))
 
-      val fMGC = mulGaussianCoarsity.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Array[Float]]] `,` Float
-        `)=>` Array[Float]]
+      val fMGC = mulGaussianCoarsity.as[In `=` Int `,` Int `,` Array[Array[Array[Float]]] `,` Float, Out[Array[Float]]]
       val (k, kt) = fMGC(localSize, globalSize)(H `,` W `,` is `,` kappa)
 
       (k, Seq("Ix, Iy" -> ist, "K" -> kt))
@@ -396,9 +378,7 @@ object harrisCornerDetection {
       val localSize = LocalSize(1)
       val globalSize = GlobalSize(H)
 
-      val f = sobelXYMulGaussianCoarsity.as[ScalaFunction `(`
-        Int `,` Int `,` Array[Array[Float]] `,` Float
-        `)=>` Array[Float]]
+      val f = sobelXYMulGaussianCoarsity.as[In `=` Int `,` Int `,` Array[Array[Float]] `,` Float, Out[Array[Float]]]
       val (k, kt) = f(localSize, globalSize)(H `,` W `,` input `,` kappa)
 
       (k, Seq("K" -> kt))

--- a/src/main/scala/apps/kmeans.scala
+++ b/src/main/scala/apps/kmeans.scala
@@ -125,9 +125,7 @@ object kmeans {
     val localSize = LocalSize(256)
     val globalSize = GlobalSize(P)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]]
-      `)=>` Array[Int]]
+    val f = k.as[In `=` Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]], Out[Array[Int]]]
     f(localSize, globalSize)(P `,` C `,` F `,` features `,` clusters)
   }
 }

--- a/src/main/scala/apps/mm.scala
+++ b/src/main/scala/apps/mm.scala
@@ -232,9 +232,7 @@ object mm {
     val N = At(0).length
     val M = B(0).length
 
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]]
-      `)=>` Array[Float]]
+    val run = kernel.as[In `=` Int `,` Int `,` Int `,` Array[Array[Float]] `,` Array[Array[Float]], Out[Array[Float]]]
     run(localSize, globalSize)(N `,` M `,` O `,` At `,` B)
   }
 }

--- a/src/main/scala/apps/molecularDynamics.scala
+++ b/src/main/scala/apps/molecularDynamics.scala
@@ -171,11 +171,11 @@ object molecularDynamics {
     val localSize = LocalSize(128)
     val globalSize = GlobalSize(N)
 
-    val f = k.as[ScalaFunction `(`
+    val f = k.as[In `=`
       Int `,` Int `,`
       Array[Float] `,` Array[Array[Int]] `,`
-      Float `,` Float `,` Float
-      `)=>` Array[Float]]
+      Float `,` Float `,` Float,
+      Out[Array[Float]]]
     f(localSize, globalSize)(
       N `,` M `,` particles `,` neighbours `,` cutsq `,` lj1 `,` lj2
     )

--- a/src/main/scala/apps/mriQ.scala
+++ b/src/main/scala/apps/mriQ.scala
@@ -144,9 +144,9 @@ object mriQ {
     val localSize = LocalSize(256)
     val globalSize = GlobalSize(K)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Array[Float]
-      `)=>` Array[Float]]
+    val f = k.as[In `=`
+      Int `,` Array[Float] `,` Array[Float],
+      Out[Array[Float]]]
     f(localSize, globalSize)(K `,` phiR `,` phiI)
   }
 
@@ -214,11 +214,11 @@ object mriQ {
     val localSize = LocalSize(256 / 4)
     val globalSize = GlobalSize(X)
 
-    val f = k.as[ScalaFunction `(`
+    val f = k.as[In `=`
       Int `,` Int `,`
       Array[Float] `,` Array[Float] `,` Array[Float] `,`
-      Array[Float] `,` Array[Float] `,` Array[Float]
-      `)=>` Array[Float]]
+      Array[Float] `,` Array[Float] `,` Array[Float],
+      Out[Array[Float]]]
     f(localSize, globalSize)(
       K `,` X `,` x `,` y `,` z `,` Qr `,` Qi `,` kvalues
     )

--- a/src/main/scala/apps/nbody.scala
+++ b/src/main/scala/apps/nbody.scala
@@ -215,9 +215,9 @@ object nbody {
     assert(pos.length % 4 == 0)
     val N = pos.length / 4
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Array[Float] `,` Float `,` Float
-      `)=>` Array[Float]]
+    val f = k.as[In `=`
+      Int `,` Array[Float] `,` Array[Float] `,` Float `,` Float,
+      Out[Array[Float]]]
     f(localSize, globalSize)(N `,` pos `,` vel `,` espSqr `,` deltaT)
   }
 

--- a/src/main/scala/apps/nearestNeighbour.scala
+++ b/src/main/scala/apps/nearestNeighbour.scala
@@ -91,9 +91,9 @@ object nearestNeighbour {
     val localSize = LocalSize(128)
     val globalSize = GlobalSize(N)
 
-    val f = k.as[ScalaFunction `(`
-      Int `,` Array[Float] `,` Float `,` Float
-      `)=>` Array[Float]]
+    val f = k.as[In `=`
+      Int `,` Array[Float] `,` Float `,` Float,
+      Out[Array[Float]]]
     f(localSize, globalSize)(N `,` locations `,` lat `,` lng)
   }
 

--- a/src/main/scala/apps/sgemm.scala
+++ b/src/main/scala/apps/sgemm.scala
@@ -292,13 +292,13 @@ object sgemm {
                      alpha: Float, beta: Float,
                      M: Int, N: Int, K: Int): (Array[Float], TimeSpan[Time.ms]) = {
 
-    val runKernel = kernel.as[ScalaFunction `(`
+    val runKernel = kernel.as[In `=`
       Int `,` Int `,` Int `,`
       Array[Array[Float]] `,`
       Array[Array[Float]] `,`
       Array[Array[Float]] `,`
       Float `,`
-      Float `)=>` Array[Float]]
+      Float, Out[Array[Float]]]
 
     runKernel(N `,` M `,` K `,` A `,` B `,` C `,` alpha `,` beta)
   }

--- a/src/main/scala/shine/OpenCL/package.scala
+++ b/src/main/scala/shine/OpenCL/package.scala
@@ -55,15 +55,6 @@ package object OpenCL {
       BuiltInFunctionCall("get_group_id", param, ContinuousRange(0, get_num_groups(param)))
   }
 
-  trait FunctionHelper {
-    type T
-    type R
-    type F = T => R
-  }
-
-
-  type `)=>`[TT, RR] = FunctionHelper { type T = TT; type R = RR }
-
   sealed trait HList {
     def length: Int
     def toList: List[Any]
@@ -85,7 +76,7 @@ package object OpenCL {
 
   type `,`[L <: HList, N] = HCons[L, N]
 
-  type `(`[L <: ScalaFunction, N] = HCons[L, N]
+  type `=`[L <: In, N] = HCons[L, N]
 
   implicit class HNilHelper[V](v1: V) {
     def `,`[V2](v2: V2): HCons[HCons[HNil.type, V], V2] = HCons(HCons(HNil, v1), v2)
@@ -93,5 +84,7 @@ package object OpenCL {
     def `;`: HCons[HNil.type, V] = HCons(HNil, v1)
   }
 
-  type ScalaFunction = HNil.type
+  type In = HNil.type
+
+  type Out[R] = R
 }

--- a/src/main/scala/shine/cuda/KernelExecutor.scala
+++ b/src/main/scala/shine/cuda/KernelExecutor.scala
@@ -8,7 +8,7 @@ import shine.C.AST.ParamKind
 import shine.DPIA.Types._
 import shine.DPIA._
 import shine.OpenCL
-import shine.OpenCL.{FunctionHelper, GlobalSize, HList, LocalSize, NDRange, get_global_size, get_local_size, get_num_groups}
+import shine.OpenCL.{GlobalSize, HList, LocalSize, NDRange, get_global_size, get_local_size, get_num_groups}
 import shine.cuda.AST.Kernel
 import util.Time.ms
 import util.{Time, TimeSpan}
@@ -29,8 +29,8 @@ object KernelExecutor {
                                     localSize: LocalSize,
                                     globalSize: GlobalSize,
                                     compilerOptions: List[String] = List.empty) {
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+    def as[T, R](implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
     }
 
     def benchmark(creator: KernelArgCreator, numberOfIterations: Integer, dataSizesBytes: Array[Long]) : BenchmarkResult =
@@ -43,18 +43,15 @@ object KernelExecutor {
 
   sealed case class KernelNoSizes(ktu: KernelModule,
                                   compilerOptions: List[String] = List.empty) {
-    //noinspection TypeAnnotation
-    def as[F <: FunctionHelper](implicit ev: F#T <:< HList): Object {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
+    def as[T, R](implicit ev: T <:< HList): AS[T, R] = AS()
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[ms])
-    } = new {
-      def apply(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+    case class AS[T, R]()(implicit ev: T <:< HList) {
+      def apply(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
       }
 
-      def withSizes(localSize: LocalSize, globalSize: GlobalSize): F#T => (F#R, TimeSpan[Time.ms]) = {
-        FromKernelModule(ktu, compilerOptions).as[F](localSize, globalSize)
+      def withSizes(localSize: LocalSize, globalSize: GlobalSize): T => (R, TimeSpan[Time.ms]) = {
+        FromKernelModule(ktu, compilerOptions).as[T, R](localSize, globalSize)
       }
     }
 
@@ -110,9 +107,9 @@ object KernelExecutor {
       * val kernelF = kernel.as[ScalaFunction`(`Array[Float]`)=>`Array[Float]]
       * val (result, time) = kernelF(xs `;`)
       */
-    def as[F <: FunctionHelper](localSize: LocalSize, globalSize: GlobalSize)
-                               (implicit ev: F#T <:< HList): F#T => (F#R, TimeSpan[Time.ms]) = {
-      hArgs: F#T => {
+    def as[T, R](localSize: LocalSize, globalSize: GlobalSize)
+                (implicit ev: T <:< HList): T => (R, TimeSpan[Time.ms]) = {
+      hArgs: T => {
         val args: List[Any] = hArgs.toList
         assert(kernel.inputParams.length == args.length)
 
@@ -146,7 +143,7 @@ object KernelExecutor {
 
         val dt = outputParam._2.typ
         assert(dt.isInstanceOf[ArrayType] || dt.isInstanceOf[DepArrayType])
-        val output = asArray[F#R](getOutputType(dt), outputArg)
+        val output = asArray[R](getOutputType(dt), outputArg)
 
         dispose(kernelArgs)
 

--- a/src/test/scala/apps/asum.scala
+++ b/src/test/scala/apps/asum.scala
@@ -128,7 +128,7 @@ class asum extends test_util.TestsWithExecutor {
     )(n: Int, input: Array[Float]): Array[Float] = {
       import shine.OpenCL._
       val k = gen.opencl.kernel.fromExpr(kernel)
-      val runKernel = k.as[ScalaFunction `(` Int `,` Array[Float] `)=>` Array[Float]]
+      val runKernel = k.as[In `=` Int `,` Array[Float], Out[Array[Float]]]
       val (output, _) = runKernel(localSize, globalSize)(n `,` input)
       output
     }

--- a/src/test/scala/apps/convolution1D.scala
+++ b/src/test/scala/apps/convolution1D.scala
@@ -89,14 +89,12 @@ class convolution1D extends test_util.Tests {
     val goldKernel = gen.opencl.kernel.fromExpr(wrapExpr(binomialSeq))
     val kernel = gen.opencl.kernel.fromExpr(wrapExpr(e))
 
-    val goldRun = goldKernel.as[ScalaFunction `(`
-      Int `,` Array[Float]
-      `)=>` Array[Float]]
+    val goldRun = goldKernel.as[In `=`
+      Int `,` Array[Float], Out[Array[Float]]]
     val (gold, _) = goldRun(LocalSize(1), GlobalSize(1))(N `,` input)
 
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Array[Float]
-      `)=>` Array[Float]]
+    val run = kernel.as[In `=`
+      Int `,` Array[Float], Out[Array[Float]]]
     val (output, time) = run(localSize, globalSize)(N `,` input)
     util.assertSame(output, gold, "output is different from gold")
     logger.debug(s"time: $time")

--- a/src/test/scala/apps/gemmTensorCheck.scala
+++ b/src/test/scala/apps/gemmTensorCheck.scala
@@ -58,10 +58,9 @@ class gemmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+      val run = KernelNoSizes(kernel, compilerOptions).as[In `=`
         Int `,` Int `,` Int `,` Float `,` Float `,`
-        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]], Out[Array[Float]]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b
@@ -86,10 +85,10 @@ class gemmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[ScalaFunction `(`
+      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[In `=`
         Int `,` Int `,` Int `,` Float `,` Float `,`
-        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]] `,` Array[Array[Float]],
+        Out[Array[Float]]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b

--- a/src/test/scala/apps/harrisCornerDetectionHalideCheck.scala
+++ b/src/test/scala/apps/harrisCornerDetectionHalideCheck.scala
@@ -100,14 +100,12 @@ class harrisCornerDetectionHalideCheck
     val random = new scala.util.Random()
     val input = Array.fill(3, Hi, Wi)(random.nextFloat() * 10.0f)
 
-    val fg = goldProg.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+    val fg = goldProg.as[In `=`
+      Int `,` Int `,` Array[Array[Array[Float]]], Out[Array[Float]]]
     val (gold, goldTime) = fg(LocalSize(1), GlobalSize(1))(Ho `,` Wo `,` input)
 
-    val f = prog.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+    val f = prog.as[In `=`
+      Int `,` Int `,` Array[Array[Array[Float]]], Out[Array[Float]]]
     val (output, time) = f(ls, gs)(Ho `,` Wo `,` input)
 
     logger.debug(s"gold time: $goldTime")

--- a/src/test/scala/apps/mmTensorCheck.scala
+++ b/src/test/scala/apps/mmTensorCheck.scala
@@ -21,9 +21,8 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     println(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
-        Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+      val run = KernelNoSizes(kernel, compilerOptions).as[In `=`
+        Array[Array[Float]] `,` Array[Array[Float]], Out[Array[Float]]]
 
       val (output, _) =  run(LocalSize(1), GlobalSize(32))(a `,` b)
 
@@ -154,10 +153,10 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-        val run = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+        val run = KernelNoSizes(kernel, compilerOptions).as[In `=`
           Int `,` Int `,` Int `,`
-          Array[Array[Float]] `,` Array[Array[Float]]
-          `)=>` Array[Float]]
+          Array[Array[Float]] `,` Array[Array[Float]],
+          Out[Array[Float]]]
 
         val aMatrix = if (matrixATranspose) a.transpose else a
         val bMatrix = if (matrixBTranspose) b.transpose else b
@@ -185,10 +184,10 @@ class mmTensorCheck extends test_util.TestWithCUDA {
     logger.debug(shine.cuda.KernelModule.translationToString(kernel))
 
     if (executeCudaTests) {
-      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[ScalaFunction `(`
+      val run = KernelWithSizes(kernel, localSize, globalSize, compilerOptions).as[In `=`
         Int `,` Int `,` Int `,`
-        Array[Array[Float]] `,` Array[Array[Float]]
-        `)=>` Array[Float]]
+        Array[Array[Float]] `,` Array[Array[Float]],
+        Out[Array[Float]]]
 
       val aMatrix = if (matrixATranspose) a.transpose else a
       val bMatrix = if (matrixBTranspose) b.transpose else b

--- a/src/test/scala/apps/separableConvolution2DCheck.scala
+++ b/src/test/scala/apps/separableConvolution2DCheck.scala
@@ -93,9 +93,9 @@ int main(int argc, char** argv) {
     val gold = computeGold(H, W, input, binomialWeights2d).flatten
 
     val kernel = gen.opencl.kernel.fromExpr(wrapExpr(e))
-    val run = kernel.as[ScalaFunction `(`
-      Int `,` Int `,` Array[Array[Float]]
-      `)=>` Array[Float]]
+    val run = kernel.as[In `=`
+      Int `,` Int `,` Array[Array[Float]],
+      Out[Array[Float]]]
     val (output, time) = run(localSize, globalSize)(H `,` W `,` input)
     util.assertSame(output, gold, "output is different from gold")
     logger.debug(s"time: $time")

--- a/src/test/scala/apps/stencil/Acoustic3D.scala
+++ b/src/test/scala/apps/stencil/Acoustic3D.scala
@@ -47,11 +47,11 @@ class Acoustic3D extends test_util.TestsWithExecutor {
   def runKernel(k: KernelExecutor.KernelNoSizes,
                 mat1: Array[Array[Array[Float]]],
                 mat2: Array[Array[Array[Float]]]): (Array[Float], TimeSpan[Time.ms]) = {
-    val f = k.as[ScalaFunction `(`
+    val f = k.as[In `=`
       Int `,` Int `,` Int `,`
       Array[Array[Array[Float]]] `,`
-      Array[Array[Array[Float]]]
-      `)=>` Array[Float]]
+      Array[Array[Array[Float]]],
+      Out[Array[Float]]]
     f(localSize, globalSize)(O `,` N `,` M `,` mat1 `,` mat2)
   }
 

--- a/src/test/scala/apps/stencils.scala
+++ b/src/test/scala/apps/stencils.scala
@@ -73,7 +73,7 @@ class stencils extends test_util.Tests {
     ): (Array[Float], TimeSpan[ms]) = {
       import shine.OpenCL._
 
-      val kernelFun = k.as[ScalaFunction `(` Int `,` Input `)=>` Array[Float]]
+      val kernelFun = k.as[In `=` Int `,` Input, Out[Array[Float]]]
       kernelFun(inputSize `,` input)
     }
   }

--- a/src/test/scala/rise/OpenCL/ExecuteOpenCL.scala
+++ b/src/test/scala/rise/OpenCL/ExecuteOpenCL.scala
@@ -19,7 +19,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[In`=`Int`,`Array[Int], Out[Array[Int]]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(8)(0)
 
     val (result, time) = kernelF(8`,`xs)
@@ -36,7 +36,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[In`=`Array[Int], Out[Array[Int]]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(n)(0)
 
     val (result, time) = kernelF(xs`;`)
@@ -53,7 +53,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`,`Int`)=>`Array[Int]]
+    val kernelF = kernel.as[In`=`Array[Int]`,`Int, Out[Array[Int]]]
     val xs = Array.fill(n)(0)
 
     val (result, _) = kernelF(LocalSize(1), GlobalSize(1))(xs`,`n)
@@ -71,7 +71,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Int`,`Array[Array[Int]]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[In`=`Int`,`Int`,`Array[Array[Int]], Out[Array[Int]]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(m)(Array.fill(n)(0))
 
     val (result, time) =  kernelF(m`,`n`,`xs)
@@ -89,7 +89,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Int`,`Array[Int]`,`Int`)=>`Array[Int]]
+    val kernelF = kernel.as[In`=`Int`,`Array[Int]`,`Int, Out[Array[Int]]]
 
     val xs = Array.fill(n)(2)
     val (result, _) =  kernelF(LocalSize(1), GlobalSize(1))(n`,`xs`,`s)
@@ -105,7 +105,7 @@ class ExecuteOpenCL extends test_util.TestsWithExecutor {
 
     val kernel = gen.opencl.kernel.fromExpr(f)
 
-    val kernelF = kernel.as[ScalaFunction`(`Array[Int]`)=>`Array[Int]].withSizes(LocalSize(1), GlobalSize(1))
+    val kernelF = kernel.as[In`=`Array[Int], Out[Array[Int]]].withSizes(LocalSize(1), GlobalSize(1))
     val xs = Array.fill(n)(0)
 
     val (result, time) =  kernelF(xs`;`)

--- a/src/test/scala/shine/DPIA/Primitives/Pad.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Pad.scala
@@ -100,8 +100,8 @@ class Pad extends test_util.Tests {
     val localSize = LocalSize(1)
     val globalSize = GlobalSize(1)
 
-    val f1 = k1.as[ScalaFunction `(` Int `,` Array[Array[Int]] `)=>`Array[Int]]
-    val f2 = k2.as[ScalaFunction `(` Int `,` Array[Array[Int]] `)=>`Array[Int]]
+    val f1 = k1.as[In `=` Int `,` Array[Array[Int]], Out[Array[Int]]]
+    val f2 = k2.as[In `=` Int `,` Array[Array[Int]], Out[Array[Int]]]
 
     val ((r1, _), (r2, _)) = util.withExecutor {
       (f1(localSize, globalSize)(N `,` input),

--- a/src/test/scala/shine/DPIA/Primitives/Partition.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Partition.scala
@@ -62,7 +62,7 @@ class Partition extends test_util.Tests {
                                        input: Array[Float]): (Array[Float], TimeSpan[Time.ms]) = {
         import shine.OpenCL._
 
-        val kernelFun = k.as[ScalaFunction `(` Int `,` Input `)=>` Array[Float]]
+        val kernelFun = k.as[In `=` Int `,` Input, Out[Array[Float]]]
         kernelFun(inputSize `,` input)
       }
     }

--- a/src/test/scala/shine/DPIA/Primitives/Reduce.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Reduce.scala
@@ -77,8 +77,8 @@ class Reduce extends test_util.TestsWithExecutor {
 
     val gold = A.reduce((row1, row2) => row1.zip(row2).map(in => in._1 + in._2))
 
-    val runKernel = gen.opencl.kernel.fromExpr(e(m)(n)).as[ScalaFunction `(`
-      Array[Array[Float]] `)=>` Array[Float]]
+    val runKernel = gen.opencl.kernel.fromExpr(e(m)(n)).as[In `=`
+      Array[Array[Float]], Out[Array[Float]]]
     val (out, _)  = runKernel(LocalSize(1), GlobalSize(1))(A`;`)
 
     assertResult(gold)(out)
@@ -121,7 +121,7 @@ class Reduce extends test_util.TestsWithExecutor {
 
     def runKernel(initWithRecordAccess: ToBeTyped[Expr]) =
       gen.opencl.kernel.fromExpr(e(initWithRecordAccess))
-        .as[ScalaFunction `(`Int`,`Array[Float]`)=>`Array[Float]]
+        .as[In `=`Int`,`Array[Float], Out[Array[Float]]]
 
     val (out1, _) =
       runKernel(initRecordExp._1)(LocalSize(1), GlobalSize(1))(n `,` A)

--- a/src/test/scala/shine/DPIA/Primitives/Scatter.scala
+++ b/src/test/scala/shine/DPIA/Primitives/Scatter.scala
@@ -26,7 +26,7 @@ class Scatter extends test_util.Tests {
     val k = gen.opencl.kernel.fromExpr(e)
     val lS = LocalSize(1)
     val gS = GlobalSize(2)
-    val f = k.as[ScalaFunction `(` Array[Int] `)=>` Array[Int]]
+    val f = k.as[In `=` Array[Int], Out[Array[Int]]]
     val input = (1 to N).toArray
     val expected = input.reverse
     val (r, _) = util.withExecutor {
@@ -53,7 +53,7 @@ class Scatter extends test_util.Tests {
     val k = gen.opencl.kernel.fromExpr(e)
     val lS = LocalSize(1)
     val gS = GlobalSize(2)
-    val f = k.as[ScalaFunction `(` Array[Int] `)=>` Array[Int]]
+    val f = k.as[In `=` Array[Int], Out[Array[Int]]]
     val input = Array.fill(2)((1 to N).toArray)
     val expected = input(0).reverse
     val (r, _) = util.withExecutor {

--- a/src/test/scala/shine/cuda/MMTest.scala
+++ b/src/test/scala/shine/cuda/MMTest.scala
@@ -67,8 +67,8 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[In `=` scala.Array[scala.Array[Float]] `,`
+        scala.Array[scala.Array[Float]], Out[scala.Array[Float]]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(matrixATest `,` matrixBTest)
 
@@ -159,8 +159,8 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(` Int `,` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[In `=` Int `,` scala.Array[scala.Array[Float]] `,`
+        scala.Array[scala.Array[Float]], Out[scala.Array[Float]]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(kTest `,` matrixATest `,` matrixBTest)
 
@@ -309,9 +309,9 @@ class MMTest extends test_util.TestWithCUDA {
 
     //Execute kernel
     if (executeCudaTests) {
-      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[ScalaFunction `(`
+      val scalaFun = KernelNoSizes(kernel, compilerOptions).as[In `=`
         Int `,` Int `,` Int `,` scala.Array[scala.Array[Float]] `,`
-        scala.Array[scala.Array[Float]] `)=>` scala.Array[Float]].withSizes(LocalSize(1), GlobalSize(32))
+        scala.Array[scala.Array[Float]], Out[scala.Array[Float]]].withSizes(LocalSize(1), GlobalSize(32))
 
       val (result, _) = scalaFun(mTest `,` nTest `,` kTest `,` matrixATest `,` matrixBTest)
 


### PR DESCRIPTION
This is a new attempt to move towards Scala 3 by breaking preparation changes from #201 in multiple up-to-date PRs. With the hope that we can merge these quickly.

This PR removes the use of generic type projections (i.e. `T#U`) in the `FunctionHelper` class, as these have been [dropped](https://docs.scala-lang.org/scala3/reference/dropped-features/type-projection.html) in Scala 3.

The replacement syntax is maybe not ideal, but once in Scala 3 (...) there is a better alternative available: https://scastie.scala-lang.org/ndV4Xu8RQZWlZRYCc6GAig