### PR TITLE
Eqsat node substitution for DataType draft

### DIFF
--- a/float-safe-optimizer/examples/add3.rise
+++ b/float-safe-optimizer/examples/add3.rise
@@ -1,3 +1,7 @@
 depFun((n: Nat) => fun((n`.`i32) ->: (n`.`i32))(in =>
   map(add(li32(3)))(in)
+<<<<<<< Updated upstream
 ))
+=======
+))
+>>>>>>> Stashed changes


### PR DESCRIPTION
Draft of code path for substituting DataType:s in e-graphs, as needed when using `foreignFun`. This initial draft is incomplete. For the following simple case, it fails with `type error: NotDataTypeId(0) != NotDataTypeId(8) ((f64 -> f64) != (f64 -> %dt-1))`:

```scala
depFun((n: Nat) => fun(n`.`f64)(x =>
    x |> map(foreignFun("cos", f64 ->: f64))
))
```

Most likely, there's a case I'm missing somewhere. 