### PR TITLE
Changed syntax as wildcard are invalid as backquoted identifiers in Scala 3

### DIFF
--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -541,7 +541,7 @@ object NamedRewriteDSL {
 
   import scala.language.implicitConversions
 
-  val `_`: rct.TypePlaceholder.type = rct.TypePlaceholder
+  val `__`: rct.TypePlaceholder.type = rct.TypePlaceholder
 
   implicit final class RewriteArrow(private val lhs: Pattern) extends AnyVal {
     @inline def -->(rhs: Pattern): (Pattern, Pattern) = lhs -> rhs
@@ -592,17 +592,17 @@ object NamedRewriteDSL {
   def asVectorAligned: Pattern = rcp.asVectorAligned.primitive
   def vectorFromScalar: Pattern = rcp.vectorFromScalar.primitive
 
-  implicit def placeholderAsNatPattern(p: `_`.type): NatPattern =
+  implicit def placeholderAsNatPattern(p: `__`.type): NatPattern =
     rct.NatIdentifier(rc.freshName("n"))
   implicit def stringAsNatPattern(name: String): NatPattern =
     rct.NatIdentifier(name)
 
-  implicit def placeholderAsDataTypePattern(p: `_`.type): DataTypePattern =
+  implicit def placeholderAsDataTypePattern(p: `__`.type): DataTypePattern =
     rcdt.DataTypeIdentifier(rc.freshName("dt"))
   implicit def stringAsDataTypePattern(name: String): DataTypePattern =
     rcdt.DataTypeIdentifier(name)
 
-  implicit def placeholderAsAddressSpacePattern(p: `_`.type): AddressSpacePattern =
+  implicit def placeholderAsAddressSpacePattern(p: `__`.type): AddressSpacePattern =
     rct.AddressSpaceIdentifier(rc.freshName("a"))
   implicit def stringAsAddressSpacePattern(name: String): AddressSpacePattern =
     rct.AddressSpaceIdentifier(name)

--- a/src/main/scala/rise/eqsat/NamedRewrite.scala
+++ b/src/main/scala/rise/eqsat/NamedRewrite.scala
@@ -541,8 +541,6 @@ object NamedRewriteDSL {
 
   import scala.language.implicitConversions
 
-  val `__`: rct.TypePlaceholder.type = rct.TypePlaceholder
-
   implicit final class RewriteArrow(private val lhs: Pattern) extends AnyVal {
     @inline def -->(rhs: Pattern): (Pattern, Pattern) = lhs -> rhs
   }
@@ -592,21 +590,22 @@ object NamedRewriteDSL {
   def asVectorAligned: Pattern = rcp.asVectorAligned.primitive
   def vectorFromScalar: Pattern = rcp.vectorFromScalar.primitive
 
-  implicit def placeholderAsNatPattern(p: `__`.type): NatPattern =
+  def `?n`: NatPattern =
     rct.NatIdentifier(rc.freshName("n"))
   implicit def stringAsNatPattern(name: String): NatPattern =
     rct.NatIdentifier(name)
 
-  implicit def placeholderAsDataTypePattern(p: `__`.type): DataTypePattern =
+  def `?dt`: DataTypePattern =
     rcdt.DataTypeIdentifier(rc.freshName("dt"))
   implicit def stringAsDataTypePattern(name: String): DataTypePattern =
     rcdt.DataTypeIdentifier(name)
 
-  implicit def placeholderAsAddressSpacePattern(p: `__`.type): AddressSpacePattern =
+  def `?a`: AddressSpacePattern =
     rct.AddressSpaceIdentifier(rc.freshName("a"))
   implicit def stringAsAddressSpacePattern(name: String): AddressSpacePattern =
     rct.AddressSpaceIdentifier(name)
 
+  def `?t`: TypePattern = rct.TypePlaceholder
   def t(name: String): TypePattern =
     rct.TypeIdentifier(name)
 

--- a/src/main/scala/rise/eqsat/rules.scala
+++ b/src/main/scala/rise/eqsat/rules.scala
@@ -123,7 +123,7 @@ object rules {
   )
 
   def splitJoin2(n: Int) = NamedRewrite.init(s"split-join-2-$n",
-    ("in" :: ((`__`: Nat)`.``__`))
+    ("in" :: (`?n``.``?dt`))
       -->
     app(join, app(nApp(split, n), "in"))
   )
@@ -272,8 +272,8 @@ object rules {
 
   val mapOutsidePair = NamedRewrite.init("map-outside-pair",
     app(app(makePair,
-      app(app(map, "fa"), "a" :: (("n": Nat)`.``__`))),
-      app(app(map, "fb"), "b" :: (("n": Nat)`.``__`)))
+      app(app(map, "fa"), "a" :: (("n": Nat)`.``?dt`))),
+      app(app(map, "fb"), "b" :: (("n": Nat)`.``?dt`)))
       -->
     app(unzip,
       app(app(map,
@@ -319,22 +319,22 @@ object rules {
     ("x": Pattern) --> app(lam("y", "y"), "x")
   )
   val transposePairAfter = NamedRewrite.init("transpose-pair-after",
-    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`))) --> app(transpose, app(transpose, "x"))
+    ("x" :: (`?n``.`(`?n``.``?dt`))) --> app(transpose, app(transpose, "x"))
   )
   val transposePairAfter2 = NamedRewrite.init("transpose-pair-after-2",
-    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`))) -->
+    ("x" :: (`?n``.`(`?n``.``?dt`))) -->
       app(lam("y", app(transpose, app(transpose, "y"))), "x")
   )
   val transposePairAfter3 = NamedRewrite.init("transpose-pair-after-3",
-    ("f" :: ("in" ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
+    ("f" :: ("in" ->: (`?n``.`(`?n``.``?dt`)))) -->
       lam("x", app(lam("y", app(transpose, app(transpose, "y"))), app("f", "x")))
   )
   val transposePairAfter4 = NamedRewrite.init("transpose-pair-after-4",
-    ("f" :: ("in" ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
+    ("f" :: ("in" ->: (`?n``.`(`?n``.``?dt`)))) -->
     lam("x", app(transpose, app(lam("y", app(transpose, app("f", "y"))), "x")))
   )
   val createTransposePair = NamedRewrite.init("create-transpose-pair",
-    app(lam("y", "y"), "x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))
+    app(lam("y", "y"), "x" :: (`?n``.`(`?n``.``?dt`)))
       -->
     app(lam("y", app(transpose, app(transpose, "y"))), "x")
   )
@@ -345,7 +345,7 @@ object rules {
     lam("y", "y")
   )
   val mapIdentityAfter = NamedRewrite.init("map-identity-after",
-    ("e" :: ((`__`: Nat)`.``__`))
+    ("e" :: (`?n``.``?dt`))
       -->
     app(app(map, lam("x", "x")), "e")
   )
@@ -358,12 +358,12 @@ object rules {
   )
 
   val slideAfter = NamedRewrite.init("slide-after",
-    ("e" :: ((`__`: Nat)`.``__`))
+    ("e" :: (`?n``.``?dt`))
       -->
     app(join, app(nApp(nApp(slide, 1), 1), "e"))
   )
   val slideAfter2 = NamedRewrite.init("slide-after-2",
-    ("e" :: ((`__`: Nat)`.``__`))
+    ("e" :: (`?n``.``?dt`))
       -->
     app(app(map, lam("x", app(app(rcp.idx.primitive, lidx(0, 1)), "x"))),
       app(nApp(nApp(slide, 1), 1), "e"))
@@ -377,7 +377,7 @@ object rules {
     app(app(map, nApp(drop, "l")), app(nApp(nApp(slide, ("n": Nat) + ("l": Nat)), 1), "in"))
   )
   val takeInSlide = NamedRewrite.init("take-in-slide",
-    app(nApp(take, "r") :: ((("s": Nat)`.``__`) ->: `__`), app(nApp(nApp(slide, "n"), 1), "in"))
+    app(nApp(take, "r") :: ((("s": Nat)`.``?dt`) ->: `?t`), app(nApp(nApp(slide, "n"), 1), "in"))
       -->
     app(app(map, nApp(take, "n")), app(nApp(nApp(slide, ("n": Nat) + ("s": Nat) - ("r": Nat)), 1), "in"))
   )
@@ -536,7 +536,7 @@ object rules {
     app(app(rcp.let.primitive, app(rcp.toMem.primitive, "in")), lam("x", "x"))
   )
   val hoistLetApp1 = NamedRewrite.init("hoist-let-app-1",
-    (app("y", app(app(rcp.let.primitive, "v"), lam("x", "b"))) :: (`__`: DataType))
+    (app("y", app(app(rcp.let.primitive, "v"), lam("x", "b"))) :: `?dt`)
       -->
     app(app(rcp.let.primitive, "v"), lam("x", app("y", "b")))
   )
@@ -576,24 +576,24 @@ object rules {
    */
 
   val mapArray = NamedRewrite.init("map-array",
-    ("x" :: ((`__`: Nat)`.`(`__`: DataType)))
+    ("x" :: (`?n``.``?dt`))
       -->
     app(app(map, lam("y", "y")), "x")
   )
   val mapSeqArray = NamedRewrite.init("map-seq-array",
-    ("x" :: ((`__`: Nat)`.`(`__`: DataType)))
+    ("x" :: (`?n``.``?dt`))
       -->
     app(app(rcp.mapSeq.primitive, lam("y", "y")), "x")
   )
 
   // TODO: condition typeHasTrivialCopy(t) / or synthesise trivial write function
   val mapSeqUnrollWrite = NamedRewrite.init("map-seq-unroll-write",
-    ("x" :: ((`__`: Nat)`.`"dt"))
+    ("x" :: (`?n``.`"dt"))
       -->
     app(app(rcp.mapSeqUnroll.primitive, lam("y", "y")), "x")
   )
   val mapSeqUnrollMapSeqWrite = NamedRewrite.init("map-seq-unroll-map-seq-write",
-    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.`"dt")))
+    ("x" :: (`?n``.`(`?n``.`"dt")))
       -->
       app(app(rcp.mapSeqUnroll.primitive, app(rcp.mapSeq.primitive, lam("y", "y"))), "x")
   )
@@ -663,7 +663,7 @@ object rules {
     )
 
     val asScalarAsVectorId = NamedRewrite.init("as-scalar-as-vector-id",
-      (app(nApp(asVector, `__`), app(asScalar, "e" :: t("t"))) :: t("t"))
+      (app(nApp(asVector, `?n`), app(asScalar, "e" :: t("t"))) :: t("t"))
         --> "e"
     )
 
@@ -915,7 +915,7 @@ object rules {
     )
 
     val transposePairAfter = NamedRewrite.init("transpose-pair-after-cnf",
-      ("f" :: (t("in") ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
+      ("f" :: (t("in") ->: (`?n``.`(`?n``.``?dt`)))) -->
       ("f" >> transpose >> transpose)
     )
 

--- a/src/main/scala/rise/eqsat/rules.scala
+++ b/src/main/scala/rise/eqsat/rules.scala
@@ -123,7 +123,7 @@ object rules {
   )
 
   def splitJoin2(n: Int) = NamedRewrite.init(s"split-join-2-$n",
-    ("in" :: ((`_`: Nat)`.``_`))
+    ("in" :: ((`__`: Nat)`.``__`))
       -->
     app(join, app(nApp(split, n), "in"))
   )
@@ -272,8 +272,8 @@ object rules {
 
   val mapOutsidePair = NamedRewrite.init("map-outside-pair",
     app(app(makePair,
-      app(app(map, "fa"), "a" :: (("n": Nat)`.``_`))),
-      app(app(map, "fb"), "b" :: (("n": Nat)`.``_`)))
+      app(app(map, "fa"), "a" :: (("n": Nat)`.``__`))),
+      app(app(map, "fb"), "b" :: (("n": Nat)`.``__`)))
       -->
     app(unzip,
       app(app(map,
@@ -319,22 +319,22 @@ object rules {
     ("x": Pattern) --> app(lam("y", "y"), "x")
   )
   val transposePairAfter = NamedRewrite.init("transpose-pair-after",
-    ("x" :: ((`_`: Nat)`.`((`_`: Nat)`.``_`))) --> app(transpose, app(transpose, "x"))
+    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`))) --> app(transpose, app(transpose, "x"))
   )
   val transposePairAfter2 = NamedRewrite.init("transpose-pair-after-2",
-    ("x" :: ((`_`: Nat)`.`((`_`: Nat)`.``_`))) -->
+    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`))) -->
       app(lam("y", app(transpose, app(transpose, "y"))), "x")
   )
   val transposePairAfter3 = NamedRewrite.init("transpose-pair-after-3",
-    ("f" :: ("in" ->: ((`_`: Nat)`.`((`_`: Nat)`.``_`)))) -->
+    ("f" :: ("in" ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
       lam("x", app(lam("y", app(transpose, app(transpose, "y"))), app("f", "x")))
   )
   val transposePairAfter4 = NamedRewrite.init("transpose-pair-after-4",
-    ("f" :: ("in" ->: ((`_`: Nat)`.`((`_`: Nat)`.``_`)))) -->
+    ("f" :: ("in" ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
     lam("x", app(transpose, app(lam("y", app(transpose, app("f", "y"))), "x")))
   )
   val createTransposePair = NamedRewrite.init("create-transpose-pair",
-    app(lam("y", "y"), "x" :: ((`_`: Nat)`.`((`_`: Nat)`.``_`)))
+    app(lam("y", "y"), "x" :: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))
       -->
     app(lam("y", app(transpose, app(transpose, "y"))), "x")
   )
@@ -345,7 +345,7 @@ object rules {
     lam("y", "y")
   )
   val mapIdentityAfter = NamedRewrite.init("map-identity-after",
-    ("e" :: ((`_`: Nat)`.``_`))
+    ("e" :: ((`__`: Nat)`.``__`))
       -->
     app(app(map, lam("x", "x")), "e")
   )
@@ -358,12 +358,12 @@ object rules {
   )
 
   val slideAfter = NamedRewrite.init("slide-after",
-    ("e" :: ((`_`: Nat)`.``_`))
+    ("e" :: ((`__`: Nat)`.``__`))
       -->
     app(join, app(nApp(nApp(slide, 1), 1), "e"))
   )
   val slideAfter2 = NamedRewrite.init("slide-after-2",
-    ("e" :: ((`_`: Nat)`.``_`))
+    ("e" :: ((`__`: Nat)`.``__`))
       -->
     app(app(map, lam("x", app(app(rcp.idx.primitive, lidx(0, 1)), "x"))),
       app(nApp(nApp(slide, 1), 1), "e"))
@@ -377,7 +377,7 @@ object rules {
     app(app(map, nApp(drop, "l")), app(nApp(nApp(slide, ("n": Nat) + ("l": Nat)), 1), "in"))
   )
   val takeInSlide = NamedRewrite.init("take-in-slide",
-    app(nApp(take, "r") :: ((("s": Nat)`.``_`) ->: `_`), app(nApp(nApp(slide, "n"), 1), "in"))
+    app(nApp(take, "r") :: ((("s": Nat)`.``__`) ->: `__`), app(nApp(nApp(slide, "n"), 1), "in"))
       -->
     app(app(map, nApp(take, "n")), app(nApp(nApp(slide, ("n": Nat) + ("s": Nat) - ("r": Nat)), 1), "in"))
   )
@@ -536,7 +536,7 @@ object rules {
     app(app(rcp.let.primitive, app(rcp.toMem.primitive, "in")), lam("x", "x"))
   )
   val hoistLetApp1 = NamedRewrite.init("hoist-let-app-1",
-    (app("y", app(app(rcp.let.primitive, "v"), lam("x", "b"))) :: (`_`: DataType))
+    (app("y", app(app(rcp.let.primitive, "v"), lam("x", "b"))) :: (`__`: DataType))
       -->
     app(app(rcp.let.primitive, "v"), lam("x", app("y", "b")))
   )
@@ -576,24 +576,24 @@ object rules {
    */
 
   val mapArray = NamedRewrite.init("map-array",
-    ("x" :: ((`_`: Nat)`.`(`_`: DataType)))
+    ("x" :: ((`__`: Nat)`.`(`__`: DataType)))
       -->
     app(app(map, lam("y", "y")), "x")
   )
   val mapSeqArray = NamedRewrite.init("map-seq-array",
-    ("x" :: ((`_`: Nat)`.`(`_`: DataType)))
+    ("x" :: ((`__`: Nat)`.`(`__`: DataType)))
       -->
     app(app(rcp.mapSeq.primitive, lam("y", "y")), "x")
   )
 
   // TODO: condition typeHasTrivialCopy(t) / or synthesise trivial write function
   val mapSeqUnrollWrite = NamedRewrite.init("map-seq-unroll-write",
-    ("x" :: ((`_`: Nat)`.`"dt"))
+    ("x" :: ((`__`: Nat)`.`"dt"))
       -->
     app(app(rcp.mapSeqUnroll.primitive, lam("y", "y")), "x")
   )
   val mapSeqUnrollMapSeqWrite = NamedRewrite.init("map-seq-unroll-map-seq-write",
-    ("x" :: ((`_`: Nat)`.`((`_`: Nat)`.`"dt")))
+    ("x" :: ((`__`: Nat)`.`((`__`: Nat)`.`"dt")))
       -->
       app(app(rcp.mapSeqUnroll.primitive, app(rcp.mapSeq.primitive, lam("y", "y"))), "x")
   )
@@ -663,7 +663,7 @@ object rules {
     )
 
     val asScalarAsVectorId = NamedRewrite.init("as-scalar-as-vector-id",
-      (app(nApp(asVector, `_`), app(asScalar, "e" :: t("t"))) :: t("t"))
+      (app(nApp(asVector, `__`), app(asScalar, "e" :: t("t"))) :: t("t"))
         --> "e"
     )
 
@@ -915,7 +915,7 @@ object rules {
     )
 
     val transposePairAfter = NamedRewrite.init("transpose-pair-after-cnf",
-      ("f" :: (t("in") ->: ((`_`: Nat)`.`((`_`: Nat)`.``_`)))) -->
+      ("f" :: (t("in") ->: ((`__`: Nat)`.`((`__`: Nat)`.``__`)))) -->
       ("f" >> transpose >> transpose)
     )
 

--- a/src/test/scala/rise/eqsat/Basic.scala
+++ b/src/test/scala/rise/eqsat/Basic.scala
@@ -99,13 +99,13 @@ class Basic extends test_util.Tests {
   }
 
   test("slideBeforeMapMapF") {
-    val `_` = rct.TypePlaceholder
+    val `__` = rct.TypePlaceholder
     def wrap(inner: ToBeTyped[rc.Expr] => ToBeTyped[rc.Expr])
     : rc.Expr =
       depFun((n: rct.Nat) =>
       depFun((dt1: rct.DataType) => depFun((dt2: rct.DataType) =>
       fun(f =>
-        inner(f :: dt1 ->: dt2) :: ((n`.`dt1) ->: `_`)
+        inner(f :: dt1 ->: dt2) :: ((n`.`dt1) ->: `__`)
       ))))
 
     ProveEquiv.init().runBENF(


### PR DESCRIPTION
Minor change to improve compatibility with Scala 3